### PR TITLE
Precinct-level results for 2016 general: Sarpy, Hall, Cheyenne

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/20161108__ne__general__cheyenne_precinct.csv
+++ b/20161108__ne__general__cheyenne_precinct.csv
@@ -1,0 +1,72 @@
+county,precinct,office,district,party,candidate,votes
+Cheyenne,Sidney 1,President/Vice President,,REP,Trump/Pence,318
+Cheyenne,Sidney 2,President/Vice President,,REP,Trump/Pence,442
+Cheyenne,Sidney 3,President/Vice President,,REP,Trump/Pence,247
+Cheyenne,Sidney 4,President/Vice President,,REP,Trump/Pence,317
+Cheyenne,Sidney 5,President/Vice President,,REP,Trump/Pence,522
+Cheyenne,Gurley,President/Vice President,,REP,Trump/Pence,197
+Cheyenne,Lodgepole,President/Vice President,,REP,Trump/Pence,248
+Cheyenne,Potter,President/Vice President,,REP,Trump/Pence,238
+Cheyenne,Union Valley,President/Vice President,,REP,Trump/Pence,184
+Cheyenne,Early/provisional,President/Vice President,,REP,Trump/Pence,951
+Cheyenne,New/former resident,President/Vice President,,REP,Trump/Pence,1
+Cheyenne,Sidney 1,President/Vice President,,DEM,Clinton/Kaine,66
+Cheyenne,Sidney 2,President/Vice President,,DEM,Clinton/Kaine,72
+Cheyenne,Sidney 3,President/Vice President,,DEM,Clinton/Kaine,59
+Cheyenne,Sidney 4,President/Vice President,,DEM,Clinton/Kaine,66
+Cheyenne,Sidney 5,President/Vice President,,DEM,Clinton/Kaine,107
+Cheyenne,Gurley,President/Vice President,,DEM,Clinton/Kaine,14
+Cheyenne,Lodgepole,President/Vice President,,DEM,Clinton/Kaine,33
+Cheyenne,Potter,President/Vice President,,DEM,Clinton/Kaine,19
+Cheyenne,Union Valley,President/Vice President,,DEM,Clinton/Kaine,22
+Cheyenne,Early/provisional,President/Vice President,,DEM,Clinton/Kaine,253
+Cheyenne,Sidney 1,President/Vice President,,LIB,Johnson/Weld,20
+Cheyenne,Sidney 2,President/Vice President,,LIB,Johnson/Weld,28
+Cheyenne,Sidney 3,President/Vice President,,LIB,Johnson/Weld,24
+Cheyenne,Sidney 4,President/Vice President,,LIB,Johnson/Weld,24
+Cheyenne,Sidney 5,President/Vice President,,LIB,Johnson/Weld,20
+Cheyenne,Gurley,President/Vice President,,LIB,Johnson/Weld,11
+Cheyenne,Lodgepole,President/Vice President,,LIB,Johnson/Weld,10
+Cheyenne,Potter,President/Vice President,,LIB,Johnson/Weld,11
+Cheyenne,Union Valley,President/Vice President,,LIB,Johnson/Weld,12
+Cheyenne,Early/provisional,President/Vice President,,LIB,Johnson/Weld,53
+Cheyenne,Sidney 1,President/Vice President,,PET,Stein/Baraka,1
+Cheyenne,Sidney 2,President/Vice President,,PET,Stein/Baraka,10
+Cheyenne,Sidney 3,President/Vice President,,PET,Stein/Baraka,10
+Cheyenne,Sidney 4,President/Vice President,,PET,Stein/Baraka,6
+Cheyenne,Sidney 5,President/Vice President,,PET,Stein/Baraka,4
+Cheyenne,Gurley,President/Vice President,,PET,Stein/Baraka,2
+Cheyenne,Lodgepole,President/Vice President,,PET,Stein/Baraka,0
+Cheyenne,Potter,President/Vice President,,PET,Stein/Baraka,0
+Cheyenne,Union Valley,President/Vice President,,PET,Stein/Baraka,3
+Cheyenne,Early/provisional,President/Vice President,,PET,Stein/Baraka,10
+Cheyenne,Sidney 1,President/Vice President,,NON,Write-in,14
+Cheyenne,Sidney 2,President/Vice President,,NON,Write-in,7
+Cheyenne,Sidney 3,President/Vice President,,NON,Write-in,4
+Cheyenne,Sidney 4,President/Vice President,,NON,Write-in,4
+Cheyenne,Sidney 5,President/Vice President,,NON,Write-in,12
+Cheyenne,Gurley,President/Vice President,,NON,Write-in,3
+Cheyenne,Lodgepole,President/Vice President,,NON,Write-in,4
+Cheyenne,Potter,President/Vice President,,NON,Write-in,7
+Cheyenne,Union Valley,President/Vice President,,NON,Write-in,2
+Cheyenne,Early/provisional,President/Vice President,,NON,Write-in,22
+Cheyenne,Sidney 1,United States Representative,3,REP,Adrian Smith,377
+Cheyenne,Sidney 2,United States Representative,3,REP,Adrian Smith,501
+Cheyenne,Sidney 3,United States Representative,3,REP,Adrian Smith,300
+Cheyenne,Sidney 4,United States Representative,3,REP,Adrian Smith,356
+Cheyenne,Sidney 5,United States Representative,3,REP,Adrian Smith,598
+Cheyenne,Gurley,United States Representative,3,REP,Adrian Smith,214
+Cheyenne,Lodgepole,United States Representative,3,REP,Adrian Smith,271
+Cheyenne,Potter,United States Representative,3,REP,Adrian Smith,255
+Cheyenne,Union Valley,United States Representative,3,REP,Adrian Smith,208
+Cheyenne,Early/provisional,United States Representative,3,REP,Adrian Smith,1080
+Cheyenne,Sidney 1,United States Representative,3,NON,Write-in,6
+Cheyenne,Sidney 2,United States Representative,3,NON,Write-in,5
+Cheyenne,Sidney 3,United States Representative,3,NON,Write-in,6
+Cheyenne,Sidney 4,United States Representative,3,NON,Write-in,5
+Cheyenne,Sidney 5,United States Representative,3,NON,Write-in,13
+Cheyenne,Gurley,United States Representative,3,NON,Write-in,1
+Cheyenne,Lodgepole,United States Representative,3,NON,Write-in,8
+Cheyenne,Potter,United States Representative,3,NON,Write-in,0
+Cheyenne,Union Valley,United States Representative,3,NON,Write-in,1
+Cheyenne,Early/provisional,United States Representative,3,NON,Write-in,20

--- a/20161108__ne__general__hall__precinct.csv
+++ b/20161108__ne__general__hall__precinct.csv
@@ -1,0 +1,188 @@
+county,precinct,office,district,party,candidate,votes
+Hall,1,United States Representative,3,REP,Adrian Smith,765
+Hall,2,United States Representative,3,REP,Adrian Smith,314
+Hall,3,United States Representative,3,REP,Adrian Smith,660
+Hall,4,United States Representative,3,REP,Adrian Smith,556
+Hall,5,United States Representative,3,REP,Adrian Smith,878
+Hall,6,United States Representative,3,REP,Adrian Smith,835
+Hall,7,United States Representative,3,REP,Adrian Smith,719
+Hall,8,United States Representative,3,REP,Adrian Smith,808
+Hall,9,United States Representative,3,REP,Adrian Smith,985
+Hall,10,United States Representative,3,REP,Adrian Smith,781
+Hall,11,United States Representative,3,REP,Adrian Smith,780
+Hall,12,United States Representative,3,REP,Adrian Smith,560
+Hall,13,United States Representative,3,REP,Adrian Smith,1068
+Hall,14,United States Representative,3,REP,Adrian Smith,1282
+Hall,15,United States Representative,3,REP,Adrian Smith,1060
+Hall,16,United States Representative,3,REP,Adrian Smith,834
+Hall,17,United States Representative,3,REP,Adrian Smith,611
+Hall,18,United States Representative,3,REP,Adrian Smith,475
+Hall,19,United States Representative,3,REP,Adrian Smith,437
+Hall,20,United States Representative,3,REP,Adrian Smith,294
+Hall,21,United States Representative,3,REP,Adrian Smith,560
+Hall,22,United States Representative,3,REP,Adrian Smith,383
+Hall,23,United States Representative,3,REP,Adrian Smith,403
+Hall,24,United States Representative,3,REP,Adrian Smith,434
+Hall,25,United States Representative,3,REP,Adrian Smith,463
+Hall,26,United States Representative,3,REP,Adrian Smith,383
+Hall,1,United States Representative,3,NON,Write-in,42
+Hall,2,United States Representative,3,NON,Write-in,23
+Hall,3,United States Representative,3,NON,Write-in,43
+Hall,4,United States Representative,3,NON,Write-in,19
+Hall,5,United States Representative,3,NON,Write-in,31
+Hall,6,United States Representative,3,NON,Write-in,28
+Hall,7,United States Representative,3,NON,Write-in,27
+Hall,8,United States Representative,3,NON,Write-in,45
+Hall,9,United States Representative,3,NON,Write-in,31
+Hall,10,United States Representative,3,NON,Write-in,31
+Hall,11,United States Representative,3,NON,Write-in,27
+Hall,12,United States Representative,3,NON,Write-in,38
+Hall,13,United States Representative,3,NON,Write-in,29
+Hall,14,United States Representative,3,NON,Write-in,31
+Hall,15,United States Representative,3,NON,Write-in,33
+Hall,16,United States Representative,3,NON,Write-in,17
+Hall,17,United States Representative,3,NON,Write-in,23
+Hall,18,United States Representative,3,NON,Write-in,26
+Hall,19,United States Representative,3,NON,Write-in,14
+Hall,20,United States Representative,3,NON,Write-in,7
+Hall,21,United States Representative,3,NON,Write-in,5
+Hall,22,United States Representative,3,NON,Write-in,6
+Hall,23,United States Representative,3,NON,Write-in,10
+Hall,24,United States Representative,3,NON,Write-in,6
+Hall,25,United States Representative,3,NON,Write-in,11
+Hall,26,United States Representative,3,NON,Write-in,7
+Hall,1,President/Vice President,,REP,Trump/Pence,540
+Hall,2,President/Vice President,,REP,Trump/Pence,197
+Hall,3,President/Vice President,,REP,Trump/Pence,502
+Hall,4,President/Vice President,,REP,Trump/Pence,475
+Hall,5,President/Vice President,,REP,Trump/Pence,776
+Hall,6,President/Vice President,,REP,Trump/Pence,699
+Hall,7,President/Vice President,,REP,Trump/Pence,542
+Hall,8,President/Vice President,,REP,Trump/Pence,625
+Hall,9,President/Vice President,,REP,Trump/Pence,830
+Hall,10,President/Vice President,,REP,Trump/Pence,586
+Hall,11,President/Vice President,,REP,Trump/Pence,635
+Hall,12,President/Vice President,,REP,Trump/Pence,377
+Hall,13,President/Vice President,,REP,Trump/Pence,931
+Hall,14,President/Vice President,,REP,Trump/Pence,1125
+Hall,15,President/Vice President,,REP,Trump/Pence,897
+Hall,16,President/Vice President,,REP,Trump/Pence,747
+Hall,17,President/Vice President,,REP,Trump/Pence,503
+Hall,18,President/Vice President,,REP,Trump/Pence,340
+Hall,19,President/Vice President,,REP,Trump/Pence,384
+Hall,20,President/Vice President,,REP,Trump/Pence,291
+Hall,21,President/Vice President,,REP,Trump/Pence,514
+Hall,22,President/Vice President,,REP,Trump/Pence,290
+Hall,23,President/Vice President,,REP,Trump/Pence,366
+Hall,24,President/Vice President,,REP,Trump/Pence,425
+Hall,25,President/Vice President,,REP,Trump/Pence,428
+Hall,26,President/Vice President,,REP,Trump/Pence,380
+Hall,27,President/Vice President,,REP,Trump/Pence,3
+Hall,1,President/Vice President,,DEM,Clinton/Kaine,396
+Hall,2,President/Vice President,,DEM,Clinton/Kaine,212
+Hall,3,President/Vice President,,DEM,Clinton/Kaine,327
+Hall,4,President/Vice President,,DEM,Clinton/Kaine,229
+Hall,5,President/Vice President,,DEM,Clinton/Kaine,288
+Hall,6,President/Vice President,,DEM,Clinton/Kaine,291
+Hall,7,President/Vice President,,DEM,Clinton/Kaine,312
+Hall,8,President/Vice President,,DEM,Clinton/Kaine,391
+Hall,9,President/Vice President,,DEM,Clinton/Kaine,349
+Hall,10,President/Vice President,,DEM,Clinton/Kaine,354
+Hall,11,President/Vice President,,DEM,Clinton/Kaine,326
+Hall,12,President/Vice President,,DEM,Clinton/Kaine,307
+Hall,13,President/Vice President,,DEM,Clinton/Kaine,330
+Hall,14,President/Vice President,,DEM,Clinton/Kaine,310
+Hall,15,President/Vice President,,DEM,Clinton/Kaine,339
+Hall,16,President/Vice President,,DEM,Clinton/Kaine,225
+Hall,17,President/Vice President,,DEM,Clinton/Kaine,232
+Hall,18,President/Vice President,,DEM,Clinton/Kaine,250
+Hall,19,President/Vice President,,DEM,Clinton/Kaine,136
+Hall,20,President/Vice President,,DEM,Clinton/Kaine,53
+Hall,21,President/Vice President,,DEM,Clinton/Kaine,110
+Hall,22,President/Vice President,,DEM,Clinton/Kaine,146
+Hall,23,President/Vice President,,DEM,Clinton/Kaine,84
+Hall,24,President/Vice President,,DEM,Clinton/Kaine,86
+Hall,25,President/Vice President,,DEM,Clinton/Kaine,105
+Hall,26,President/Vice President,,DEM,Clinton/Kaine,94
+Hall,27,President/Vice President,,DEM,Clinton/Kaine,0
+Hall,1,President/Vice President,,LIB,Johnson/Weld,40
+Hall,2,President/Vice President,,LIB,Johnson/Weld,19
+Hall,3,President/Vice President,,LIB,Johnson/Weld,46
+Hall,4,President/Vice President,,LIB,Johnson/Weld,17
+Hall,5,President/Vice President,,LIB,Johnson/Weld,37
+Hall,6,President/Vice President,,LIB,Johnson/Weld,40
+Hall,7,President/Vice President,,LIB,Johnson/Weld,48
+Hall,8,President/Vice President,,LIB,Johnson/Weld,64
+Hall,9,President/Vice President,,LIB,Johnson/Weld,57
+Hall,10,President/Vice President,,LIB,Johnson/Weld,55
+Hall,11,President/Vice President,,LIB,Johnson/Weld,47
+Hall,12,President/Vice President,,LIB,Johnson/Weld,39
+Hall,13,President/Vice President,,LIB,Johnson/Weld,46
+Hall,14,President/Vice President,,LIB,Johnson/Weld,49
+Hall,15,President/Vice President,,LIB,Johnson/Weld,44
+Hall,16,President/Vice President,,LIB,Johnson/Weld,37
+Hall,17,President/Vice President,,LIB,Johnson/Weld,37
+Hall,18,President/Vice President,,LIB,Johnson/Weld,30
+Hall,19,President/Vice President,,LIB,Johnson/Weld,17
+Hall,20,President/Vice President,,LIB,Johnson/Weld,12
+Hall,21,President/Vice President,,LIB,Johnson/Weld,22
+Hall,22,President/Vice President,,LIB,Johnson/Weld,25
+Hall,23,President/Vice President,,LIB,Johnson/Weld,16
+Hall,24,President/Vice President,,LIB,Johnson/Weld,18
+Hall,25,President/Vice President,,LIB,Johnson/Weld,18
+Hall,26,President/Vice President,,LIB,Johnson/Weld,14
+Hall,27,President/Vice President,,LIB,Johnson/Weld,1
+Hall,1,President/Vice President,,PET,Stein/Baraka,7
+Hall,2,President/Vice President,,PET,Stein/Baraka,5
+Hall,3,President/Vice President,,PET,Stein/Baraka,8
+Hall,4,President/Vice President,,PET,Stein/Baraka,6
+Hall,5,President/Vice President,,PET,Stein/Baraka,7
+Hall,6,President/Vice President,,PET,Stein/Baraka,8
+Hall,7,President/Vice President,,PET,Stein/Baraka,13
+Hall,8,President/Vice President,,PET,Stein/Baraka,13
+Hall,9,President/Vice President,,PET,Stein/Baraka,13
+Hall,10,President/Vice President,,PET,Stein/Baraka,11
+Hall,11,President/Vice President,,PET,Stein/Baraka,15
+Hall,12,President/Vice President,,PET,Stein/Baraka,15
+Hall,13,President/Vice President,,PET,Stein/Baraka,2
+Hall,14,President/Vice President,,PET,Stein/Baraka,8
+Hall,15,President/Vice President,,PET,Stein/Baraka,7
+Hall,16,President/Vice President,,PET,Stein/Baraka,9
+Hall,17,President/Vice President,,PET,Stein/Baraka,3
+Hall,18,President/Vice President,,PET,Stein/Baraka,3
+Hall,19,President/Vice President,,PET,Stein/Baraka,2
+Hall,20,President/Vice President,,PET,Stein/Baraka,1
+Hall,21,President/Vice President,,PET,Stein/Baraka,8
+Hall,22,President/Vice President,,PET,Stein/Baraka,4
+Hall,23,President/Vice President,,PET,Stein/Baraka,7
+Hall,24,President/Vice President,,PET,Stein/Baraka,8
+Hall,25,President/Vice President,,PET,Stein/Baraka,7
+Hall,26,President/Vice President,,PET,Stein/Baraka,2
+Hall,27,President/Vice President,,PET,Stein/Baraka,0
+Hall,1,President/Vice President,,NON,Write-in,16
+Hall,2,President/Vice President,,NON,Write-in,7
+Hall,3,President/Vice President,,NON,Write-in,14
+Hall,4,President/Vice President,,NON,Write-in,6
+Hall,5,President/Vice President,,NON,Write-in,10
+Hall,6,President/Vice President,,NON,Write-in,21
+Hall,7,President/Vice President,,NON,Write-in,22
+Hall,8,President/Vice President,,NON,Write-in,15
+Hall,9,President/Vice President,,NON,Write-in,12
+Hall,10,President/Vice President,,NON,Write-in,15
+Hall,11,President/Vice President,,NON,Write-in,10
+Hall,12,President/Vice President,,NON,Write-in,9
+Hall,13,President/Vice President,,NON,Write-in,17
+Hall,14,President/Vice President,,NON,Write-in,32
+Hall,15,President/Vice President,,NON,Write-in,16
+Hall,16,President/Vice President,,NON,Write-in,12
+Hall,17,President/Vice President,,NON,Write-in,10
+Hall,18,President/Vice President,,NON,Write-in,0
+Hall,19,President/Vice President,,NON,Write-in,8
+Hall,20,President/Vice President,,NON,Write-in,0
+Hall,21,President/Vice President,,NON,Write-in,2
+Hall,22,President/Vice President,,NON,Write-in,6
+Hall,23,President/Vice President,,NON,Write-in,3
+Hall,24,President/Vice President,,NON,Write-in,6
+Hall,25,President/Vice President,,NON,Write-in,9
+Hall,26,President/Vice President,,NON,Write-in,5
+Hall,27,President/Vice President,,NON,Write-in,0

--- a/20161108__ne__general__sarpy__precinct.csv
+++ b/20161108__ne__general__sarpy__precinct.csv
@@ -1,0 +1,3427 @@
+county,precinct,office,district,party,candidate,votes,election_day,early_voting,provisional
+Sarpy,,President/Vice President,,REP,Trump/Pence,45143,28941,15752,450
+Sarpy,Precinct 1,President/Vice President,,REP,Trump/Pence,443,313,128,2
+Sarpy,Precinct 2,President/Vice President,,REP,Trump/Pence,551,401,142,8
+Sarpy,Precinct 3,President/Vice President,,REP,Trump/Pence,776,467,295,14
+Sarpy,Precinct 4,President/Vice President,,REP,Trump/Pence,720,487,228,5
+Sarpy,Precinct 5,President/Vice President,,REP,Trump/Pence,586,351,231,4
+Sarpy,Precinct 6,President/Vice President,,REP,Trump/Pence,658,469,182,7
+Sarpy,Precinct 7,President/Vice President,,REP,Trump/Pence,657,438,204,15
+Sarpy,Precinct 8,President/Vice President,,REP,Trump/Pence,684,480,196,8
+Sarpy,Precinct 9,President/Vice President,,REP,Trump/Pence,660,495,158,7
+Sarpy,Precinct 10,President/Vice President,,REP,Trump/Pence,455,359,88,8
+Sarpy,Precinct 11,President/Vice President,,REP,Trump/Pence,1000,593,398,9
+Sarpy,Precinct 12,President/Vice President,,REP,Trump/Pence,947,642,292,13
+Sarpy,Precinct 13,President/Vice President,,REP,Trump/Pence,921,574,337,10
+Sarpy,Precinct 16,President/Vice President,,REP,Trump/Pence,765,473,287,5
+Sarpy,Precinct 17,President/Vice President,,REP,Trump/Pence,768,518,244,6
+Sarpy,Precinct 18,President/Vice President,,REP,Trump/Pence,544,375,166,3
+Sarpy,Precinct 19,President/Vice President,,REP,Trump/Pence,1235,558,664,13
+Sarpy,Precinct 20,President/Vice President,,REP,Trump/Pence,794,530,261,3
+Sarpy,Precinct 21,President/Vice President,,REP,Trump/Pence,1211,648,557,6
+Sarpy,Precinct 22,President/Vice President,,REP,Trump/Pence,716,488,219,9
+Sarpy,Precinct 23,President/Vice President,,REP,Trump/Pence,1242,685,540,17
+Sarpy,Precinct 24,President/Vice President,,REP,Trump/Pence,602,388,209,5
+Sarpy,Precinct 25,President/Vice President,,REP,Trump/Pence,560,386,159,15
+Sarpy,Precinct 26,President/Vice President,,REP,Trump/Pence,769,489,270,10
+Sarpy,Precinct 31,President/Vice President,,REP,Trump/Pence,1397,940,448,9
+Sarpy,Precinct 32,President/Vice President,,REP,Trump/Pence,631,435,190,6
+Sarpy,Precinct 33,President/Vice President,,REP,Trump/Pence,682,446,228,8
+Sarpy,Precinct 34,President/Vice President,,REP,Trump/Pence,806,542,255,9
+Sarpy,Precinct 35,President/Vice President,,REP,Trump/Pence,774,552,218,4
+Sarpy,Precinct 36,President/Vice President,,REP,Trump/Pence,912,601,306,5
+Sarpy,Precinct 37,President/Vice President,,REP,Trump/Pence,1350,793,550,7
+Sarpy,Precinct 38,President/Vice President,,REP,Trump/Pence,795,539,246,10
+Sarpy,Precinct 39,President/Vice President,,REP,Trump/Pence,942,573,368,1
+Sarpy,Precinct 40,President/Vice President,,REP,Trump/Pence,856,567,279,10
+Sarpy,Precinct 41,President/Vice President,,REP,Trump/Pence,1077,580,485,12
+Sarpy,Precinct 42,President/Vice President,,REP,Trump/Pence,887,506,372,9
+Sarpy,Precinct 46,President/Vice President,,REP,Trump/Pence,803,519,282,2
+Sarpy,Precinct 47,President/Vice President,,REP,Trump/Pence,490,387,96,7
+Sarpy,Precinct 48,President/Vice President,,REP,Trump/Pence,1139,580,550,9
+Sarpy,Precinct 49,President/Vice President,,REP,Trump/Pence,972,554,408,10
+Sarpy,Precinct 51,President/Vice President,,REP,Trump/Pence,1413,935,467,11
+Sarpy,Precinct 52,President/Vice President,,REP,Trump/Pence,1331,811,503,17
+Sarpy,Precinct 53,President/Vice President,,REP,Trump/Pence,1001,645,346,10
+Sarpy,Precinct 54,President/Vice President,,REP,Trump/Pence,971,574,384,13
+Sarpy,Precinct 55,President/Vice President,,REP,Trump/Pence,1250,837,401,12
+Sarpy,Precinct 56,President/Vice President,,REP,Trump/Pence,818,571,245,2
+Sarpy,Precinct 57,President/Vice President,,REP,Trump/Pence,715,515,193,7
+Sarpy,Precinct 58,President/Vice President,,REP,Trump/Pence,769,552,208,9
+Sarpy,Precinct 59,President/Vice President,,REP,Trump/Pence,820,578,232,10
+Sarpy,Precinct 60,President/Vice President,,REP,Trump/Pence,675,509,161,5
+Sarpy,Precinct 61,President/Vice President,,REP,Trump/Pence,1817,1162,633,22
+Sarpy,Precinct 62,President/Vice President,,REP,Trump/Pence,783,531,240,12
+Sarpy,New/Former Resident 1,President/Vice President,,REP,Trump/Pence,0,0,0,0
+Sarpy,New/Former Resident 2,President/Vice President,,REP,Trump/Pence,3,0,3,0
+Sarpy,,President/Vice President,,DEM,Clinton/Kaine,28033,14788,12942,303
+Sarpy,Precinct 1,President/Vice President,,DEM,Clinton/Kaine,478,311,159,8
+Sarpy,Precinct 2,President/Vice President,,DEM,Clinton/Kaine,337,221,112,4
+Sarpy,Precinct 3,President/Vice President,,DEM,Clinton/Kaine,578,311,262,5
+Sarpy,Precinct 4,President/Vice President,,DEM,Clinton/Kaine,470,289,176,5
+Sarpy,Precinct 5,President/Vice President,,DEM,Clinton/Kaine,408,194,209,5
+Sarpy,Precinct 6,President/Vice President,,DEM,Clinton/Kaine,529,304,213,12
+Sarpy,Precinct 7,President/Vice President,,DEM,Clinton/Kaine,441,234,199,8
+Sarpy,Precinct 8,President/Vice President,,DEM,Clinton/Kaine,411,226,183,2
+Sarpy,Precinct 9,President/Vice President,,DEM,Clinton/Kaine,436,291,139,6
+Sarpy,Precinct 10,President/Vice President,,DEM,Clinton/Kaine,310,195,109,6
+Sarpy,Precinct 11,President/Vice President,,DEM,Clinton/Kaine,601,298,300,3
+Sarpy,Precinct 12,President/Vice President,,DEM,Clinton/Kaine,462,250,204,8
+Sarpy,Precinct 13,President/Vice President,,DEM,Clinton/Kaine,597,273,316,8
+Sarpy,Precinct 16,President/Vice President,,DEM,Clinton/Kaine,609,335,270,4
+Sarpy,Precinct 17,President/Vice President,,DEM,Clinton/Kaine,546,296,247,3
+Sarpy,Precinct 18,President/Vice President,,DEM,Clinton/Kaine,505,300,201,4
+Sarpy,Precinct 19,President/Vice President,,DEM,Clinton/Kaine,748,294,441,13
+Sarpy,Precinct 20,President/Vice President,,DEM,Clinton/Kaine,664,326,330,8
+Sarpy,Precinct 21,President/Vice President,,DEM,Clinton/Kaine,683,305,369,9
+Sarpy,Precinct 22,President/Vice President,,DEM,Clinton/Kaine,536,280,249,7
+Sarpy,Precinct 23,President/Vice President,,DEM,Clinton/Kaine,656,248,393,15
+Sarpy,Precinct 24,President/Vice President,,DEM,Clinton/Kaine,316,165,149,2
+Sarpy,Precinct 25,President/Vice President,,DEM,Clinton/Kaine,386,205,172,9
+Sarpy,Precinct 26,President/Vice President,,DEM,Clinton/Kaine,440,241,194,5
+Sarpy,Precinct 31,President/Vice President,,DEM,Clinton/Kaine,905,502,389,14
+Sarpy,Precinct 32,President/Vice President,,DEM,Clinton/Kaine,453,241,209,3
+Sarpy,Precinct 33,President/Vice President,,DEM,Clinton/Kaine,616,357,246,13
+Sarpy,Precinct 34,President/Vice President,,DEM,Clinton/Kaine,650,367,277,6
+Sarpy,Precinct 35,President/Vice President,,DEM,Clinton/Kaine,525,290,231,4
+Sarpy,Precinct 36,President/Vice President,,DEM,Clinton/Kaine,463,225,236,2
+Sarpy,Precinct 37,President/Vice President,,DEM,Clinton/Kaine,804,403,390,11
+Sarpy,Precinct 38,President/Vice President,,DEM,Clinton/Kaine,542,306,231,5
+Sarpy,Precinct 39,President/Vice President,,DEM,Clinton/Kaine,518,278,240,0
+Sarpy,Precinct 40,President/Vice President,,DEM,Clinton/Kaine,474,256,210,8
+Sarpy,Precinct 41,President/Vice President,,DEM,Clinton/Kaine,649,293,351,5
+Sarpy,Precinct 42,President/Vice President,,DEM,Clinton/Kaine,545,273,268,4
+Sarpy,Precinct 46,President/Vice President,,DEM,Clinton/Kaine,292,144,148,0
+Sarpy,Precinct 47,President/Vice President,,DEM,Clinton/Kaine,217,146,70,1
+Sarpy,Precinct 48,President/Vice President,,DEM,Clinton/Kaine,530,232,297,1
+Sarpy,Precinct 49,President/Vice President,,DEM,Clinton/Kaine,630,291,333,6
+Sarpy,Precinct 51,President/Vice President,,DEM,Clinton/Kaine,785,464,318,3
+Sarpy,Precinct 52,President/Vice President,,DEM,Clinton/Kaine,797,401,387,9
+Sarpy,Precinct 53,President/Vice President,,DEM,Clinton/Kaine,770,357,402,11
+Sarpy,Precinct 54,President/Vice President,,DEM,Clinton/Kaine,699,331,361,7
+Sarpy,Precinct 55,President/Vice President,,DEM,Clinton/Kaine,765,438,318,9
+Sarpy,Precinct 56,President/Vice President,,DEM,Clinton/Kaine,530,289,239,2
+Sarpy,Precinct 57,President/Vice President,,DEM,Clinton/Kaine,487,287,198,2
+Sarpy,Precinct 58,President/Vice President,,DEM,Clinton/Kaine,280,177,102,1
+Sarpy,Precinct 59,President/Vice President,,DEM,Clinton/Kaine,335,208,126,1
+Sarpy,Precinct 60,President/Vice President,,DEM,Clinton/Kaine,356,212,144,0
+Sarpy,Precinct 61,President/Vice President,,DEM,Clinton/Kaine,747,344,399,4
+Sarpy,Precinct 62,President/Vice President,,DEM,Clinton/Kaine,520,284,224,12
+Sarpy,New/Former Resident 1,President/Vice President,,DEM,Clinton/Kaine,1,0,1,0
+Sarpy,New/Former Resident 2,President/Vice President,,DEM,Clinton/Kaine,1,0,1,0
+Sarpy,,President/Vice President,,LIB,Johnson/Weld,4682,3049,1566,67
+Sarpy,Precinct 1,President/Vice President,,LIB,Johnson/Weld,41,29,11,1
+Sarpy,Precinct 2,President/Vice President,,LIB,Johnson/Weld,65,50,14,1
+Sarpy,Precinct 3,President/Vice President,,LIB,Johnson/Weld,84,56,27,1
+Sarpy,Precinct 4,President/Vice President,,LIB,Johnson/Weld,93,65,25,3
+Sarpy,Precinct 5,President/Vice President,,LIB,Johnson/Weld,64,43,21,0
+Sarpy,Precinct 6,President/Vice President,,LIB,Johnson/Weld,93,72,19,2
+Sarpy,Precinct 7,President/Vice President,,LIB,Johnson/Weld,66,49,15,2
+Sarpy,Precinct 8,President/Vice President,,LIB,Johnson/Weld,56,33,21,2
+Sarpy,Precinct 9,President/Vice President,,LIB,Johnson/Weld,84,52,30,2
+Sarpy,Precinct 10,President/Vice President,,LIB,Johnson/Weld,82,63,14,5
+Sarpy,Precinct 11,President/Vice President,,LIB,Johnson/Weld,126,77,45,4
+Sarpy,Precinct 12,President/Vice President,,LIB,Johnson/Weld,97,56,41,0
+Sarpy,Precinct 13,President/Vice President,,LIB,Johnson/Weld,87,63,24,0
+Sarpy,Precinct 16,President/Vice President,,LIB,Johnson/Weld,79,58,21,0
+Sarpy,Precinct 17,President/Vice President,,LIB,Johnson/Weld,59,37,21,1
+Sarpy,Precinct 18,President/Vice President,,LIB,Johnson/Weld,78,50,27,1
+Sarpy,Precinct 19,President/Vice President,,LIB,Johnson/Weld,127,62,64,1
+Sarpy,Precinct 20,President/Vice President,,LIB,Johnson/Weld,74,52,22,0
+Sarpy,Precinct 21,President/Vice President,,LIB,Johnson/Weld,118,70,46,2
+Sarpy,Precinct 22,President/Vice President,,LIB,Johnson/Weld,113,73,39,1
+Sarpy,Precinct 23,President/Vice President,,LIB,Johnson/Weld,112,68,41,3
+Sarpy,Precinct 24,President/Vice President,,LIB,Johnson/Weld,78,55,21,2
+Sarpy,Precinct 25,President/Vice President,,LIB,Johnson/Weld,88,61,25,2
+Sarpy,Precinct 26,President/Vice President,,LIB,Johnson/Weld,106,72,33,1
+Sarpy,Precinct 31,President/Vice President,,LIB,Johnson/Weld,147,96,46,5
+Sarpy,Precinct 32,President/Vice President,,LIB,Johnson/Weld,74,48,24,2
+Sarpy,Precinct 33,President/Vice President,,LIB,Johnson/Weld,78,56,19,3
+Sarpy,Precinct 34,President/Vice President,,LIB,Johnson/Weld,107,76,31,0
+Sarpy,Precinct 35,President/Vice President,,LIB,Johnson/Weld,84,57,26,1
+Sarpy,Precinct 36,President/Vice President,,LIB,Johnson/Weld,55,31,23,1
+Sarpy,Precinct 37,President/Vice President,,LIB,Johnson/Weld,113,69,42,2
+Sarpy,Precinct 38,President/Vice President,,LIB,Johnson/Weld,89,61,28,0
+Sarpy,Precinct 39,President/Vice President,,LIB,Johnson/Weld,100,58,42,0
+Sarpy,Precinct 40,President/Vice President,,LIB,Johnson/Weld,94,59,33,2
+Sarpy,Precinct 41,President/Vice President,,LIB,Johnson/Weld,110,67,42,1
+Sarpy,Precinct 42,President/Vice President,,LIB,Johnson/Weld,103,64,39,0
+Sarpy,Precinct 46,President/Vice President,,LIB,Johnson/Weld,53,40,13,0
+Sarpy,Precinct 47,President/Vice President,,LIB,Johnson/Weld,57,42,15,0
+Sarpy,Precinct 48,President/Vice President,,LIB,Johnson/Weld,91,40,50,1
+Sarpy,Precinct 49,President/Vice President,,LIB,Johnson/Weld,123,76,43,4
+Sarpy,Precinct 51,President/Vice President,,LIB,Johnson/Weld,113,67,46,0
+Sarpy,Precinct 52,President/Vice President,,LIB,Johnson/Weld,115,71,43,1
+Sarpy,Precinct 53,President/Vice President,,LIB,Johnson/Weld,118,70,46,2
+Sarpy,Precinct 54,President/Vice President,,LIB,Johnson/Weld,105,68,36,1
+Sarpy,Precinct 55,President/Vice President,,LIB,Johnson/Weld,121,88,33,0
+Sarpy,Precinct 56,President/Vice President,,LIB,Johnson/Weld,69,51,18,0
+Sarpy,Precinct 57,President/Vice President,,LIB,Johnson/Weld,86,62,24,0
+Sarpy,Precinct 58,President/Vice President,,LIB,Johnson/Weld,42,28,14,0
+Sarpy,Precinct 59,President/Vice President,,LIB,Johnson/Weld,78,58,20,0
+Sarpy,Precinct 60,President/Vice President,,LIB,Johnson/Weld,72,50,22,0
+Sarpy,Precinct 61,President/Vice President,,LIB,Johnson/Weld,121,70,48,3
+Sarpy,Precinct 62,President/Vice President,,LIB,Johnson/Weld,94,60,33,1
+Sarpy,New/Former Resident 1,President/Vice President,,LIB,Johnson/Weld,0,0,0,0
+Sarpy,New/Former Resident 2,President/Vice President,,LIB,Johnson/Weld,0,0,0,0
+Sarpy,,President/Vice President,,PET,Stein/Baraka,836,555,264,17
+Sarpy,Precinct 1,President/Vice President,,PET,Stein/Baraka,23,19,4,0
+Sarpy,Precinct 2,President/Vice President,,PET,Stein/Baraka,15,10,5,0
+Sarpy,Precinct 3,President/Vice President,,PET,Stein/Baraka,23,13,10,0
+Sarpy,Precinct 4,President/Vice President,,PET,Stein/Baraka,13,10,3,0
+Sarpy,Precinct 5,President/Vice President,,PET,Stein/Baraka,12,6,5,1
+Sarpy,Precinct 6,President/Vice President,,PET,Stein/Baraka,25,18,5,2
+Sarpy,Precinct 7,President/Vice President,,PET,Stein/Baraka,13,10,3,0
+Sarpy,Precinct 8,President/Vice President,,PET,Stein/Baraka,7,4,3,0
+Sarpy,Precinct 9,President/Vice President,,PET,Stein/Baraka,18,13,5,0
+Sarpy,Precinct 10,President/Vice President,,PET,Stein/Baraka,21,14,6,1
+Sarpy,Precinct 11,President/Vice President,,PET,Stein/Baraka,15,11,4,0
+Sarpy,Precinct 12,President/Vice President,,PET,Stein/Baraka,14,12,2,0
+Sarpy,Precinct 13,President/Vice President,,PET,Stein/Baraka,22,19,3,0
+Sarpy,Precinct 16,President/Vice President,,PET,Stein/Baraka,25,19,6,0
+Sarpy,Precinct 17,President/Vice President,,PET,Stein/Baraka,27,19,6,2
+Sarpy,Precinct 18,President/Vice President,,PET,Stein/Baraka,10,8,2,0
+Sarpy,Precinct 19,President/Vice President,,PET,Stein/Baraka,24,7,16,1
+Sarpy,Precinct 20,President/Vice President,,PET,Stein/Baraka,15,8,7,0
+Sarpy,Precinct 21,President/Vice President,,PET,Stein/Baraka,15,12,3,0
+Sarpy,Precinct 22,President/Vice President,,PET,Stein/Baraka,17,11,6,0
+Sarpy,Precinct 23,President/Vice President,,PET,Stein/Baraka,13,7,6,0
+Sarpy,Precinct 24,President/Vice President,,PET,Stein/Baraka,10,5,5,0
+Sarpy,Precinct 25,President/Vice President,,PET,Stein/Baraka,16,11,4,1
+Sarpy,Precinct 26,President/Vice President,,PET,Stein/Baraka,11,6,4,1
+Sarpy,Precinct 31,President/Vice President,,PET,Stein/Baraka,20,8,10,2
+Sarpy,Precinct 32,President/Vice President,,PET,Stein/Baraka,14,9,5,0
+Sarpy,Precinct 33,President/Vice President,,PET,Stein/Baraka,17,12,5,0
+Sarpy,Precinct 34,President/Vice President,,PET,Stein/Baraka,25,21,4,0
+Sarpy,Precinct 35,President/Vice President,,PET,Stein/Baraka,18,10,8,0
+Sarpy,Precinct 36,President/Vice President,,PET,Stein/Baraka,9,7,2,0
+Sarpy,Precinct 37,President/Vice President,,PET,Stein/Baraka,17,12,4,1
+Sarpy,Precinct 38,President/Vice President,,PET,Stein/Baraka,19,12,7,0
+Sarpy,Precinct 39,President/Vice President,,PET,Stein/Baraka,18,11,6,1
+Sarpy,Precinct 40,President/Vice President,,PET,Stein/Baraka,16,11,5,0
+Sarpy,Precinct 41,President/Vice President,,PET,Stein/Baraka,17,13,4,0
+Sarpy,Precinct 42,President/Vice President,,PET,Stein/Baraka,14,7,7,0
+Sarpy,Precinct 46,President/Vice President,,PET,Stein/Baraka,6,5,1,0
+Sarpy,Precinct 47,President/Vice President,,PET,Stein/Baraka,12,9,2,1
+Sarpy,Precinct 48,President/Vice President,,PET,Stein/Baraka,15,8,7,0
+Sarpy,Precinct 49,President/Vice President,,PET,Stein/Baraka,22,15,7,0
+Sarpy,Precinct 51,President/Vice President,,PET,Stein/Baraka,11,10,1,0
+Sarpy,Precinct 52,President/Vice President,,PET,Stein/Baraka,18,10,7,1
+Sarpy,Precinct 53,President/Vice President,,PET,Stein/Baraka,16,11,5,0
+Sarpy,Precinct 54,President/Vice President,,PET,Stein/Baraka,13,4,9,0
+Sarpy,Precinct 55,President/Vice President,,PET,Stein/Baraka,13,11,2,0
+Sarpy,Precinct 56,President/Vice President,,PET,Stein/Baraka,19,12,7,0
+Sarpy,Precinct 57,President/Vice President,,PET,Stein/Baraka,14,11,3,0
+Sarpy,Precinct 58,President/Vice President,,PET,Stein/Baraka,8,4,4,0
+Sarpy,Precinct 59,President/Vice President,,PET,Stein/Baraka,13,12,1,0
+Sarpy,Precinct 60,President/Vice President,,PET,Stein/Baraka,13,8,5,0
+Sarpy,Precinct 61,President/Vice President,,PET,Stein/Baraka,19,11,7,1
+Sarpy,Precinct 62,President/Vice President,,PET,Stein/Baraka,16,9,6,1
+Sarpy,New/Former Resident 1,President/Vice President,,PET,Stein/Baraka,0,0,0,0
+Sarpy,New/Former Resident 2,President/Vice President,,PET,Stein/Baraka,0,0,0,0
+Sarpy,,President/Vice President,,,WRITE-IN,1886,1082,782,22
+Sarpy,Precinct 1,President/Vice President,,,WRITE-IN,13,9,4,0
+Sarpy,Precinct 2,President/Vice President,,,WRITE-IN,12,10,2,0
+Sarpy,Precinct 3,President/Vice President,,,WRITE-IN,51,32,18,1
+Sarpy,Precinct 4,President/Vice President,,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 5,President/Vice President,,,WRITE-IN,20,16,4,0
+Sarpy,Precinct 6,President/Vice President,,,WRITE-IN,32,19,10,3
+Sarpy,Precinct 7,President/Vice President,,,WRITE-IN,23,14,7,2
+Sarpy,Precinct 8,President/Vice President,,,WRITE-IN,38,20,18,0
+Sarpy,Precinct 9,President/Vice President,,,WRITE-IN,27,19,8,0
+Sarpy,Precinct 10,President/Vice President,,,WRITE-IN,17,13,3,1
+Sarpy,Precinct 11,President/Vice President,,,WRITE-IN,47,25,22,0
+Sarpy,Precinct 12,President/Vice President,,,WRITE-IN,40,20,20,0
+Sarpy,Precinct 13,President/Vice President,,,WRITE-IN,33,14,18,1
+Sarpy,Precinct 16,President/Vice President,,,WRITE-IN,29,14,15,0
+Sarpy,Precinct 17,President/Vice President,,,WRITE-IN,24,17,7,0
+Sarpy,Precinct 18,President/Vice President,,,WRITE-IN,21,11,10,0
+Sarpy,Precinct 19,President/Vice President,,,WRITE-IN,64,24,39,1
+Sarpy,Precinct 20,President/Vice President,,,WRITE-IN,42,25,17,0
+Sarpy,Precinct 21,President/Vice President,,,WRITE-IN,80,40,40,0
+Sarpy,Precinct 22,President/Vice President,,,WRITE-IN,44,25,19,0
+Sarpy,Precinct 23,President/Vice President,,,WRITE-IN,58,29,28,1
+Sarpy,Precinct 24,President/Vice President,,,WRITE-IN,17,11,6,0
+Sarpy,Precinct 25,President/Vice President,,,WRITE-IN,28,16,11,1
+Sarpy,Precinct 26,President/Vice President,,,WRITE-IN,36,25,11,0
+Sarpy,Precinct 31,President/Vice President,,,WRITE-IN,68,47,21,0
+Sarpy,Precinct 32,President/Vice President,,,WRITE-IN,30,20,10,0
+Sarpy,Precinct 33,President/Vice President,,,WRITE-IN,40,21,18,1
+Sarpy,Precinct 34,President/Vice President,,,WRITE-IN,32,25,6,1
+Sarpy,Precinct 35,President/Vice President,,,WRITE-IN,22,17,5,0
+Sarpy,Precinct 36,President/Vice President,,,WRITE-IN,37,15,22,0
+Sarpy,Precinct 37,President/Vice President,,,WRITE-IN,61,36,25,0
+Sarpy,Precinct 38,President/Vice President,,,WRITE-IN,49,30,19,0
+Sarpy,Precinct 39,President/Vice President,,,WRITE-IN,55,30,25,0
+Sarpy,Precinct 40,President/Vice President,,,WRITE-IN,36,23,12,1
+Sarpy,Precinct 41,President/Vice President,,,WRITE-IN,42,26,15,1
+Sarpy,Precinct 42,President/Vice President,,,WRITE-IN,40,23,17,0
+Sarpy,Precinct 46,President/Vice President,,,WRITE-IN,10,7,3,0
+Sarpy,Precinct 47,President/Vice President,,,WRITE-IN,15,14,1,0
+Sarpy,Precinct 48,President/Vice President,,,WRITE-IN,48,25,23,0
+Sarpy,Precinct 49,President/Vice President,,,WRITE-IN,59,29,30,0
+Sarpy,Precinct 51,President/Vice President,,,WRITE-IN,36,13,22,1
+Sarpy,Precinct 52,President/Vice President,,,WRITE-IN,52,29,22,1
+Sarpy,Precinct 53,President/Vice President,,,WRITE-IN,33,17,16,0
+Sarpy,Precinct 54,President/Vice President,,,WRITE-IN,41,25,16,0
+Sarpy,Precinct 55,President/Vice President,,,WRITE-IN,55,35,18,2
+Sarpy,Precinct 56,President/Vice President,,,WRITE-IN,15,11,4,0
+Sarpy,Precinct 57,President/Vice President,,,WRITE-IN,20,11,8,1
+Sarpy,Precinct 58,President/Vice President,,,WRITE-IN,21,8,13,0
+Sarpy,Precinct 59,President/Vice President,,,WRITE-IN,23,13,9,1
+Sarpy,Precinct 60,President/Vice President,,,WRITE-IN,35,25,10,0
+Sarpy,Precinct 61,President/Vice President,,,WRITE-IN,49,26,23,0
+Sarpy,Precinct 62,President/Vice President,,,WRITE-IN,48,24,23,1
+Sarpy,New/Former Resident 1,President/Vice President,,,WRITE-IN,1,0,1,0
+Sarpy,New/Former Resident 2,President/Vice President,,,WRITE-IN,0,0,0,0
+Sarpy,,President/Vice President CNG,1,REP,Trump/Pence,15656,10289,5188,179
+Sarpy,Precinct 1,President/Vice President CNG,1,REP,Trump/Pence,443,313,128,2
+Sarpy,Precinct 2,President/Vice President CNG,1,REP,Trump/Pence,551,401,142,8
+Sarpy,Precinct 3,President/Vice President CNG,1,REP,Trump/Pence,776,467,295,14
+Sarpy,Precinct 4,President/Vice President CNG,1,REP,Trump/Pence,720,487,228,5
+Sarpy,Precinct 5,President/Vice President CNG,1,REP,Trump/Pence,586,351,231,4
+Sarpy,Precinct 6,President/Vice President CNG,1,REP,Trump/Pence,658,469,182,7
+Sarpy,Precinct 7,President/Vice President CNG,1,REP,Trump/Pence,657,438,204,15
+Sarpy,Precinct 8,President/Vice President CNG,1,REP,Trump/Pence,684,480,196,8
+Sarpy,Precinct 9,President/Vice President CNG,1,REP,Trump/Pence,660,495,158,7
+Sarpy,Precinct 10,President/Vice President CNG,1,REP,Trump/Pence,455,359,88,8
+Sarpy,Precinct 11,President/Vice President CNG,1,REP,Trump/Pence,1000,593,398,9
+Sarpy,Precinct 12,President/Vice President CNG,1,REP,Trump/Pence,947,642,292,13
+Sarpy,Precinct 13,President/Vice President CNG,1,REP,Trump/Pence,921,574,337,10
+Sarpy,Precinct 16,President/Vice President CNG,1,REP,Trump/Pence,765,473,287,5
+Sarpy,Precinct 17,President/Vice President CNG,1,REP,Trump/Pence,768,518,244,6
+Sarpy,Precinct 18,President/Vice President CNG,1,REP,Trump/Pence,544,375,166,3
+Sarpy,Precinct 19,President/Vice President CNG,1,REP,Trump/Pence,629,300,320,9
+Sarpy,Precinct 20,President/Vice President CNG,1,REP,Trump/Pence,794,530,261,3
+Sarpy,Precinct 21,President/Vice President CNG,1,REP,Trump/Pence,451,273,174,4
+Sarpy,Precinct 22,President/Vice President CNG,1,REP,Trump/Pence,716,488,219,9
+Sarpy,Precinct 24,President/Vice President CNG,1,REP,Trump/Pence,602,388,209,5
+Sarpy,Precinct 25,President/Vice President CNG,1,REP,Trump/Pence,560,386,159,15
+Sarpy,Precinct 26,President/Vice President CNG,1,REP,Trump/Pence,769,489,270,10
+Sarpy,New/Former Resident 1,President/Vice President CNG,1,REP,Trump/Pence,0,0,0,0
+Sarpy,,President/Vice President CNG,1,DEM,Clinton/Kaine,10801,5912,4754,135
+Sarpy,Precinct 1,President/Vice President CNG,1,DEM,Clinton/Kaine,478,311,159,8
+Sarpy,Precinct 2,President/Vice President CNG,1,DEM,Clinton/Kaine,337,221,112,4
+Sarpy,Precinct 3,President/Vice President CNG,1,DEM,Clinton/Kaine,578,311,262,5
+Sarpy,Precinct 4,President/Vice President CNG,1,DEM,Clinton/Kaine,470,289,176,5
+Sarpy,Precinct 5,President/Vice President CNG,1,DEM,Clinton/Kaine,408,194,209,5
+Sarpy,Precinct 6,President/Vice President CNG,1,DEM,Clinton/Kaine,529,304,213,12
+Sarpy,Precinct 7,President/Vice President CNG,1,DEM,Clinton/Kaine,441,234,199,8
+Sarpy,Precinct 8,President/Vice President CNG,1,DEM,Clinton/Kaine,411,226,183,2
+Sarpy,Precinct 9,President/Vice President CNG,1,DEM,Clinton/Kaine,436,291,139,6
+Sarpy,Precinct 10,President/Vice President CNG,1,DEM,Clinton/Kaine,310,195,109,6
+Sarpy,Precinct 11,President/Vice President CNG,1,DEM,Clinton/Kaine,601,298,300,3
+Sarpy,Precinct 12,President/Vice President CNG,1,DEM,Clinton/Kaine,462,250,204,8
+Sarpy,Precinct 13,President/Vice President CNG,1,DEM,Clinton/Kaine,597,273,316,8
+Sarpy,Precinct 16,President/Vice President CNG,1,DEM,Clinton/Kaine,609,335,270,4
+Sarpy,Precinct 17,President/Vice President CNG,1,DEM,Clinton/Kaine,546,296,247,3
+Sarpy,Precinct 18,President/Vice President CNG,1,DEM,Clinton/Kaine,505,300,201,4
+Sarpy,Precinct 19,President/Vice President CNG,1,DEM,Clinton/Kaine,437,201,227,9
+Sarpy,Precinct 20,President/Vice President CNG,1,DEM,Clinton/Kaine,664,326,330,8
+Sarpy,Precinct 21,President/Vice President CNG,1,DEM,Clinton/Kaine,303,166,133,4
+Sarpy,Precinct 22,President/Vice President CNG,1,DEM,Clinton/Kaine,536,280,249,7
+Sarpy,Precinct 24,President/Vice President CNG,1,DEM,Clinton/Kaine,316,165,149,2
+Sarpy,Precinct 25,President/Vice President CNG,1,DEM,Clinton/Kaine,386,205,172,9
+Sarpy,Precinct 26,President/Vice President CNG,1,DEM,Clinton/Kaine,440,241,194,5
+Sarpy,New/Former Resident 1,President/Vice President CNG,1,DEM,Clinton/Kaine,1,0,1,0
+Sarpy,,President/Vice President CNG,1,LIB,Johnson/Weld,1839,1240,566,33
+Sarpy,Precinct 1,President/Vice President CNG,1,LIB,Johnson/Weld,41,29,11,1
+Sarpy,Precinct 2,President/Vice President CNG,1,LIB,Johnson/Weld,65,50,14,1
+Sarpy,Precinct 3,President/Vice President CNG,1,LIB,Johnson/Weld,84,56,27,1
+Sarpy,Precinct 4,President/Vice President CNG,1,LIB,Johnson/Weld,93,65,25,3
+Sarpy,Precinct 5,President/Vice President CNG,1,LIB,Johnson/Weld,64,43,21,0
+Sarpy,Precinct 6,President/Vice President CNG,1,LIB,Johnson/Weld,93,72,19,2
+Sarpy,Precinct 7,President/Vice President CNG,1,LIB,Johnson/Weld,66,49,15,2
+Sarpy,Precinct 8,President/Vice President CNG,1,LIB,Johnson/Weld,56,33,21,2
+Sarpy,Precinct 9,President/Vice President CNG,1,LIB,Johnson/Weld,84,52,30,2
+Sarpy,Precinct 10,President/Vice President CNG,1,LIB,Johnson/Weld,82,63,14,5
+Sarpy,Precinct 11,President/Vice President CNG,1,LIB,Johnson/Weld,126,77,45,4
+Sarpy,Precinct 12,President/Vice President CNG,1,LIB,Johnson/Weld,97,56,41,0
+Sarpy,Precinct 13,President/Vice President CNG,1,LIB,Johnson/Weld,87,63,24,0
+Sarpy,Precinct 16,President/Vice President CNG,1,LIB,Johnson/Weld,79,58,21,0
+Sarpy,Precinct 17,President/Vice President CNG,1,LIB,Johnson/Weld,59,37,21,1
+Sarpy,Precinct 18,President/Vice President CNG,1,LIB,Johnson/Weld,78,50,27,1
+Sarpy,Precinct 19,President/Vice President CNG,1,LIB,Johnson/Weld,66,37,29,0
+Sarpy,Precinct 20,President/Vice President CNG,1,LIB,Johnson/Weld,74,52,22,0
+Sarpy,Precinct 21,President/Vice President CNG,1,LIB,Johnson/Weld,60,37,21,2
+Sarpy,Precinct 22,President/Vice President CNG,1,LIB,Johnson/Weld,113,73,39,1
+Sarpy,Precinct 24,President/Vice President CNG,1,LIB,Johnson/Weld,78,55,21,2
+Sarpy,Precinct 25,President/Vice President CNG,1,LIB,Johnson/Weld,88,61,25,2
+Sarpy,Precinct 26,President/Vice President CNG,1,LIB,Johnson/Weld,106,72,33,1
+Sarpy,New/Former Resident 1,President/Vice President CNG,1,LIB,Johnson/Weld,0,0,0,0
+Sarpy,,President/Vice President CNG,1,PET,Stein/Baraka,371,254,108,9
+Sarpy,Precinct 1,President/Vice President CNG,1,PET,Stein/Baraka,23,19,4,0
+Sarpy,Precinct 2,President/Vice President CNG,1,PET,Stein/Baraka,15,10,5,0
+Sarpy,Precinct 3,President/Vice President CNG,1,PET,Stein/Baraka,23,13,10,0
+Sarpy,Precinct 4,President/Vice President CNG,1,PET,Stein/Baraka,13,10,3,0
+Sarpy,Precinct 5,President/Vice President CNG,1,PET,Stein/Baraka,12,6,5,1
+Sarpy,Precinct 6,President/Vice President CNG,1,PET,Stein/Baraka,25,18,5,2
+Sarpy,Precinct 7,President/Vice President CNG,1,PET,Stein/Baraka,13,10,3,0
+Sarpy,Precinct 8,President/Vice President CNG,1,PET,Stein/Baraka,7,4,3,0
+Sarpy,Precinct 9,President/Vice President CNG,1,PET,Stein/Baraka,18,13,5,0
+Sarpy,Precinct 10,President/Vice President CNG,1,PET,Stein/Baraka,21,14,6,1
+Sarpy,Precinct 11,President/Vice President CNG,1,PET,Stein/Baraka,15,11,4,0
+Sarpy,Precinct 12,President/Vice President CNG,1,PET,Stein/Baraka,14,12,2,0
+Sarpy,Precinct 13,President/Vice President CNG,1,PET,Stein/Baraka,22,19,3,0
+Sarpy,Precinct 16,President/Vice President CNG,1,PET,Stein/Baraka,25,19,6,0
+Sarpy,Precinct 17,President/Vice President CNG,1,PET,Stein/Baraka,27,19,6,2
+Sarpy,Precinct 18,President/Vice President CNG,1,PET,Stein/Baraka,10,8,2,0
+Sarpy,Precinct 19,President/Vice President CNG,1,PET,Stein/Baraka,12,3,8,1
+Sarpy,Precinct 20,President/Vice President CNG,1,PET,Stein/Baraka,15,8,7,0
+Sarpy,Precinct 21,President/Vice President CNG,1,PET,Stein/Baraka,7,5,2,0
+Sarpy,Precinct 22,President/Vice President CNG,1,PET,Stein/Baraka,17,11,6,0
+Sarpy,Precinct 24,President/Vice President CNG,1,PET,Stein/Baraka,10,5,5,0
+Sarpy,Precinct 25,President/Vice President CNG,1,PET,Stein/Baraka,16,11,4,1
+Sarpy,Precinct 26,President/Vice President CNG,1,PET,Stein/Baraka,11,6,4,1
+Sarpy,New/Former Resident 1,President/Vice President CNG,1,PET,Stein/Baraka,0,0,0,0
+Sarpy,,President/Vice President CNG,1,,WRITE-IN,666,394,263,9
+Sarpy,Precinct 1,President/Vice President CNG,1,,WRITE-IN,13,9,4,0
+Sarpy,Precinct 2,President/Vice President CNG,1,,WRITE-IN,12,10,2,0
+Sarpy,Precinct 3,President/Vice President CNG,1,,WRITE-IN,51,32,18,1
+Sarpy,Precinct 4,President/Vice President CNG,1,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 5,President/Vice President CNG,1,,WRITE-IN,20,16,4,0
+Sarpy,Precinct 6,President/Vice President CNG,1,,WRITE-IN,32,19,10,3
+Sarpy,Precinct 7,President/Vice President CNG,1,,WRITE-IN,23,14,7,2
+Sarpy,Precinct 8,President/Vice President CNG,1,,WRITE-IN,38,20,18,0
+Sarpy,Precinct 9,President/Vice President CNG,1,,WRITE-IN,27,19,8,0
+Sarpy,Precinct 10,President/Vice President CNG,1,,WRITE-IN,17,13,3,1
+Sarpy,Precinct 11,President/Vice President CNG,1,,WRITE-IN,47,25,22,0
+Sarpy,Precinct 12,President/Vice President CNG,1,,WRITE-IN,40,20,20,0
+Sarpy,Precinct 13,President/Vice President CNG,1,,WRITE-IN,33,14,18,1
+Sarpy,Precinct 16,President/Vice President CNG,1,,WRITE-IN,29,14,15,0
+Sarpy,Precinct 17,President/Vice President CNG,1,,WRITE-IN,24,17,7,0
+Sarpy,Precinct 18,President/Vice President CNG,1,,WRITE-IN,21,11,10,0
+Sarpy,Precinct 19,President/Vice President CNG,1,,WRITE-IN,28,13,15,0
+Sarpy,Precinct 20,President/Vice President CNG,1,,WRITE-IN,42,25,17,0
+Sarpy,Precinct 21,President/Vice President CNG,1,,WRITE-IN,26,17,9,0
+Sarpy,Precinct 22,President/Vice President CNG,1,,WRITE-IN,44,25,19,0
+Sarpy,Precinct 24,President/Vice President CNG,1,,WRITE-IN,17,11,6,0
+Sarpy,Precinct 25,President/Vice President CNG,1,,WRITE-IN,28,16,11,1
+Sarpy,Precinct 26,President/Vice President CNG,1,,WRITE-IN,36,25,11,0
+Sarpy,New/Former Resident 1,President/Vice President CNG,1,,WRITE-IN,1,0,1,0
+Sarpy,,President/Vice President CNG,2,REP,Trump/Pence,29487,18652,10564,271
+Sarpy,Precinct 19,President/Vice President CNG,2,REP,Trump/Pence,606,258,344,4
+Sarpy,Precinct 21,President/Vice President CNG,2,REP,Trump/Pence,760,375,383,2
+Sarpy,Precinct 23,President/Vice President CNG,2,REP,Trump/Pence,1242,685,540,17
+Sarpy,Precinct 31,President/Vice President CNG,2,REP,Trump/Pence,1397,940,448,9
+Sarpy,Precinct 32,President/Vice President CNG,2,REP,Trump/Pence,631,435,190,6
+Sarpy,Precinct 33,President/Vice President CNG,2,REP,Trump/Pence,682,446,228,8
+Sarpy,Precinct 34,President/Vice President CNG,2,REP,Trump/Pence,806,542,255,9
+Sarpy,Precinct 35,President/Vice President CNG,2,REP,Trump/Pence,774,552,218,4
+Sarpy,Precinct 36,President/Vice President CNG,2,REP,Trump/Pence,912,601,306,5
+Sarpy,Precinct 37,President/Vice President CNG,2,REP,Trump/Pence,1350,793,550,7
+Sarpy,Precinct 38,President/Vice President CNG,2,REP,Trump/Pence,795,539,246,10
+Sarpy,Precinct 39,President/Vice President CNG,2,REP,Trump/Pence,942,573,368,1
+Sarpy,Precinct 40,President/Vice President CNG,2,REP,Trump/Pence,856,567,279,10
+Sarpy,Precinct 41,President/Vice President CNG,2,REP,Trump/Pence,1077,580,485,12
+Sarpy,Precinct 42,President/Vice President CNG,2,REP,Trump/Pence,887,506,372,9
+Sarpy,Precinct 46,President/Vice President CNG,2,REP,Trump/Pence,803,519,282,2
+Sarpy,Precinct 47,President/Vice President CNG,2,REP,Trump/Pence,490,387,96,7
+Sarpy,Precinct 48,President/Vice President CNG,2,REP,Trump/Pence,1139,580,550,9
+Sarpy,Precinct 49,President/Vice President CNG,2,REP,Trump/Pence,972,554,408,10
+Sarpy,Precinct 51,President/Vice President CNG,2,REP,Trump/Pence,1413,935,467,11
+Sarpy,Precinct 52,President/Vice President CNG,2,REP,Trump/Pence,1331,811,503,17
+Sarpy,Precinct 53,President/Vice President CNG,2,REP,Trump/Pence,1001,645,346,10
+Sarpy,Precinct 54,President/Vice President CNG,2,REP,Trump/Pence,971,574,384,13
+Sarpy,Precinct 55,President/Vice President CNG,2,REP,Trump/Pence,1250,837,401,12
+Sarpy,Precinct 56,President/Vice President CNG,2,REP,Trump/Pence,818,571,245,2
+Sarpy,Precinct 57,President/Vice President CNG,2,REP,Trump/Pence,715,515,193,7
+Sarpy,Precinct 58,President/Vice President CNG,2,REP,Trump/Pence,769,552,208,9
+Sarpy,Precinct 59,President/Vice President CNG,2,REP,Trump/Pence,820,578,232,10
+Sarpy,Precinct 60,President/Vice President CNG,2,REP,Trump/Pence,675,509,161,5
+Sarpy,Precinct 61,President/Vice President CNG,2,REP,Trump/Pence,1817,1162,633,22
+Sarpy,Precinct 62,President/Vice President CNG,2,REP,Trump/Pence,783,531,240,12
+Sarpy,New/Former Resident 2,President/Vice President CNG,2,REP,Trump/Pence,3,0,3,0
+Sarpy,,President/Vice President CNG,2,DEM,Clinton/Kaine,17232,8876,8188,168
+Sarpy,Precinct 19,President/Vice President CNG,2,DEM,Clinton/Kaine,311,93,214,4
+Sarpy,Precinct 21,President/Vice President CNG,2,DEM,Clinton/Kaine,380,139,236,5
+Sarpy,Precinct 23,President/Vice President CNG,2,DEM,Clinton/Kaine,656,248,393,15
+Sarpy,Precinct 31,President/Vice President CNG,2,DEM,Clinton/Kaine,905,502,389,14
+Sarpy,Precinct 32,President/Vice President CNG,2,DEM,Clinton/Kaine,453,241,209,3
+Sarpy,Precinct 33,President/Vice President CNG,2,DEM,Clinton/Kaine,616,357,246,13
+Sarpy,Precinct 34,President/Vice President CNG,2,DEM,Clinton/Kaine,650,367,277,6
+Sarpy,Precinct 35,President/Vice President CNG,2,DEM,Clinton/Kaine,525,290,231,4
+Sarpy,Precinct 36,President/Vice President CNG,2,DEM,Clinton/Kaine,463,225,236,2
+Sarpy,Precinct 37,President/Vice President CNG,2,DEM,Clinton/Kaine,804,403,390,11
+Sarpy,Precinct 38,President/Vice President CNG,2,DEM,Clinton/Kaine,542,306,231,5
+Sarpy,Precinct 39,President/Vice President CNG,2,DEM,Clinton/Kaine,518,278,240,0
+Sarpy,Precinct 40,President/Vice President CNG,2,DEM,Clinton/Kaine,474,256,210,8
+Sarpy,Precinct 41,President/Vice President CNG,2,DEM,Clinton/Kaine,649,293,351,5
+Sarpy,Precinct 42,President/Vice President CNG,2,DEM,Clinton/Kaine,545,273,268,4
+Sarpy,Precinct 46,President/Vice President CNG,2,DEM,Clinton/Kaine,292,144,148,0
+Sarpy,Precinct 47,President/Vice President CNG,2,DEM,Clinton/Kaine,217,146,70,1
+Sarpy,Precinct 48,President/Vice President CNG,2,DEM,Clinton/Kaine,530,232,297,1
+Sarpy,Precinct 49,President/Vice President CNG,2,DEM,Clinton/Kaine,630,291,333,6
+Sarpy,Precinct 51,President/Vice President CNG,2,DEM,Clinton/Kaine,785,464,318,3
+Sarpy,Precinct 52,President/Vice President CNG,2,DEM,Clinton/Kaine,797,401,387,9
+Sarpy,Precinct 53,President/Vice President CNG,2,DEM,Clinton/Kaine,770,357,402,11
+Sarpy,Precinct 54,President/Vice President CNG,2,DEM,Clinton/Kaine,699,331,361,7
+Sarpy,Precinct 55,President/Vice President CNG,2,DEM,Clinton/Kaine,765,438,318,9
+Sarpy,Precinct 56,President/Vice President CNG,2,DEM,Clinton/Kaine,530,289,239,2
+Sarpy,Precinct 57,President/Vice President CNG,2,DEM,Clinton/Kaine,487,287,198,2
+Sarpy,Precinct 58,President/Vice President CNG,2,DEM,Clinton/Kaine,280,177,102,1
+Sarpy,Precinct 59,President/Vice President CNG,2,DEM,Clinton/Kaine,335,208,126,1
+Sarpy,Precinct 60,President/Vice President CNG,2,DEM,Clinton/Kaine,356,212,144,0
+Sarpy,Precinct 61,President/Vice President CNG,2,DEM,Clinton/Kaine,747,344,399,4
+Sarpy,Precinct 62,President/Vice President CNG,2,DEM,Clinton/Kaine,520,284,224,12
+Sarpy,New/Former Resident 2,President/Vice President CNG,2,DEM,Clinton/Kaine,1,0,1,0
+Sarpy,,President/Vice President CNG,2,LIB,Johnson/Weld,2843,1809,1000,34
+Sarpy,Precinct 19,President/Vice President CNG,2,LIB,Johnson/Weld,61,25,35,1
+Sarpy,Precinct 21,President/Vice President CNG,2,LIB,Johnson/Weld,58,33,25,0
+Sarpy,Precinct 23,President/Vice President CNG,2,LIB,Johnson/Weld,112,68,41,3
+Sarpy,Precinct 31,President/Vice President CNG,2,LIB,Johnson/Weld,147,96,46,5
+Sarpy,Precinct 32,President/Vice President CNG,2,LIB,Johnson/Weld,74,48,24,2
+Sarpy,Precinct 33,President/Vice President CNG,2,LIB,Johnson/Weld,78,56,19,3
+Sarpy,Precinct 34,President/Vice President CNG,2,LIB,Johnson/Weld,107,76,31,0
+Sarpy,Precinct 35,President/Vice President CNG,2,LIB,Johnson/Weld,84,57,26,1
+Sarpy,Precinct 36,President/Vice President CNG,2,LIB,Johnson/Weld,55,31,23,1
+Sarpy,Precinct 37,President/Vice President CNG,2,LIB,Johnson/Weld,113,69,42,2
+Sarpy,Precinct 38,President/Vice President CNG,2,LIB,Johnson/Weld,89,61,28,0
+Sarpy,Precinct 39,President/Vice President CNG,2,LIB,Johnson/Weld,100,58,42,0
+Sarpy,Precinct 40,President/Vice President CNG,2,LIB,Johnson/Weld,94,59,33,2
+Sarpy,Precinct 41,President/Vice President CNG,2,LIB,Johnson/Weld,110,67,42,1
+Sarpy,Precinct 42,President/Vice President CNG,2,LIB,Johnson/Weld,103,64,39,0
+Sarpy,Precinct 46,President/Vice President CNG,2,LIB,Johnson/Weld,53,40,13,0
+Sarpy,Precinct 47,President/Vice President CNG,2,LIB,Johnson/Weld,57,42,15,0
+Sarpy,Precinct 48,President/Vice President CNG,2,LIB,Johnson/Weld,91,40,50,1
+Sarpy,Precinct 49,President/Vice President CNG,2,LIB,Johnson/Weld,123,76,43,4
+Sarpy,Precinct 51,President/Vice President CNG,2,LIB,Johnson/Weld,113,67,46,0
+Sarpy,Precinct 52,President/Vice President CNG,2,LIB,Johnson/Weld,115,71,43,1
+Sarpy,Precinct 53,President/Vice President CNG,2,LIB,Johnson/Weld,118,70,46,2
+Sarpy,Precinct 54,President/Vice President CNG,2,LIB,Johnson/Weld,105,68,36,1
+Sarpy,Precinct 55,President/Vice President CNG,2,LIB,Johnson/Weld,121,88,33,0
+Sarpy,Precinct 56,President/Vice President CNG,2,LIB,Johnson/Weld,69,51,18,0
+Sarpy,Precinct 57,President/Vice President CNG,2,LIB,Johnson/Weld,86,62,24,0
+Sarpy,Precinct 58,President/Vice President CNG,2,LIB,Johnson/Weld,42,28,14,0
+Sarpy,Precinct 59,President/Vice President CNG,2,LIB,Johnson/Weld,78,58,20,0
+Sarpy,Precinct 60,President/Vice President CNG,2,LIB,Johnson/Weld,72,50,22,0
+Sarpy,Precinct 61,President/Vice President CNG,2,LIB,Johnson/Weld,121,70,48,3
+Sarpy,Precinct 62,President/Vice President CNG,2,LIB,Johnson/Weld,94,60,33,1
+Sarpy,New/Former Resident 2,President/Vice President CNG,2,LIB,Johnson/Weld,0,0,0,0
+Sarpy,,President/Vice President CNG,2,PET,Stein/Baraka,465,301,156,8
+Sarpy,Precinct 19,President/Vice President CNG,2,PET,Stein/Baraka,12,4,8,0
+Sarpy,Precinct 21,President/Vice President CNG,2,PET,Stein/Baraka,8,7,1,0
+Sarpy,Precinct 23,President/Vice President CNG,2,PET,Stein/Baraka,13,7,6,0
+Sarpy,Precinct 31,President/Vice President CNG,2,PET,Stein/Baraka,20,8,10,2
+Sarpy,Precinct 32,President/Vice President CNG,2,PET,Stein/Baraka,14,9,5,0
+Sarpy,Precinct 33,President/Vice President CNG,2,PET,Stein/Baraka,17,12,5,0
+Sarpy,Precinct 34,President/Vice President CNG,2,PET,Stein/Baraka,25,21,4,0
+Sarpy,Precinct 35,President/Vice President CNG,2,PET,Stein/Baraka,18,10,8,0
+Sarpy,Precinct 36,President/Vice President CNG,2,PET,Stein/Baraka,9,7,2,0
+Sarpy,Precinct 37,President/Vice President CNG,2,PET,Stein/Baraka,17,12,4,1
+Sarpy,Precinct 38,President/Vice President CNG,2,PET,Stein/Baraka,19,12,7,0
+Sarpy,Precinct 39,President/Vice President CNG,2,PET,Stein/Baraka,18,11,6,1
+Sarpy,Precinct 40,President/Vice President CNG,2,PET,Stein/Baraka,16,11,5,0
+Sarpy,Precinct 41,President/Vice President CNG,2,PET,Stein/Baraka,17,13,4,0
+Sarpy,Precinct 42,President/Vice President CNG,2,PET,Stein/Baraka,14,7,7,0
+Sarpy,Precinct 46,President/Vice President CNG,2,PET,Stein/Baraka,6,5,1,0
+Sarpy,Precinct 47,President/Vice President CNG,2,PET,Stein/Baraka,12,9,2,1
+Sarpy,Precinct 48,President/Vice President CNG,2,PET,Stein/Baraka,15,8,7,0
+Sarpy,Precinct 49,President/Vice President CNG,2,PET,Stein/Baraka,22,15,7,0
+Sarpy,Precinct 51,President/Vice President CNG,2,PET,Stein/Baraka,11,10,1,0
+Sarpy,Precinct 52,President/Vice President CNG,2,PET,Stein/Baraka,18,10,7,1
+Sarpy,Precinct 53,President/Vice President CNG,2,PET,Stein/Baraka,16,11,5,0
+Sarpy,Precinct 54,President/Vice President CNG,2,PET,Stein/Baraka,13,4,9,0
+Sarpy,Precinct 55,President/Vice President CNG,2,PET,Stein/Baraka,13,11,2,0
+Sarpy,Precinct 56,President/Vice President CNG,2,PET,Stein/Baraka,19,12,7,0
+Sarpy,Precinct 57,President/Vice President CNG,2,PET,Stein/Baraka,14,11,3,0
+Sarpy,Precinct 58,President/Vice President CNG,2,PET,Stein/Baraka,8,4,4,0
+Sarpy,Precinct 59,President/Vice President CNG,2,PET,Stein/Baraka,13,12,1,0
+Sarpy,Precinct 60,President/Vice President CNG,2,PET,Stein/Baraka,13,8,5,0
+Sarpy,Precinct 61,President/Vice President CNG,2,PET,Stein/Baraka,19,11,7,1
+Sarpy,Precinct 62,President/Vice President CNG,2,PET,Stein/Baraka,16,9,6,1
+Sarpy,New/Former Resident 2,President/Vice President CNG,2,PET,Stein/Baraka,0,0,0,0
+Sarpy,,President/Vice President CNG,2,,WRITE-IN,1220,688,519,13
+Sarpy,Precinct 19,President/Vice President CNG,2,,WRITE-IN,36,11,24,1
+Sarpy,Precinct 21,President/Vice President CNG,2,,WRITE-IN,54,23,31,0
+Sarpy,Precinct 23,President/Vice President CNG,2,,WRITE-IN,58,29,28,1
+Sarpy,Precinct 31,President/Vice President CNG,2,,WRITE-IN,68,47,21,0
+Sarpy,Precinct 32,President/Vice President CNG,2,,WRITE-IN,30,20,10,0
+Sarpy,Precinct 33,President/Vice President CNG,2,,WRITE-IN,40,21,18,1
+Sarpy,Precinct 34,President/Vice President CNG,2,,WRITE-IN,32,25,6,1
+Sarpy,Precinct 35,President/Vice President CNG,2,,WRITE-IN,22,17,5,0
+Sarpy,Precinct 36,President/Vice President CNG,2,,WRITE-IN,37,15,22,0
+Sarpy,Precinct 37,President/Vice President CNG,2,,WRITE-IN,61,36,25,0
+Sarpy,Precinct 38,President/Vice President CNG,2,,WRITE-IN,49,30,19,0
+Sarpy,Precinct 39,President/Vice President CNG,2,,WRITE-IN,55,30,25,0
+Sarpy,Precinct 40,President/Vice President CNG,2,,WRITE-IN,36,23,12,1
+Sarpy,Precinct 41,President/Vice President CNG,2,,WRITE-IN,42,26,15,1
+Sarpy,Precinct 42,President/Vice President CNG,2,,WRITE-IN,40,23,17,0
+Sarpy,Precinct 46,President/Vice President CNG,2,,WRITE-IN,10,7,3,0
+Sarpy,Precinct 47,President/Vice President CNG,2,,WRITE-IN,15,14,1,0
+Sarpy,Precinct 48,President/Vice President CNG,2,,WRITE-IN,48,25,23,0
+Sarpy,Precinct 49,President/Vice President CNG,2,,WRITE-IN,59,29,30,0
+Sarpy,Precinct 51,President/Vice President CNG,2,,WRITE-IN,36,13,22,1
+Sarpy,Precinct 52,President/Vice President CNG,2,,WRITE-IN,52,29,22,1
+Sarpy,Precinct 53,President/Vice President CNG,2,,WRITE-IN,33,17,16,0
+Sarpy,Precinct 54,President/Vice President CNG,2,,WRITE-IN,41,25,16,0
+Sarpy,Precinct 55,President/Vice President CNG,2,,WRITE-IN,55,35,18,2
+Sarpy,Precinct 56,President/Vice President CNG,2,,WRITE-IN,15,11,4,0
+Sarpy,Precinct 57,President/Vice President CNG,2,,WRITE-IN,20,11,8,1
+Sarpy,Precinct 58,President/Vice President CNG,2,,WRITE-IN,21,8,13,0
+Sarpy,Precinct 59,President/Vice President CNG,2,,WRITE-IN,23,13,9,1
+Sarpy,Precinct 60,President/Vice President CNG,2,,WRITE-IN,35,25,10,0
+Sarpy,Precinct 61,President/Vice President CNG,2,,WRITE-IN,49,26,23,0
+Sarpy,Precinct 62,President/Vice President CNG,2,,WRITE-IN,48,24,23,1
+Sarpy,New/Former Resident 2,President/Vice President CNG,2,,WRITE-IN,0,0,0,0
+Sarpy,,United States Representative,1,REP,Jeff Fortenberry,18745,12172,6357,216
+Sarpy,Precinct 1,United States Representative,1,REP,Jeff Fortenberry,519,367,150,2
+Sarpy,Precinct 2,United States Representative,1,REP,Jeff Fortenberry,659,487,164,8
+Sarpy,Precinct 3,United States Representative,1,REP,Jeff Fortenberry,952,571,368,13
+Sarpy,Precinct 4,United States Representative,1,REP,Jeff Fortenberry,845,577,260,8
+Sarpy,Precinct 5,United States Representative,1,REP,Jeff Fortenberry,718,424,287,7
+Sarpy,Precinct 6,United States Representative,1,REP,Jeff Fortenberry,816,578,226,12
+Sarpy,Precinct 7,United States Representative,1,REP,Jeff Fortenberry,771,503,251,17
+Sarpy,Precinct 8,United States Representative,1,REP,Jeff Fortenberry,826,559,255,12
+Sarpy,Precinct 9,United States Representative,1,REP,Jeff Fortenberry,786,581,197,8
+Sarpy,Precinct 10,United States Representative,1,REP,Jeff Fortenberry,537,419,107,11
+Sarpy,Precinct 11,United States Representative,1,REP,Jeff Fortenberry,1205,713,480,12
+Sarpy,Precinct 12,United States Representative,1,REP,Jeff Fortenberry,1104,741,350,13
+Sarpy,Precinct 13,United States Representative,1,REP,Jeff Fortenberry,1118,661,443,14
+Sarpy,Precinct 16,United States Representative,1,REP,Jeff Fortenberry,881,539,336,6
+Sarpy,Precinct 17,United States Representative,1,REP,Jeff Fortenberry,841,549,287,5
+Sarpy,Precinct 18,United States Representative,1,REP,Jeff Fortenberry,631,427,201,3
+Sarpy,Precinct 19,United States Representative,1,REP,Jeff Fortenberry,750,347,390,13
+Sarpy,Precinct 20,United States Representative,1,REP,Jeff Fortenberry,960,651,308,1
+Sarpy,Precinct 21,United States Representative,1,REP,Jeff Fortenberry,560,340,216,4
+Sarpy,Precinct 22,United States Representative,1,REP,Jeff Fortenberry,889,584,295,10
+Sarpy,Precinct 24,United States Representative,1,REP,Jeff Fortenberry,741,478,257,6
+Sarpy,Precinct 25,United States Representative,1,REP,Jeff Fortenberry,691,462,212,17
+Sarpy,Precinct 26,United States Representative,1,REP,Jeff Fortenberry,945,614,317,14
+Sarpy,,United States Representative,1,DEM,Daniel M. Wik,9544,5249,4167,128
+Sarpy,Precinct 1,United States Representative,1,DEM,Daniel M. Wik,437,286,143,8
+Sarpy,Precinct 2,United States Representative,1,DEM,Daniel M. Wik,285,180,102,3
+Sarpy,Precinct 3,United States Representative,1,DEM,Daniel M. Wik,491,267,220,4
+Sarpy,Precinct 4,United States Representative,1,DEM,Daniel M. Wik,437,264,168,5
+Sarpy,Precinct 5,United States Representative,1,DEM,Daniel M. Wik,337,169,164,4
+Sarpy,Precinct 6,United States Representative,1,DEM,Daniel M. Wik,460,269,182,9
+Sarpy,Precinct 7,United States Representative,1,DEM,Daniel M. Wik,400,224,167,9
+Sarpy,Precinct 8,United States Representative,1,DEM,Daniel M. Wik,333,176,156,1
+Sarpy,Precinct 9,United States Representative,1,DEM,Daniel M. Wik,399,263,128,8
+Sarpy,Precinct 10,United States Representative,1,DEM,Daniel M. Wik,312,202,102,8
+Sarpy,Precinct 11,United States Representative,1,DEM,Daniel M. Wik,520,254,262,4
+Sarpy,Precinct 12,United States Representative,1,DEM,Daniel M. Wik,386,194,186,6
+Sarpy,Precinct 13,United States Representative,1,DEM,Daniel M. Wik,515,257,252,6
+Sarpy,Precinct 16,United States Representative,1,DEM,Daniel M. Wik,558,309,247,2
+Sarpy,Precinct 17,United States Representative,1,DEM,Daniel M. Wik,534,296,231,7
+Sarpy,Precinct 18,United States Representative,1,DEM,Daniel M. Wik,475,283,188,4
+Sarpy,Precinct 19,United States Representative,1,DEM,Daniel M. Wik,361,180,175,6
+Sarpy,Precinct 20,United States Representative,1,DEM,Daniel M. Wik,587,275,303,9
+Sarpy,Precinct 21,United States Representative,1,DEM,Daniel M. Wik,263,141,116,6
+Sarpy,Precinct 22,United States Representative,1,DEM,Daniel M. Wik,486,262,218,6
+Sarpy,Precinct 24,United States Representative,1,DEM,Daniel M. Wik,238,112,124,2
+Sarpy,Precinct 25,United States Representative,1,DEM,Daniel M. Wik,346,189,149,8
+Sarpy,Precinct 26,United States Representative,1,DEM,Daniel M. Wik,384,197,184,3
+Sarpy,,United States Representative,1,,WRITE-IN,94,61,32,1
+Sarpy,Precinct 1,United States Representative,1,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 2,United States Representative,1,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 3,United States Representative,1,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 4,United States Representative,1,,WRITE-IN,5,1,4,0
+Sarpy,Precinct 5,United States Representative,1,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 6,United States Representative,1,,WRITE-IN,2,2,0,0
+Sarpy,Precinct 7,United States Representative,1,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 8,United States Representative,1,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 9,United States Representative,1,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 10,United States Representative,1,,WRITE-IN,7,3,4,0
+Sarpy,Precinct 11,United States Representative,1,,WRITE-IN,7,7,0,0
+Sarpy,Precinct 12,United States Representative,1,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 13,United States Representative,1,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 16,United States Representative,1,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 17,United States Representative,1,,WRITE-IN,4,3,0,1
+Sarpy,Precinct 18,United States Representative,1,,WRITE-IN,5,2,3,0
+Sarpy,Precinct 19,United States Representative,1,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 20,United States Representative,1,,WRITE-IN,5,2,3,0
+Sarpy,Precinct 21,United States Representative,1,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 22,United States Representative,1,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 24,United States Representative,1,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 25,United States Representative,1,,WRITE-IN,3,1,2,0
+Sarpy,Precinct 26,United States Representative,1,,WRITE-IN,3,3,0,0
+Sarpy,,United States Representative,2,REP,Don Bacon,30675,19536,10850,289
+Sarpy,Precinct 19,United States Representative,2,REP,Don Bacon,658,284,370,4
+Sarpy,Precinct 21,United States Representative,2,REP,Don Bacon,825,415,406,4
+Sarpy,Precinct 23,United States Representative,2,REP,Don Bacon,1351,744,587,20
+Sarpy,Precinct 31,United States Representative,2,REP,Don Bacon,1508,1010,486,12
+Sarpy,Precinct 32,United States Representative,2,REP,Don Bacon,643,453,184,6
+Sarpy,Precinct 33,United States Representative,2,REP,Don Bacon,720,476,234,10
+Sarpy,Precinct 34,United States Representative,2,REP,Don Bacon,757,518,229,10
+Sarpy,Precinct 35,United States Representative,2,REP,Don Bacon,749,548,196,5
+Sarpy,Precinct 36,United States Representative,2,REP,Don Bacon,941,600,336,5
+Sarpy,Precinct 37,United States Representative,2,REP,Don Bacon,1464,866,588,10
+Sarpy,Precinct 38,United States Representative,2,REP,Don Bacon,850,590,250,10
+Sarpy,Precinct 39,United States Representative,2,REP,Don Bacon,998,623,374,1
+Sarpy,Precinct 40,United States Representative,2,REP,Don Bacon,878,587,279,12
+Sarpy,Precinct 41,United States Representative,2,REP,Don Bacon,1115,624,481,10
+Sarpy,Precinct 42,United States Representative,2,REP,Don Bacon,928,535,385,8
+Sarpy,Precinct 46,United States Representative,2,REP,Don Bacon,777,520,256,1
+Sarpy,Precinct 47,United States Representative,2,REP,Don Bacon,475,372,96,7
+Sarpy,Precinct 48,United States Representative,2,REP,Don Bacon,1180,609,562,9
+Sarpy,Precinct 49,United States Representative,2,REP,Don Bacon,1104,643,451,10
+Sarpy,Precinct 51,United States Representative,2,REP,Don Bacon,1510,1011,489,10
+Sarpy,Precinct 52,United States Representative,2,REP,Don Bacon,1380,856,508,16
+Sarpy,Precinct 53,United States Representative,2,REP,Don Bacon,1062,691,357,14
+Sarpy,Precinct 54,United States Representative,2,REP,Don Bacon,1006,599,393,14
+Sarpy,Precinct 55,United States Representative,2,REP,Don Bacon,1316,883,421,12
+Sarpy,Precinct 56,United States Representative,2,REP,Don Bacon,813,570,241,2
+Sarpy,Precinct 57,United States Representative,2,REP,Don Bacon,701,518,177,6
+Sarpy,Precinct 58,United States Representative,2,REP,Don Bacon,796,564,223,9
+Sarpy,Precinct 59,United States Representative,2,REP,Don Bacon,814,586,222,6
+Sarpy,Precinct 60,United States Representative,2,REP,Don Bacon,693,524,164,5
+Sarpy,Precinct 61,United States Representative,2,REP,Don Bacon,1826,1163,638,25
+Sarpy,Precinct 62,United States Representative,2,REP,Don Bacon,837,554,267,16
+Sarpy,,United States Representative,2,DEM,Brad Ashford,18372,9456,8743,173
+Sarpy,Precinct 19,United States Representative,2,DEM,Brad Ashford,342,92,247,3
+Sarpy,Precinct 21,United States Representative,2,DEM,Brad Ashford,385,146,237,2
+Sarpy,Precinct 23,United States Representative,2,DEM,Brad Ashford,646,245,387,14
+Sarpy,Precinct 31,United States Representative,2,DEM,Brad Ashford,944,531,396,17
+Sarpy,Precinct 32,United States Representative,2,DEM,Brad Ashford,497,255,237,5
+Sarpy,Precinct 33,United States Representative,2,DEM,Brad Ashford,644,364,267,13
+Sarpy,Precinct 34,United States Representative,2,DEM,Brad Ashford,750,439,306,5
+Sarpy,Precinct 35,United States Representative,2,DEM,Brad Ashford,599,337,259,3
+Sarpy,Precinct 36,United States Representative,2,DEM,Brad Ashford,491,246,242,3
+Sarpy,Precinct 37,United States Representative,2,DEM,Brad Ashford,814,402,403,9
+Sarpy,Precinct 38,United States Representative,2,DEM,Brad Ashford,580,325,250,5
+Sarpy,Precinct 39,United States Representative,2,DEM,Brad Ashford,561,279,282,0
+Sarpy,Precinct 40,United States Representative,2,DEM,Brad Ashford,544,302,235,7
+Sarpy,Precinct 41,United States Representative,2,DEM,Brad Ashford,708,323,377,8
+Sarpy,Precinct 42,United States Representative,2,DEM,Brad Ashford,589,297,286,6
+Sarpy,Precinct 46,United States Representative,2,DEM,Brad Ashford,341,174,166,1
+Sarpy,Precinct 47,United States Representative,2,DEM,Brad Ashford,268,189,77,2
+Sarpy,Precinct 48,United States Representative,2,DEM,Brad Ashford,579,250,328,1
+Sarpy,Precinct 49,United States Representative,2,DEM,Brad Ashford,630,288,335,7
+Sarpy,Precinct 51,United States Representative,2,DEM,Brad Ashford,762,424,334,4
+Sarpy,Precinct 52,United States Representative,2,DEM,Brad Ashford,831,414,405,12
+Sarpy,Precinct 53,United States Representative,2,DEM,Brad Ashford,770,345,417,8
+Sarpy,Precinct 54,United States Representative,2,DEM,Brad Ashford,722,342,374,6
+Sarpy,Precinct 55,United States Representative,2,DEM,Brad Ashford,797,468,321,8
+Sarpy,Precinct 56,United States Representative,2,DEM,Brad Ashford,578,320,257,1
+Sarpy,Precinct 57,United States Representative,2,DEM,Brad Ashford,544,317,223,4
+Sarpy,Precinct 58,United States Representative,2,DEM,Brad Ashford,289,176,112,1
+Sarpy,Precinct 59,United States Representative,2,DEM,Brad Ashford,407,248,155,4
+Sarpy,Precinct 60,United States Representative,2,DEM,Brad Ashford,399,238,161,0
+Sarpy,Precinct 61,United States Representative,2,DEM,Brad Ashford,822,387,430,5
+Sarpy,Precinct 62,United States Representative,2,DEM,Brad Ashford,539,293,237,9
+Sarpy,,United States Representative,2,LIB,Steven Laird,1696,1093,582,21
+Sarpy,Precinct 19,United States Representative,2,LIB,Steven Laird,29,14,12,3
+Sarpy,Precinct 21,United States Representative,2,LIB,Steven Laird,41,22,18,1
+Sarpy,Precinct 23,United States Representative,2,LIB,Steven Laird,65,36,28,1
+Sarpy,Precinct 31,United States Representative,2,LIB,Steven Laird,64,41,22,1
+Sarpy,Precinct 32,United States Representative,2,LIB,Steven Laird,54,41,13,0
+Sarpy,Precinct 33,United States Representative,2,LIB,Steven Laird,55,38,15,2
+Sarpy,Precinct 34,United States Representative,2,LIB,Steven Laird,92,67,25,0
+Sarpy,Precinct 35,United States Representative,2,LIB,Steven Laird,62,36,26,0
+Sarpy,Precinct 36,United States Representative,2,LIB,Steven Laird,35,26,9,0
+Sarpy,Precinct 37,United States Representative,2,LIB,Steven Laird,56,36,19,1
+Sarpy,Precinct 38,United States Representative,2,LIB,Steven Laird,47,25,22,0
+Sarpy,Precinct 39,United States Representative,2,LIB,Steven Laird,61,36,24,1
+Sarpy,Precinct 40,United States Representative,2,LIB,Steven Laird,51,36,14,1
+Sarpy,Precinct 41,United States Representative,2,LIB,Steven Laird,53,25,28,0
+Sarpy,Precinct 42,United States Representative,2,LIB,Steven Laird,61,40,21,0
+Sarpy,Precinct 46,United States Representative,2,LIB,Steven Laird,26,14,12,0
+Sarpy,Precinct 47,United States Representative,2,LIB,Steven Laird,40,32,8,0
+Sarpy,Precinct 48,United States Representative,2,LIB,Steven Laird,52,24,27,1
+Sarpy,Precinct 49,United States Representative,2,LIB,Steven Laird,56,27,26,3
+Sarpy,Precinct 51,United States Representative,2,LIB,Steven Laird,63,44,18,1
+Sarpy,Precinct 52,United States Representative,2,LIB,Steven Laird,67,39,27,1
+Sarpy,Precinct 53,United States Representative,2,LIB,Steven Laird,70,44,26,0
+Sarpy,Precinct 54,United States Representative,2,LIB,Steven Laird,70,45,25,0
+Sarpy,Precinct 55,United States Representative,2,LIB,Steven Laird,68,48,18,2
+Sarpy,Precinct 56,United States Representative,2,LIB,Steven Laird,48,35,13,0
+Sarpy,Precinct 57,United States Representative,2,LIB,Steven Laird,59,44,15,0
+Sarpy,Precinct 58,United States Representative,2,LIB,Steven Laird,29,24,5,0
+Sarpy,Precinct 59,United States Representative,2,LIB,Steven Laird,46,39,7,0
+Sarpy,Precinct 60,United States Representative,2,LIB,Steven Laird,50,39,11,0
+Sarpy,Precinct 61,United States Representative,2,LIB,Steven Laird,64,34,29,1
+Sarpy,Precinct 62,United States Representative,2,LIB,Steven Laird,62,42,19,1
+Sarpy,,United States Representative,2,,WRITE-IN,34,17,16,1
+Sarpy,Precinct 19,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 21,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 23,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 31,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 32,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 33,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 34,United States Representative,2,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 35,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 36,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 37,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 38,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 39,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 40,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 41,United States Representative,2,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 42,United States Representative,2,,WRITE-IN,3,1,2,0
+Sarpy,Precinct 46,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 47,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 48,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 49,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 51,United States Representative,2,,WRITE-IN,2,0,2,0
+Sarpy,Precinct 52,United States Representative,2,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 53,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 54,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 55,United States Representative,2,,WRITE-IN,3,0,3,0
+Sarpy,Precinct 56,United States Representative,2,,WRITE-IN,2,1,0,1
+Sarpy,Precinct 57,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 58,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 59,United States Representative,2,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 60,United States Representative,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 61,United States Representative,2,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 62,United States Representative,2,,WRITE-IN,2,2,0,0
+Sarpy,,Public Defender,,REP,Thomas P. Strigenz,62603,38478,23463,662
+Sarpy,Precinct 1,Public Defender,,REP,Thomas P. Strigenz,726,503,213,10
+Sarpy,Precinct 2,Public Defender,,REP,Thomas P. Strigenz,774,568,196,10
+Sarpy,Precinct 3,Public Defender,,REP,Thomas P. Strigenz,1162,673,472,17
+Sarpy,Precinct 4,Public Defender,,REP,Thomas P. Strigenz,1007,671,325,11
+Sarpy,Precinct 5,Public Defender,,REP,Thomas P. Strigenz,867,503,354,10
+Sarpy,Precinct 6,Public Defender,,REP,Thomas P. Strigenz,998,681,300,17
+Sarpy,Precinct 7,Public Defender,,REP,Thomas P. Strigenz,937,585,330,22
+Sarpy,Precinct 8,Public Defender,,REP,Thomas P. Strigenz,940,611,319,10
+Sarpy,Precinct 9,Public Defender,,REP,Thomas P. Strigenz,977,705,258,14
+Sarpy,Precinct 10,Public Defender,,REP,Thomas P. Strigenz,687,504,169,14
+Sarpy,Precinct 11,Public Defender,,REP,Thomas P. Strigenz,1423,819,589,15
+Sarpy,Precinct 12,Public Defender,,REP,Thomas P. Strigenz,1205,776,414,15
+Sarpy,Precinct 13,Public Defender,,REP,Thomas P. Strigenz,1299,756,525,18
+Sarpy,Precinct 16,Public Defender,,REP,Thomas P. Strigenz,1136,690,441,5
+Sarpy,Precinct 17,Public Defender,,REP,Thomas P. Strigenz,1105,701,396,8
+Sarpy,Precinct 18,Public Defender,,REP,Thomas P. Strigenz,840,561,273,6
+Sarpy,Precinct 19,Public Defender,,REP,Thomas P. Strigenz,1712,745,943,24
+Sarpy,Precinct 20,Public Defender,,REP,Thomas P. Strigenz,1238,776,454,8
+Sarpy,Precinct 21,Public Defender,,REP,Thomas P. Strigenz,1637,862,762,13
+Sarpy,Precinct 22,Public Defender,,REP,Thomas P. Strigenz,1105,717,375,13
+Sarpy,Precinct 23,Public Defender,,REP,Thomas P. Strigenz,1654,847,779,28
+Sarpy,Precinct 24,Public Defender,,REP,Thomas P. Strigenz,828,509,312,7
+Sarpy,Precinct 25,Public Defender,,REP,Thomas P. Strigenz,873,568,283,22
+Sarpy,Precinct 26,Public Defender,,REP,Thomas P. Strigenz,1103,703,385,15
+Sarpy,Precinct 31,Public Defender,,REP,Thomas P. Strigenz,1910,1216,671,23
+Sarpy,Precinct 32,Public Defender,,REP,Thomas P. Strigenz,937,613,315,9
+Sarpy,Precinct 33,Public Defender,,REP,Thomas P. Strigenz,1091,677,394,20
+Sarpy,Precinct 34,Public Defender,,REP,Thomas P. Strigenz,1255,819,426,10
+Sarpy,Precinct 35,Public Defender,,REP,Thomas P. Strigenz,1073,709,360,4
+Sarpy,Precinct 36,Public Defender,,REP,Thomas P. Strigenz,1167,711,449,7
+Sarpy,Precinct 37,Public Defender,,REP,Thomas P. Strigenz,1841,1056,774,11
+Sarpy,Precinct 38,Public Defender,,REP,Thomas P. Strigenz,1191,779,401,11
+Sarpy,Precinct 39,Public Defender,,REP,Thomas P. Strigenz,1267,740,525,2
+Sarpy,Precinct 40,Public Defender,,REP,Thomas P. Strigenz,1175,745,416,14
+Sarpy,Precinct 41,Public Defender,,REP,Thomas P. Strigenz,1468,786,668,14
+Sarpy,Precinct 42,Public Defender,,REP,Thomas P. Strigenz,1237,706,523,8
+Sarpy,Precinct 46,Public Defender,,REP,Thomas P. Strigenz,855,551,303,1
+Sarpy,Precinct 47,Public Defender,,REP,Thomas P. Strigenz,640,493,138,9
+Sarpy,Precinct 48,Public Defender,,REP,Thomas P. Strigenz,1490,744,736,10
+Sarpy,Precinct 49,Public Defender,,REP,Thomas P. Strigenz,1391,750,625,16
+Sarpy,Precinct 51,Public Defender,,REP,Thomas P. Strigenz,1850,1181,657,12
+Sarpy,Precinct 52,Public Defender,,REP,Thomas P. Strigenz,1735,1022,693,20
+Sarpy,Precinct 53,Public Defender,,REP,Thomas P. Strigenz,1461,864,582,15
+Sarpy,Precinct 54,Public Defender,,REP,Thomas P. Strigenz,1430,809,607,14
+Sarpy,Precinct 55,Public Defender,,REP,Thomas P. Strigenz,1685,1103,566,16
+Sarpy,Precinct 56,Public Defender,,REP,Thomas P. Strigenz,1104,723,377,4
+Sarpy,Precinct 57,Public Defender,,REP,Thomas P. Strigenz,984,687,289,8
+Sarpy,Precinct 58,Public Defender,,REP,Thomas P. Strigenz,897,619,269,9
+Sarpy,Precinct 59,Public Defender,,REP,Thomas P. Strigenz,972,675,288,9
+Sarpy,Precinct 60,Public Defender,,REP,Thomas P. Strigenz,919,650,265,4
+Sarpy,Precinct 61,Public Defender,,REP,Thomas P. Strigenz,2155,1266,863,26
+Sarpy,Precinct 62,Public Defender,,REP,Thomas P. Strigenz,1190,750,416,24
+Sarpy,,Public Defender,,,WRITE-IN,1258,748,493,17
+Sarpy,Precinct 1,Public Defender,,,WRITE-IN,39,27,12,0
+Sarpy,Precinct 2,Public Defender,,,WRITE-IN,17,10,7,0
+Sarpy,Precinct 3,Public Defender,,,WRITE-IN,35,21,13,1
+Sarpy,Precinct 4,Public Defender,,,WRITE-IN,26,18,8,0
+Sarpy,Precinct 5,Public Defender,,,WRITE-IN,23,12,10,1
+Sarpy,Precinct 6,Public Defender,,,WRITE-IN,23,16,7,0
+Sarpy,Precinct 7,Public Defender,,,WRITE-IN,24,13,11,0
+Sarpy,Precinct 8,Public Defender,,,WRITE-IN,20,10,10,0
+Sarpy,Precinct 9,Public Defender,,,WRITE-IN,27,21,6,0
+Sarpy,Precinct 10,Public Defender,,,WRITE-IN,29,17,11,1
+Sarpy,Precinct 11,Public Defender,,,WRITE-IN,25,14,11,0
+Sarpy,Precinct 12,Public Defender,,,WRITE-IN,20,15,4,1
+Sarpy,Precinct 13,Public Defender,,,WRITE-IN,22,16,5,1
+Sarpy,Precinct 16,Public Defender,,,WRITE-IN,47,27,20,0
+Sarpy,Precinct 17,Public Defender,,,WRITE-IN,26,18,7,1
+Sarpy,Precinct 18,Public Defender,,,WRITE-IN,26,17,9,0
+Sarpy,Precinct 19,Public Defender,,,WRITE-IN,33,17,14,2
+Sarpy,Precinct 20,Public Defender,,,WRITE-IN,30,17,12,1
+Sarpy,Precinct 21,Public Defender,,,WRITE-IN,28,13,14,1
+Sarpy,Precinct 22,Public Defender,,,WRITE-IN,35,21,14,0
+Sarpy,Precinct 23,Public Defender,,,WRITE-IN,28,12,16,0
+Sarpy,Precinct 24,Public Defender,,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 25,Public Defender,,,WRITE-IN,17,9,7,1
+Sarpy,Precinct 26,Public Defender,,,WRITE-IN,26,15,11,0
+Sarpy,Precinct 31,Public Defender,,,WRITE-IN,33,18,15,0
+Sarpy,Precinct 32,Public Defender,,,WRITE-IN,14,8,6,0
+Sarpy,Precinct 33,Public Defender,,,WRITE-IN,40,27,11,2
+Sarpy,Precinct 34,Public Defender,,,WRITE-IN,25,13,11,1
+Sarpy,Precinct 35,Public Defender,,,WRITE-IN,19,14,5,0
+Sarpy,Precinct 36,Public Defender,,,WRITE-IN,14,9,5,0
+Sarpy,Precinct 37,Public Defender,,,WRITE-IN,33,19,14,0
+Sarpy,Precinct 38,Public Defender,,,WRITE-IN,22,14,8,0
+Sarpy,Precinct 39,Public Defender,,,WRITE-IN,20,13,7,0
+Sarpy,Precinct 40,Public Defender,,,WRITE-IN,26,19,7,0
+Sarpy,Precinct 41,Public Defender,,,WRITE-IN,24,12,12,0
+Sarpy,Precinct 42,Public Defender,,,WRITE-IN,23,7,16,0
+Sarpy,Precinct 46,Public Defender,,,WRITE-IN,8,2,6,0
+Sarpy,Precinct 47,Public Defender,,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 48,Public Defender,,,WRITE-IN,16,8,8,0
+Sarpy,Precinct 49,Public Defender,,,WRITE-IN,26,18,7,1
+Sarpy,Precinct 51,Public Defender,,,WRITE-IN,20,15,5,0
+Sarpy,Precinct 52,Public Defender,,,WRITE-IN,26,13,13,0
+Sarpy,Precinct 53,Public Defender,,,WRITE-IN,33,16,17,0
+Sarpy,Precinct 54,Public Defender,,,WRITE-IN,19,9,8,2
+Sarpy,Precinct 55,Public Defender,,,WRITE-IN,36,25,11,0
+Sarpy,Precinct 56,Public Defender,,,WRITE-IN,32,16,16,0
+Sarpy,Precinct 57,Public Defender,,,WRITE-IN,29,15,14,0
+Sarpy,Precinct 58,Public Defender,,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 59,Public Defender,,,WRITE-IN,13,9,4,0
+Sarpy,Precinct 60,Public Defender,,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 61,Public Defender,,,WRITE-IN,26,15,11,0
+Sarpy,Precinct 62,Public Defender,,,WRITE-IN,18,13,5,0
+Sarpy,,Co Comm,1,REP,Don Kelly,12472,7559,4749,164
+Sarpy,Precinct 2,Co Comm,1,REP,Don Kelly,238,164,69,5
+Sarpy,Precinct 8,Co Comm,1,REP,Don Kelly,952,618,323,11
+Sarpy,Precinct 9,Co Comm,1,REP,Don Kelly,976,705,257,14
+Sarpy,Precinct 10,Co Comm,1,REP,Don Kelly,688,510,164,14
+Sarpy,Precinct 11,Co Comm,1,REP,Don Kelly,1432,833,585,14
+Sarpy,Precinct 12,Co Comm,1,REP,Don Kelly,1212,785,411,16
+Sarpy,Precinct 21,Co Comm,1,REP,Don Kelly,1664,878,773,13
+Sarpy,Precinct 23,Co Comm,1,REP,Don Kelly,1673,857,789,27
+Sarpy,Precinct 24,Co Comm,1,REP,Don Kelly,830,515,308,7
+Sarpy,Precinct 25,Co Comm,1,REP,Don Kelly,863,560,282,21
+Sarpy,Precinct 26,Co Comm,1,REP,Don Kelly,1107,700,390,17
+Sarpy,Precinct 48,Co Comm,1,REP,Don Kelly,837,434,398,5
+Sarpy,,Co Comm,1,,WRITE-IN,281,143,134,4
+Sarpy,Precinct 2,Co Comm,1,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 8,Co Comm,1,,WRITE-IN,23,11,12,0
+Sarpy,Precinct 9,Co Comm,1,,WRITE-IN,18,12,6,0
+Sarpy,Precinct 10,Co Comm,1,,WRITE-IN,26,16,9,1
+Sarpy,Precinct 11,Co Comm,1,,WRITE-IN,27,12,14,1
+Sarpy,Precinct 12,Co Comm,1,,WRITE-IN,35,22,13,0
+Sarpy,Precinct 21,Co Comm,1,,WRITE-IN,33,16,16,1
+Sarpy,Precinct 23,Co Comm,1,,WRITE-IN,28,11,17,0
+Sarpy,Precinct 24,Co Comm,1,,WRITE-IN,21,8,13,0
+Sarpy,Precinct 25,Co Comm,1,,WRITE-IN,19,11,7,1
+Sarpy,Precinct 26,Co Comm,1,,WRITE-IN,27,14,13,0
+Sarpy,Precinct 48,Co Comm,1,,WRITE-IN,16,4,12,0
+Sarpy,,Co Comm,3,REP,Brian Zuger,6692,4452,2165,75
+Sarpy,Precinct 1,Co Comm,3,REP,Brian Zuger,405,289,114,2
+Sarpy,Precinct 2,Co Comm,3,REP,Brian Zuger,351,263,85,3
+Sarpy,Precinct 3,Co Comm,3,REP,Brian Zuger,751,461,278,12
+Sarpy,Precinct 4,Co Comm,3,REP,Brian Zuger,639,425,206,8
+Sarpy,Precinct 5,Co Comm,3,REP,Brian Zuger,531,324,204,3
+Sarpy,Precinct 6,Co Comm,3,REP,Brian Zuger,571,403,160,8
+Sarpy,Precinct 7,Co Comm,3,REP,Brian Zuger,607,407,186,14
+Sarpy,Precinct 13,Co Comm,3,REP,Brian Zuger,872,528,331,13
+Sarpy,Precinct 18,Co Comm,3,REP,Brian Zuger,489,348,139,2
+Sarpy,Precinct 20,Co Comm,3,REP,Brian Zuger,768,527,240,1
+Sarpy,Precinct 22,Co Comm,3,REP,Brian Zuger,708,477,222,9
+Sarpy,,Co Comm,3,DEM,Tom Richards,6430,3646,2705,79
+Sarpy,Precinct 1,Co Comm,3,DEM,Tom Richards,520,337,175,8
+Sarpy,Precinct 2,Co Comm,3,DEM,Tom Richards,294,203,89,2
+Sarpy,Precinct 3,Co Comm,3,DEM,Tom Richards,651,343,303,5
+Sarpy,Precinct 4,Co Comm,3,DEM,Tom Richards,599,376,219,4
+Sarpy,Precinct 5,Co Comm,3,DEM,Tom Richards,477,236,233,8
+Sarpy,Precinct 6,Co Comm,3,DEM,Tom Richards,678,426,239,13
+Sarpy,Precinct 7,Co Comm,3,DEM,Tom Richards,535,295,228,12
+Sarpy,Precinct 13,Co Comm,3,DEM,Tom Richards,718,369,342,7
+Sarpy,Precinct 18,Co Comm,3,DEM,Tom Richards,593,351,238,4
+Sarpy,Precinct 20,Co Comm,3,DEM,Tom Richards,733,369,355,9
+Sarpy,Precinct 22,Co Comm,3,DEM,Tom Richards,632,341,284,7
+Sarpy,,Co Comm,3,,WRITE-IN,40,27,13,0
+Sarpy,Precinct 1,Co Comm,3,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 2,Co Comm,3,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 3,Co Comm,3,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 4,Co Comm,3,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 5,Co Comm,3,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 6,Co Comm,3,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 7,Co Comm,3,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 13,Co Comm,3,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 18,Co Comm,3,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 20,Co Comm,3,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 22,Co Comm,3,,WRITE-IN,4,2,2,0
+Sarpy,,Co Comm,4,REP,Gary F. Mixan,12755,7485,5164,106
+Sarpy,Precinct 16,Co Comm,4,REP,Gary F. Mixan,1180,705,470,5
+Sarpy,Precinct 17,Co Comm,4,REP,Gary F. Mixan,1154,739,408,7
+Sarpy,Precinct 19,Co Comm,4,REP,Gary F. Mixan,1727,764,939,24
+Sarpy,Precinct 34,Co Comm,4,REP,Gary F. Mixan,1224,802,411,11
+Sarpy,Precinct 35,Co Comm,4,REP,Gary F. Mixan,1056,703,349,4
+Sarpy,Precinct 37,Co Comm,4,REP,Gary F. Mixan,1856,1061,782,13
+Sarpy,Precinct 38,Co Comm,4,REP,Gary F. Mixan,1173,765,397,11
+Sarpy,Precinct 40,Co Comm,4,REP,Gary F. Mixan,706,465,231,10
+Sarpy,Precinct 41,Co Comm,4,REP,Gary F. Mixan,1467,789,664,14
+Sarpy,Precinct 42,Co Comm,4,REP,Gary F. Mixan,1212,692,513,7
+Sarpy,,Co Comm,4,,WRITE-IN,282,146,132,4
+Sarpy,Precinct 16,Co Comm,4,,WRITE-IN,40,23,17,0
+Sarpy,Precinct 17,Co Comm,4,,WRITE-IN,24,13,10,1
+Sarpy,Precinct 19,Co Comm,4,,WRITE-IN,43,19,22,2
+Sarpy,Precinct 34,Co Comm,4,,WRITE-IN,31,14,17,0
+Sarpy,Precinct 35,Co Comm,4,,WRITE-IN,19,13,6,0
+Sarpy,Precinct 37,Co Comm,4,,WRITE-IN,32,20,12,0
+Sarpy,Precinct 38,Co Comm,4,,WRITE-IN,22,13,9,0
+Sarpy,Precinct 40,Co Comm,4,,WRITE-IN,18,10,7,1
+Sarpy,Precinct 41,Co Comm,4,,WRITE-IN,26,12,14,0
+Sarpy,Precinct 42,Co Comm,4,,WRITE-IN,27,9,18,0
+Sarpy,,Sarpy County Consolidation,,,Yes,61648,36320,24748,580
+Sarpy,Precinct 1,Sarpy County Consolidation,,,Yes,749,508,235,6
+Sarpy,Precinct 2,Sarpy County Consolidation,,,Yes,764,528,226,10
+Sarpy,Precinct 3,Sarpy County Consolidation,,,Yes,1148,655,477,16
+Sarpy,Precinct 4,Sarpy County Consolidation,,,Yes,1034,667,358,9
+Sarpy,Precinct 5,Sarpy County Consolidation,,,Yes,842,459,375,8
+Sarpy,Precinct 6,Sarpy County Consolidation,,,Yes,1014,663,334,17
+Sarpy,Precinct 7,Sarpy County Consolidation,,,Yes,933,583,335,15
+Sarpy,Precinct 8,Sarpy County Consolidation,,,Yes,944,586,349,9
+Sarpy,Precinct 9,Sarpy County Consolidation,,,Yes,894,637,247,10
+Sarpy,Precinct 10,Sarpy County Consolidation,,,Yes,649,465,170,14
+Sarpy,Precinct 11,Sarpy County Consolidation,,,Yes,1400,767,624,9
+Sarpy,Precinct 12,Sarpy County Consolidation,,,Yes,1160,720,427,13
+Sarpy,Precinct 13,Sarpy County Consolidation,,,Yes,1339,727,601,11
+Sarpy,Precinct 16,Sarpy County Consolidation,,,Yes,1126,662,456,8
+Sarpy,Precinct 17,Sarpy County Consolidation,,,Yes,1066,643,410,13
+Sarpy,Precinct 18,Sarpy County Consolidation,,,Yes,827,520,304,3
+Sarpy,Precinct 19,Sarpy County Consolidation,,,Yes,1716,724,972,20
+Sarpy,Precinct 20,Sarpy County Consolidation,,,Yes,1217,730,479,8
+Sarpy,Precinct 21,Sarpy County Consolidation,,,Yes,1676,829,833,14
+Sarpy,Precinct 22,Sarpy County Consolidation,,,Yes,1083,665,406,12
+Sarpy,Precinct 23,Sarpy County Consolidation,,,Yes,1590,768,797,25
+Sarpy,Precinct 24,Sarpy County Consolidation,,,Yes,787,456,326,5
+Sarpy,Precinct 25,Sarpy County Consolidation,,,Yes,784,499,271,14
+Sarpy,Precinct 26,Sarpy County Consolidation,,,Yes,1059,633,411,15
+Sarpy,Precinct 31,Sarpy County Consolidation,,,Yes,1990,1234,738,18
+Sarpy,Precinct 32,Sarpy County Consolidation,,,Yes,914,565,342,7
+Sarpy,Precinct 33,Sarpy County Consolidation,,,Yes,1103,671,421,11
+Sarpy,Precinct 34,Sarpy County Consolidation,,,Yes,1184,745,429,10
+Sarpy,Precinct 35,Sarpy County Consolidation,,,Yes,1075,693,378,4
+Sarpy,Precinct 36,Sarpy County Consolidation,,,Yes,1166,673,487,6
+Sarpy,Precinct 37,Sarpy County Consolidation,,,Yes,1828,990,823,15
+Sarpy,Precinct 38,Sarpy County Consolidation,,,Yes,1128,713,408,7
+Sarpy,Precinct 39,Sarpy County Consolidation,,,Yes,1251,696,553,2
+Sarpy,Precinct 40,Sarpy County Consolidation,,,Yes,1100,673,410,17
+Sarpy,Precinct 41,Sarpy County Consolidation,,,Yes,1473,769,691,13
+Sarpy,Precinct 42,Sarpy County Consolidation,,,Yes,1194,636,549,9
+Sarpy,Precinct 46,Sarpy County Consolidation,,,Yes,856,522,333,1
+Sarpy,Precinct 47,Sarpy County Consolidation,,,Yes,616,471,139,6
+Sarpy,Precinct 48,Sarpy County Consolidation,,,Yes,1452,694,749,9
+Sarpy,Precinct 49,Sarpy County Consolidation,,,Yes,1410,742,651,17
+Sarpy,Precinct 51,Sarpy County Consolidation,,,Yes,1820,1129,679,12
+Sarpy,Precinct 52,Sarpy County Consolidation,,,Yes,1797,995,784,18
+Sarpy,Precinct 53,Sarpy County Consolidation,,,Yes,1440,800,623,17
+Sarpy,Precinct 54,Sarpy County Consolidation,,,Yes,1385,738,634,13
+Sarpy,Precinct 55,Sarpy County Consolidation,,,Yes,1661,1041,604,16
+Sarpy,Precinct 56,Sarpy County Consolidation,,,Yes,1083,675,405,3
+Sarpy,Precinct 57,Sarpy County Consolidation,,,Yes,982,654,321,7
+Sarpy,Precinct 58,Sarpy County Consolidation,,,Yes,877,601,269,7
+Sarpy,Precinct 59,Sarpy County Consolidation,,,Yes,956,654,295,7
+Sarpy,Precinct 60,Sarpy County Consolidation,,,Yes,867,598,266,3
+Sarpy,Precinct 61,Sarpy County Consolidation,,,Yes,2160,1204,933,23
+Sarpy,Precinct 62,Sarpy County Consolidation,,,Yes,1079,650,411,18
+Sarpy,,Sarpy County Consolidation,,,No,10608,6824,3627,157
+Sarpy,Precinct 1,Sarpy County Consolidation,,,No,166,115,47,4
+Sarpy,Precinct 2,Sarpy County Consolidation,,,No,131,104,25,2
+Sarpy,Precinct 3,Sarpy County Consolidation,,,No,220,126,92,2
+Sarpy,Precinct 4,Sarpy County Consolidation,,,No,182,126,52,4
+Sarpy,Precinct 5,Sarpy County Consolidation,,,No,166,105,58,3
+Sarpy,Precinct 6,Sarpy County Consolidation,,,No,211,146,63,2
+Sarpy,Precinct 7,Sarpy County Consolidation,,,No,198,113,76,9
+Sarpy,Precinct 8,Sarpy County Consolidation,,,No,140,95,42,3
+Sarpy,Precinct 9,Sarpy County Consolidation,,,No,227,155,67,5
+Sarpy,Precinct 10,Sarpy County Consolidation,,,No,171,125,41,5
+Sarpy,Precinct 11,Sarpy County Consolidation,,,No,204,139,60,5
+Sarpy,Precinct 12,Sarpy County Consolidation,,,No,232,149,79,4
+Sarpy,Precinct 13,Sarpy County Consolidation,,,No,181,114,60,7
+Sarpy,Precinct 16,Sarpy County Consolidation,,,No,235,147,88,0
+Sarpy,Precinct 17,Sarpy County Consolidation,,,No,249,160,88,1
+Sarpy,Precinct 18,Sarpy County Consolidation,,,No,219,148,69,2
+Sarpy,Precinct 19,Sarpy County Consolidation,,,No,248,110,131,7
+Sarpy,Precinct 20,Sarpy County Consolidation,,,No,219,120,97,2
+Sarpy,Precinct 21,Sarpy County Consolidation,,,No,240,145,93,2
+Sarpy,Precinct 22,Sarpy County Consolidation,,,No,208,138,67,3
+Sarpy,Precinct 23,Sarpy County Consolidation,,,No,229,118,105,6
+Sarpy,Precinct 24,Sarpy County Consolidation,,,No,115,81,33,1
+Sarpy,Precinct 25,Sarpy County Consolidation,,,No,193,119,66,8
+Sarpy,Precinct 26,Sarpy County Consolidation,,,No,185,124,59,2
+Sarpy,Precinct 31,Sarpy County Consolidation,,,No,279,170,100,9
+Sarpy,Precinct 32,Sarpy County Consolidation,,,No,163,107,53,3
+Sarpy,Precinct 33,Sarpy County Consolidation,,,No,191,125,56,10
+Sarpy,Precinct 34,Sarpy County Consolidation,,,No,262,181,76,5
+Sarpy,Precinct 35,Sarpy County Consolidation,,,No,207,136,70,1
+Sarpy,Precinct 36,Sarpy County Consolidation,,,No,160,106,54,0
+Sarpy,Precinct 37,Sarpy County Consolidation,,,No,263,175,86,2
+Sarpy,Precinct 38,Sarpy County Consolidation,,,No,199,135,59,5
+Sarpy,Precinct 39,Sarpy County Consolidation,,,No,218,139,79,0
+Sarpy,Precinct 40,Sarpy County Consolidation,,,No,242,165,77,0
+Sarpy,Precinct 41,Sarpy County Consolidation,,,No,206,107,98,1
+Sarpy,Precinct 42,Sarpy County Consolidation,,,No,221,137,81,3
+Sarpy,Precinct 46,Sarpy County Consolidation,,,No,164,105,59,0
+Sarpy,Precinct 47,Sarpy County Consolidation,,,No,118,88,28,2
+Sarpy,Precinct 48,Sarpy County Consolidation,,,No,198,106,91,1
+Sarpy,Precinct 49,Sarpy County Consolidation,,,No,211,113,98,0
+Sarpy,Precinct 51,Sarpy County Consolidation,,,No,238,163,75,0
+Sarpy,Precinct 52,Sarpy County Consolidation,,,No,236,150,80,6
+Sarpy,Precinct 53,Sarpy County Consolidation,,,No,239,144,93,2
+Sarpy,Precinct 54,Sarpy County Consolidation,,,No,221,143,76,2
+Sarpy,Precinct 55,Sarpy County Consolidation,,,No,280,196,81,3
+Sarpy,Precinct 56,Sarpy County Consolidation,,,No,200,138,61,1
+Sarpy,Precinct 57,Sarpy County Consolidation,,,No,200,140,58,2
+Sarpy,Precinct 58,Sarpy County Consolidation,,,No,114,81,33,0
+Sarpy,Precinct 59,Sarpy County Consolidation,,,No,165,109,55,1
+Sarpy,Precinct 60,Sarpy County Consolidation,,,No,162,116,44,2
+Sarpy,Precinct 61,Sarpy County Consolidation,,,No,248,167,81,0
+Sarpy,Precinct 62,Sarpy County Consolidation,,,No,234,160,67,7
+Sarpy,,Mem of Leg,3,,Tommy Garrett,7476,4433,2974,69
+Sarpy,Precinct 16,Mem of Leg,3,,Tommy Garrett,592,366,222,4
+Sarpy,Precinct 17,Mem of Leg,3,,Tommy Garrett,580,364,210,6
+Sarpy,Precinct 18,Mem of Leg,3,,Tommy Garrett,470,322,145,3
+Sarpy,Precinct 19,Mem of Leg,3,,Tommy Garrett,939,418,512,9
+Sarpy,Precinct 20,Mem of Leg,3,,Tommy Garrett,665,445,216,4
+Sarpy,Precinct 21,Mem of Leg,3,,Tommy Garrett,1039,557,478,4
+Sarpy,Precinct 22,Mem of Leg,3,,Tommy Garrett,617,394,216,7
+Sarpy,Precinct 23,Mem of Leg,3,,Tommy Garrett,892,470,407,15
+Sarpy,Precinct 24,Mem of Leg,3,,Tommy Garrett,512,333,177,2
+Sarpy,Precinct 25,Mem of Leg,3,,Tommy Garrett,487,329,148,10
+Sarpy,Precinct 26,Mem of Leg,3,,Tommy Garrett,683,435,243,5
+Sarpy,,Mem of Leg,3,,Carol Blood,7959,4236,3625,98
+Sarpy,Precinct 16,Mem of Leg,3,,Carol Blood,805,456,346,3
+Sarpy,Precinct 17,Mem of Leg,3,,Carol Blood,767,460,301,6
+Sarpy,Precinct 18,Mem of Leg,3,,Carol Blood,620,376,242,2
+Sarpy,Precinct 19,Mem of Leg,3,,Carol Blood,1027,416,592,19
+Sarpy,Precinct 20,Mem of Leg,3,,Carol Blood,788,414,368,6
+Sarpy,Precinct 21,Mem of Leg,3,,Carol Blood,898,439,447,12
+Sarpy,Precinct 22,Mem of Leg,3,,Carol Blood,688,412,269,7
+Sarpy,Precinct 23,Mem of Leg,3,,Carol Blood,883,396,471,16
+Sarpy,Precinct 24,Mem of Leg,3,,Carol Blood,413,233,175,5
+Sarpy,Precinct 25,Mem of Leg,3,,Carol Blood,489,293,184,12
+Sarpy,Precinct 26,Mem of Leg,3,,Carol Blood,581,341,230,10
+Sarpy,,Mem of Leg,3,,WRITE-IN,53,31,19,3
+Sarpy,Precinct 16,Mem of Leg,3,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 17,Mem of Leg,3,,WRITE-IN,9,7,1,1
+Sarpy,Precinct 18,Mem of Leg,3,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 19,Mem of Leg,3,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 20,Mem of Leg,3,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 21,Mem of Leg,3,,WRITE-IN,8,5,2,1
+Sarpy,Precinct 22,Mem of Leg,3,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 23,Mem of Leg,3,,WRITE-IN,6,3,2,1
+Sarpy,Precinct 24,Mem of Leg,3,,WRITE-IN,4,1,3,0
+Sarpy,Precinct 25,Mem of Leg,3,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 26,Mem of Leg,3,,WRITE-IN,5,2,3,0
+Sarpy,,Mem of Leg,45,,Sue Crawford,8774,5301,3343,130
+Sarpy,Precinct 1,Mem of Leg,45,,Sue Crawford,584,390,187,7
+Sarpy,Precinct 2,Mem of Leg,45,,Sue Crawford,502,353,141,8
+Sarpy,Precinct 3,Mem of Leg,45,,Sue Crawford,846,477,357,12
+Sarpy,Precinct 4,Mem of Leg,45,,Sue Crawford,721,461,250,10
+Sarpy,Precinct 5,Mem of Leg,45,,Sue Crawford,620,321,292,7
+Sarpy,Precinct 6,Mem of Leg,45,,Sue Crawford,722,464,243,15
+Sarpy,Precinct 7,Mem of Leg,45,,Sue Crawford,664,404,248,12
+Sarpy,Precinct 8,Mem of Leg,45,,Sue Crawford,605,371,231,3
+Sarpy,Precinct 9,Mem of Leg,45,,Sue Crawford,687,477,199,11
+Sarpy,Precinct 10,Mem of Leg,45,,Sue Crawford,452,316,128,8
+Sarpy,Precinct 11,Mem of Leg,45,,Sue Crawford,813,428,374,11
+Sarpy,Precinct 12,Mem of Leg,45,,Sue Crawford,698,407,281,10
+Sarpy,Precinct 13,Mem of Leg,45,,Sue Crawford,860,432,412,16
+Sarpy,,Mem of Leg,45,,Michael J. Cook,6734,4437,2230,67
+Sarpy,Precinct 1,Mem of Leg,45,,Michael J. Cook,329,230,96,3
+Sarpy,Precinct 2,Mem of Leg,45,,Michael J. Cook,425,302,121,2
+Sarpy,Precinct 3,Mem of Leg,45,,Michael J. Cook,536,311,220,5
+Sarpy,Precinct 4,Mem of Leg,45,,Michael J. Cook,509,338,168,3
+Sarpy,Precinct 5,Mem of Leg,45,,Michael J. Cook,388,244,140,4
+Sarpy,Precinct 6,Mem of Leg,45,,Michael J. Cook,510,355,150,5
+Sarpy,Precinct 7,Mem of Leg,45,,Michael J. Cook,479,301,168,10
+Sarpy,Precinct 8,Mem of Leg,45,,Michael J. Cook,486,321,157,8
+Sarpy,Precinct 9,Mem of Leg,45,,Michael J. Cook,436,321,111,4
+Sarpy,Precinct 10,Mem of Leg,45,,Michael J. Cook,369,283,76,10
+Sarpy,Precinct 11,Mem of Leg,45,,Michael J. Cook,825,489,334,2
+Sarpy,Precinct 12,Mem of Leg,45,,Michael J. Cook,724,493,223,8
+Sarpy,Precinct 13,Mem of Leg,45,,Michael J. Cook,718,449,266,3
+Sarpy,,Mem of Leg,45,,WRITE-IN,49,37,10,2
+Sarpy,Precinct 1,Mem of Leg,45,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 2,Mem of Leg,45,,WRITE-IN,2,2,0,0
+Sarpy,Precinct 3,Mem of Leg,45,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 4,Mem of Leg,45,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 5,Mem of Leg,45,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 6,Mem of Leg,45,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 7,Mem of Leg,45,,WRITE-IN,4,3,0,1
+Sarpy,Precinct 8,Mem of Leg,45,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 9,Mem of Leg,45,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 10,Mem of Leg,45,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 11,Mem of Leg,45,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 12,Mem of Leg,45,,WRITE-IN,2,2,0,0
+Sarpy,Precinct 13,Mem of Leg,45,,WRITE-IN,1,0,0,1
+Sarpy,,Mem of Leg,49,,John Murante,15137,9502,5490,145
+Sarpy,Precinct 51,Mem of Leg,49,,John Murante,1709,1093,604,12
+Sarpy,Precinct 52,Mem of Leg,49,,John Murante,1616,932,666,18
+Sarpy,Precinct 53,Mem of Leg,49,,John Murante,1343,780,548,15
+Sarpy,Precinct 54,Mem of Leg,49,,John Murante,1331,746,572,13
+Sarpy,Precinct 55,Mem of Leg,49,,John Murante,1546,1003,526,17
+Sarpy,Precinct 56,Mem of Leg,49,,John Murante,1021,654,363,4
+Sarpy,Precinct 57,Mem of Leg,49,,John Murante,903,617,278,8
+Sarpy,Precinct 58,Mem of Leg,49,,John Murante,837,585,246,6
+Sarpy,Precinct 59,Mem of Leg,49,,John Murante,923,647,269,7
+Sarpy,Precinct 60,Mem of Leg,49,,John Murante,872,624,244,4
+Sarpy,Precinct 61,Mem of Leg,49,,John Murante,1956,1146,789,21
+Sarpy,Precinct 62,Mem of Leg,49,,John Murante,1080,675,385,20
+Sarpy,,Mem of Leg,49,,WRITE-IN,296,178,117,1
+Sarpy,Precinct 51,Mem of Leg,49,,WRITE-IN,32,21,11,0
+Sarpy,Precinct 52,Mem of Leg,49,,WRITE-IN,31,17,13,1
+Sarpy,Precinct 53,Mem of Leg,49,,WRITE-IN,29,15,14,0
+Sarpy,Precinct 54,Mem of Leg,49,,WRITE-IN,27,13,14,0
+Sarpy,Precinct 55,Mem of Leg,49,,WRITE-IN,35,27,8,0
+Sarpy,Precinct 56,Mem of Leg,49,,WRITE-IN,18,10,8,0
+Sarpy,Precinct 57,Mem of Leg,49,,WRITE-IN,31,19,12,0
+Sarpy,Precinct 58,Mem of Leg,49,,WRITE-IN,13,6,7,0
+Sarpy,Precinct 59,Mem of Leg,49,,WRITE-IN,14,10,4,0
+Sarpy,Precinct 60,Mem of Leg,49,,WRITE-IN,16,6,10,0
+Sarpy,Precinct 61,Mem of Leg,49,,WRITE-IN,38,25,13,0
+Sarpy,Precinct 62,Mem of Leg,49,,WRITE-IN,12,9,3,0
+Sarpy,,State BOE Member,2,,Lisa Fricke,31384,18653,12394,337
+Sarpy,Precinct 2,State BOE Member,2,,Lisa Fricke,180,122,56,2
+Sarpy,Precinct 5,State BOE Member,2,,Lisa Fricke,582,335,244,3
+Sarpy,Precinct 6,State BOE Member,2,,Lisa Fricke,764,509,243,12
+Sarpy,Precinct 7,State BOE Member,2,,Lisa Fricke,439,257,174,8
+Sarpy,Precinct 8,State BOE Member,2,,Lisa Fricke,633,393,234,6
+Sarpy,Precinct 9,State BOE Member,2,,Lisa Fricke,640,462,170,8
+Sarpy,Precinct 10,State BOE Member,2,,Lisa Fricke,515,362,140,13
+Sarpy,Precinct 11,State BOE Member,2,,Lisa Fricke,881,500,374,7
+Sarpy,Precinct 12,State BOE Member,2,,Lisa Fricke,793,499,284,10
+Sarpy,Precinct 19,State BOE Member,2,,Lisa Fricke,679,279,385,15
+Sarpy,Precinct 20,State BOE Member,2,,Lisa Fricke,311,170,139,2
+Sarpy,Precinct 21,State BOE Member,2,,Lisa Fricke,966,497,464,5
+Sarpy,Precinct 22,State BOE Member,2,,Lisa Fricke,805,491,303,11
+Sarpy,Precinct 23,State BOE Member,2,,Lisa Fricke,950,426,505,19
+Sarpy,Precinct 24,State BOE Member,2,,Lisa Fricke,524,307,211,6
+Sarpy,Precinct 25,State BOE Member,2,,Lisa Fricke,542,326,206,10
+Sarpy,Precinct 26,State BOE Member,2,,Lisa Fricke,739,452,276,11
+Sarpy,Precinct 31,State BOE Member,2,,Lisa Fricke,1271,800,456,15
+Sarpy,Precinct 32,State BOE Member,2,,Lisa Fricke,698,436,255,7
+Sarpy,Precinct 33,State BOE Member,2,,Lisa Fricke,822,508,299,15
+Sarpy,Precinct 36,State BOE Member,2,,Lisa Fricke,788,471,314,3
+Sarpy,Precinct 39,State BOE Member,2,,Lisa Fricke,859,504,353,2
+Sarpy,Precinct 40,State BOE Member,2,,Lisa Fricke,852,547,298,7
+Sarpy,Precinct 41,State BOE Member,2,,Lisa Fricke,960,487,466,7
+Sarpy,Precinct 42,State BOE Member,2,,Lisa Fricke,877,483,388,6
+Sarpy,Precinct 46,State BOE Member,2,,Lisa Fricke,510,297,212,1
+Sarpy,Precinct 47,State BOE Member,2,,Lisa Fricke,398,298,95,5
+Sarpy,Precinct 48,State BOE Member,2,,Lisa Fricke,811,394,412,5
+Sarpy,Precinct 49,State BOE Member,2,,Lisa Fricke,992,541,441,10
+Sarpy,Precinct 51,State BOE Member,2,,Lisa Fricke,1117,716,392,9
+Sarpy,Precinct 52,State BOE Member,2,,Lisa Fricke,1122,627,474,21
+Sarpy,Precinct 53,State BOE Member,2,,Lisa Fricke,990,560,420,10
+Sarpy,Precinct 54,State BOE Member,2,,Lisa Fricke,966,542,415,9
+Sarpy,Precinct 55,State BOE Member,2,,Lisa Fricke,1091,683,394,14
+Sarpy,Precinct 56,State BOE Member,2,,Lisa Fricke,783,483,297,3
+Sarpy,Precinct 57,State BOE Member,2,,Lisa Fricke,703,469,232,2
+Sarpy,Precinct 58,State BOE Member,2,,Lisa Fricke,540,393,144,3
+Sarpy,Precinct 59,State BOE Member,2,,Lisa Fricke,605,426,176,3
+Sarpy,Precinct 60,State BOE Member,2,,Lisa Fricke,619,425,194,0
+Sarpy,Precinct 61,State BOE Member,2,,Lisa Fricke,1297,717,565,15
+Sarpy,Precinct 62,State BOE Member,2,,Lisa Fricke,770,459,294,17
+Sarpy,,State BOE Member,2,,Glen A. Flint,17111,10155,6779,177
+Sarpy,Precinct 2,State BOE Member,2,,Glen A. Flint,80,55,23,2
+Sarpy,Precinct 5,State BOE Member,2,,Glen A. Flint,327,184,135,8
+Sarpy,Precinct 6,State BOE Member,2,,Glen A. Flint,343,228,109,6
+Sarpy,Precinct 7,State BOE Member,2,,Glen A. Flint,245,156,85,4
+Sarpy,Precinct 8,State BOE Member,2,,Glen A. Flint,327,207,116,4
+Sarpy,Precinct 9,State BOE Member,2,,Glen A. Flint,397,279,112,6
+Sarpy,Precinct 10,State BOE Member,2,,Glen A. Flint,235,178,53,4
+Sarpy,Precinct 11,State BOE Member,2,,Glen A. Flint,591,313,273,5
+Sarpy,Precinct 12,State BOE Member,2,,Glen A. Flint,457,281,170,6
+Sarpy,Precinct 19,State BOE Member,2,,Glen A. Flint,474,190,277,7
+Sarpy,Precinct 20,State BOE Member,2,,Glen A. Flint,116,71,45,0
+Sarpy,Precinct 21,State BOE Member,2,,Glen A. Flint,720,362,348,10
+Sarpy,Precinct 22,State BOE Member,2,,Glen A. Flint,373,229,142,2
+Sarpy,Precinct 23,State BOE Member,2,,Glen A. Flint,640,341,293,6
+Sarpy,Precinct 24,State BOE Member,2,,Glen A. Flint,276,165,110,1
+Sarpy,Precinct 25,State BOE Member,2,,Glen A. Flint,352,232,109,11
+Sarpy,Precinct 26,State BOE Member,2,,Glen A. Flint,393,239,150,4
+Sarpy,Precinct 31,State BOE Member,2,,Glen A. Flint,669,419,244,6
+Sarpy,Precinct 32,State BOE Member,2,,Glen A. Flint,288,183,102,3
+Sarpy,Precinct 33,State BOE Member,2,,Glen A. Flint,324,192,127,5
+Sarpy,Precinct 36,State BOE Member,2,,Glen A. Flint,361,195,164,2
+Sarpy,Precinct 39,State BOE Member,2,,Glen A. Flint,466,257,209,0
+Sarpy,Precinct 40,State BOE Member,2,,Glen A. Flint,366,214,146,6
+Sarpy,Precinct 41,State BOE Member,2,,Glen A. Flint,513,287,222,4
+Sarpy,Precinct 42,State BOE Member,2,,Glen A. Flint,412,227,181,4
+Sarpy,Precinct 46,State BOE Member,2,,Glen A. Flint,344,224,120,0
+Sarpy,Precinct 47,State BOE Member,2,,Glen A. Flint,268,212,55,1
+Sarpy,Precinct 48,State BOE Member,2,,Glen A. Flint,662,337,321,4
+Sarpy,Precinct 49,State BOE Member,2,,Glen A. Flint,441,227,209,5
+Sarpy,Precinct 51,State BOE Member,2,,Glen A. Flint,652,388,261,3
+Sarpy,Precinct 52,State BOE Member,2,,Glen A. Flint,624,360,260,4
+Sarpy,Precinct 53,State BOE Member,2,,Glen A. Flint,512,283,222,7
+Sarpy,Precinct 54,State BOE Member,2,,Glen A. Flint,459,256,199,4
+Sarpy,Precinct 55,State BOE Member,2,,Glen A. Flint,610,398,208,4
+Sarpy,Precinct 56,State BOE Member,2,,Glen A. Flint,345,226,119,0
+Sarpy,Precinct 57,State BOE Member,2,,Glen A. Flint,332,225,101,6
+Sarpy,Precinct 58,State BOE Member,2,,Glen A. Flint,279,166,110,3
+Sarpy,Precinct 59,State BOE Member,2,,Glen A. Flint,365,240,121,4
+Sarpy,Precinct 60,State BOE Member,2,,Glen A. Flint,313,219,90,4
+Sarpy,Precinct 61,State BOE Member,2,,Glen A. Flint,755,447,300,8
+Sarpy,Precinct 62,State BOE Member,2,,Glen A. Flint,405,263,138,4
+Sarpy,,State BOE Member,2,,WRITE-IN,261,176,80,5
+Sarpy,Precinct 2,State BOE Member,2,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 5,State BOE Member,2,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 6,State BOE Member,2,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 7,State BOE Member,2,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 8,State BOE Member,2,,WRITE-IN,7,5,1,1
+Sarpy,Precinct 9,State BOE Member,2,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 10,State BOE Member,2,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 11,State BOE Member,2,,WRITE-IN,7,7,0,0
+Sarpy,Precinct 12,State BOE Member,2,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 19,State BOE Member,2,,WRITE-IN,5,2,3,0
+Sarpy,Precinct 20,State BOE Member,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 21,State BOE Member,2,,WRITE-IN,12,7,4,1
+Sarpy,Precinct 22,State BOE Member,2,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 23,State BOE Member,2,,WRITE-IN,7,3,3,1
+Sarpy,Precinct 24,State BOE Member,2,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 25,State BOE Member,2,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 26,State BOE Member,2,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 31,State BOE Member,2,,WRITE-IN,11,8,3,0
+Sarpy,Precinct 32,State BOE Member,2,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 33,State BOE Member,2,,WRITE-IN,9,6,3,0
+Sarpy,Precinct 36,State BOE Member,2,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 39,State BOE Member,2,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 40,State BOE Member,2,,WRITE-IN,13,11,2,0
+Sarpy,Precinct 41,State BOE Member,2,,WRITE-IN,5,2,3,0
+Sarpy,Precinct 42,State BOE Member,2,,WRITE-IN,5,0,5,0
+Sarpy,Precinct 46,State BOE Member,2,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 47,State BOE Member,2,,WRITE-IN,1,0,0,1
+Sarpy,Precinct 48,State BOE Member,2,,WRITE-IN,4,1,3,0
+Sarpy,Precinct 49,State BOE Member,2,,WRITE-IN,8,6,1,1
+Sarpy,Precinct 51,State BOE Member,2,,WRITE-IN,9,5,4,0
+Sarpy,Precinct 52,State BOE Member,2,,WRITE-IN,8,8,0,0
+Sarpy,Precinct 53,State BOE Member,2,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 54,State BOE Member,2,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 55,State BOE Member,2,,WRITE-IN,12,8,4,0
+Sarpy,Precinct 56,State BOE Member,2,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 57,State BOE Member,2,,WRITE-IN,8,5,3,0
+Sarpy,Precinct 58,State BOE Member,2,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 59,State BOE Member,2,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 60,State BOE Member,2,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 61,State BOE Member,2,,WRITE-IN,10,4,6,0
+Sarpy,Precinct 62,State BOE Member,2,,WRITE-IN,8,7,1,0
+Sarpy,,State BOE Member,4,,John Witzel,14134,8747,5251,136
+Sarpy,Precinct 1,State BOE Member,4,,John Witzel,738,500,229,9
+Sarpy,Precinct 2,State BOE Member,4,,John Witzel,485,359,121,5
+Sarpy,Precinct 3,State BOE Member,4,,John Witzel,1113,636,459,18
+Sarpy,Precinct 4,State BOE Member,4,,John Witzel,952,629,313,10
+Sarpy,Precinct 7,State BOE Member,4,,John Witzel,303,192,105,6
+Sarpy,Precinct 13,State BOE Member,4,,John Witzel,1172,668,485,19
+Sarpy,Precinct 16,State BOE Member,4,,John Witzel,1067,636,425,6
+Sarpy,Precinct 17,State BOE Member,4,,John Witzel,1067,674,385,8
+Sarpy,Precinct 18,State BOE Member,4,,John Witzel,844,556,283,5
+Sarpy,Precinct 19,State BOE Member,4,,John Witzel,511,232,276,3
+Sarpy,Precinct 20,State BOE Member,4,,John Witzel,818,519,291,8
+Sarpy,Precinct 34,State BOE Member,4,,John Witzel,1212,784,418,10
+Sarpy,Precinct 35,State BOE Member,4,,John Witzel,1012,658,350,4
+Sarpy,Precinct 37,State BOE Member,4,,John Witzel,1732,992,724,16
+Sarpy,Precinct 38,State BOE Member,4,,John Witzel,1108,712,387,9
+Sarpy,,State BOE Member,4,,WRITE-IN,265,165,95,5
+Sarpy,Precinct 1,State BOE Member,4,,WRITE-IN,24,16,8,0
+Sarpy,Precinct 2,State BOE Member,4,,WRITE-IN,9,8,1,0
+Sarpy,Precinct 3,State BOE Member,4,,WRITE-IN,15,8,7,0
+Sarpy,Precinct 4,State BOE Member,4,,WRITE-IN,24,16,8,0
+Sarpy,Precinct 7,State BOE Member,4,,WRITE-IN,5,3,0,2
+Sarpy,Precinct 13,State BOE Member,4,,WRITE-IN,15,12,3,0
+Sarpy,Precinct 16,State BOE Member,4,,WRITE-IN,28,16,12,0
+Sarpy,Precinct 17,State BOE Member,4,,WRITE-IN,27,16,9,2
+Sarpy,Precinct 18,State BOE Member,4,,WRITE-IN,21,12,9,0
+Sarpy,Precinct 19,State BOE Member,4,,WRITE-IN,14,9,5,0
+Sarpy,Precinct 20,State BOE Member,4,,WRITE-IN,16,7,9,0
+Sarpy,Precinct 34,State BOE Member,4,,WRITE-IN,16,7,8,1
+Sarpy,Precinct 35,State BOE Member,4,,WRITE-IN,15,11,4,0
+Sarpy,Precinct 37,State BOE Member,4,,WRITE-IN,22,14,8,0
+Sarpy,Precinct 38,State BOE Member,4,,WRITE-IN,14,10,4,0
+Sarpy,,Retain Michael G. Heavican,,,Yes,47256,28173,18574,509
+Sarpy,Precinct 1,Retain Michael G. Heavican,,,Yes,591,402,184,5
+Sarpy,Precinct 2,Retain Michael G. Heavican,,,Yes,592,424,160,8
+Sarpy,Precinct 3,Retain Michael G. Heavican,,,Yes,892,492,388,12
+Sarpy,Precinct 4,Retain Michael G. Heavican,,,Yes,787,522,257,8
+Sarpy,Precinct 5,Retain Michael G. Heavican,,,Yes,684,385,289,10
+Sarpy,Precinct 6,Retain Michael G. Heavican,,,Yes,800,534,252,14
+Sarpy,Precinct 7,Retain Michael G. Heavican,,,Yes,715,426,272,17
+Sarpy,Precinct 8,Retain Michael G. Heavican,,,Yes,711,454,248,9
+Sarpy,Precinct 9,Retain Michael G. Heavican,,,Yes,727,508,210,9
+Sarpy,Precinct 10,Retain Michael G. Heavican,,,Yes,517,370,133,14
+Sarpy,Precinct 11,Retain Michael G. Heavican,,,Yes,1080,582,486,12
+Sarpy,Precinct 12,Retain Michael G. Heavican,,,Yes,882,561,304,17
+Sarpy,Precinct 13,Retain Michael G. Heavican,,,Yes,1007,533,458,16
+Sarpy,Precinct 16,Retain Michael G. Heavican,,,Yes,841,490,347,4
+Sarpy,Precinct 17,Retain Michael G. Heavican,,,Yes,812,488,318,6
+Sarpy,Precinct 18,Retain Michael G. Heavican,,,Yes,653,426,225,2
+Sarpy,Precinct 19,Retain Michael G. Heavican,,,Yes,1324,570,737,17
+Sarpy,Precinct 20,Retain Michael G. Heavican,,,Yes,946,569,369,8
+Sarpy,Precinct 21,Retain Michael G. Heavican,,,Yes,1279,663,607,9
+Sarpy,Precinct 22,Retain Michael G. Heavican,,,Yes,842,537,297,8
+Sarpy,Precinct 23,Retain Michael G. Heavican,,,Yes,1256,626,611,19
+Sarpy,Precinct 24,Retain Michael G. Heavican,,,Yes,571,340,224,7
+Sarpy,Precinct 25,Retain Michael G. Heavican,,,Yes,672,412,244,16
+Sarpy,Precinct 26,Retain Michael G. Heavican,,,Yes,843,525,309,9
+Sarpy,Precinct 31,Retain Michael G. Heavican,,,Yes,1469,932,521,16
+Sarpy,Precinct 32,Retain Michael G. Heavican,,,Yes,691,438,244,9
+Sarpy,Precinct 33,Retain Michael G. Heavican,,,Yes,864,524,326,14
+Sarpy,Precinct 34,Retain Michael G. Heavican,,,Yes,1000,630,361,9
+Sarpy,Precinct 35,Retain Michael G. Heavican,,,Yes,826,518,303,5
+Sarpy,Precinct 36,Retain Michael G. Heavican,,,Yes,912,529,379,4
+Sarpy,Precinct 37,Retain Michael G. Heavican,,,Yes,1425,807,605,13
+Sarpy,Precinct 38,Retain Michael G. Heavican,,,Yes,918,577,333,8
+Sarpy,Precinct 39,Retain Michael G. Heavican,,,Yes,980,549,430,1
+Sarpy,Precinct 40,Retain Michael G. Heavican,,,Yes,875,536,330,9
+Sarpy,Precinct 41,Retain Michael G. Heavican,,,Yes,1148,598,539,11
+Sarpy,Precinct 42,Retain Michael G. Heavican,,,Yes,967,517,440,10
+Sarpy,Precinct 46,Retain Michael G. Heavican,,,Yes,605,375,229,1
+Sarpy,Precinct 47,Retain Michael G. Heavican,,,Yes,441,335,100,6
+Sarpy,Precinct 48,Retain Michael G. Heavican,,,Yes,1056,508,539,9
+Sarpy,Precinct 49,Retain Michael G. Heavican,,,Yes,1109,591,509,9
+Sarpy,Precinct 51,Retain Michael G. Heavican,,,Yes,1364,863,490,11
+Sarpy,Precinct 52,Retain Michael G. Heavican,,,Yes,1291,731,546,14
+Sarpy,Precinct 53,Retain Michael G. Heavican,,,Yes,1095,620,460,15
+Sarpy,Precinct 54,Retain Michael G. Heavican,,,Yes,1025,568,449,8
+Sarpy,Precinct 55,Retain Michael G. Heavican,,,Yes,1199,770,418,11
+Sarpy,Precinct 56,Retain Michael G. Heavican,,,Yes,777,502,273,2
+Sarpy,Precinct 57,Retain Michael G. Heavican,,,Yes,717,490,219,8
+Sarpy,Precinct 58,Retain Michael G. Heavican,,,Yes,694,474,213,7
+Sarpy,Precinct 59,Retain Michael G. Heavican,,,Yes,725,494,223,8
+Sarpy,Precinct 60,Retain Michael G. Heavican,,,Yes,659,445,212,2
+Sarpy,Precinct 61,Retain Michael G. Heavican,,,Yes,1556,885,654,17
+Sarpy,Precinct 62,Retain Michael G. Heavican,,,Yes,844,528,300,16
+Sarpy,,Retain Michael G. Heavican,,,No,19104,11905,7018,181
+Sarpy,Precinct 1,Retain Michael G. Heavican,,,No,268,179,84,5
+Sarpy,Precinct 2,Retain Michael G. Heavican,,,No,249,175,73,1
+Sarpy,Precinct 3,Retain Michael G. Heavican,,,No,378,233,139,6
+Sarpy,Precinct 4,Retain Michael G. Heavican,,,No,333,220,110,3
+Sarpy,Precinct 5,Retain Michael G. Heavican,,,No,242,154,87,1
+Sarpy,Precinct 6,Retain Michael G. Heavican,,,No,331,220,105,6
+Sarpy,Precinct 7,Retain Michael G. Heavican,,,No,319,213,101,5
+Sarpy,Precinct 8,Retain Michael G. Heavican,,,No,297,189,107,1
+Sarpy,Precinct 9,Retain Michael G. Heavican,,,No,309,229,75,5
+Sarpy,Precinct 10,Retain Michael G. Heavican,,,No,238,182,53,3
+Sarpy,Precinct 11,Retain Michael G. Heavican,,,No,421,266,153,2
+Sarpy,Precinct 12,Retain Michael G. Heavican,,,No,402,256,146,0
+Sarpy,Precinct 13,Retain Michael G. Heavican,,,No,375,246,127,2
+Sarpy,Precinct 16,Retain Michael G. Heavican,,,No,443,267,173,3
+Sarpy,Precinct 17,Retain Michael G. Heavican,,,No,415,268,140,7
+Sarpy,Precinct 18,Retain Michael G. Heavican,,,No,335,213,118,4
+Sarpy,Precinct 19,Retain Michael G. Heavican,,,No,466,189,271,6
+Sarpy,Precinct 20,Retain Michael G. Heavican,,,No,417,246,169,2
+Sarpy,Precinct 21,Retain Michael G. Heavican,,,No,431,224,201,6
+Sarpy,Precinct 22,Retain Michael G. Heavican,,,No,368,224,138,6
+Sarpy,Precinct 23,Retain Michael G. Heavican,,,No,436,207,219,10
+Sarpy,Precinct 24,Retain Michael G. Heavican,,,No,249,158,90,1
+Sarpy,Precinct 25,Retain Michael G. Heavican,,,No,244,168,71,5
+Sarpy,Precinct 26,Retain Michael G. Heavican,,,No,303,190,107,6
+Sarpy,Precinct 31,Retain Michael G. Heavican,,,No,570,352,209,9
+Sarpy,Precinct 32,Retain Michael G. Heavican,,,No,308,192,115,1
+Sarpy,Precinct 33,Retain Michael G. Heavican,,,No,327,213,109,5
+Sarpy,Precinct 34,Retain Michael G. Heavican,,,No,367,244,118,5
+Sarpy,Precinct 35,Retain Michael G. Heavican,,,No,334,230,103,1
+Sarpy,Precinct 36,Retain Michael G. Heavican,,,No,336,205,130,1
+Sarpy,Precinct 37,Retain Michael G. Heavican,,,No,482,283,195,4
+Sarpy,Precinct 38,Retain Michael G. Heavican,,,No,315,211,102,2
+Sarpy,Precinct 39,Retain Michael G. Heavican,,,No,375,237,137,1
+Sarpy,Precinct 40,Retain Michael G. Heavican,,,No,378,253,119,6
+Sarpy,Precinct 41,Retain Michael G. Heavican,,,No,389,205,180,4
+Sarpy,Precinct 42,Retain Michael G. Heavican,,,No,361,207,152,2
+Sarpy,Precinct 46,Retain Michael G. Heavican,,,No,279,176,102,1
+Sarpy,Precinct 47,Retain Michael G. Heavican,,,No,221,172,49,0
+Sarpy,Precinct 48,Retain Michael G. Heavican,,,No,429,239,189,1
+Sarpy,Precinct 49,Retain Michael G. Heavican,,,No,369,206,157,6
+Sarpy,Precinct 51,Retain Michael G. Heavican,,,No,516,324,192,0
+Sarpy,Precinct 52,Retain Michael G. Heavican,,,No,518,298,213,7
+Sarpy,Precinct 53,Retain Michael G. Heavican,,,No,453,268,183,2
+Sarpy,Precinct 54,Retain Michael G. Heavican,,,No,456,265,183,8
+Sarpy,Precinct 55,Retain Michael G. Heavican,,,No,548,365,177,6
+Sarpy,Precinct 56,Retain Michael G. Heavican,,,No,392,248,143,1
+Sarpy,Precinct 57,Retain Michael G. Heavican,,,No,345,228,117,0
+Sarpy,Precinct 58,Retain Michael G. Heavican,,,No,215,146,68,1
+Sarpy,Precinct 59,Retain Michael G. Heavican,,,No,298,206,92,0
+Sarpy,Precinct 60,Retain Michael G. Heavican,,,No,296,218,77,1
+Sarpy,Precinct 61,Retain Michael G. Heavican,,,No,612,381,225,6
+Sarpy,Precinct 62,Retain Michael G. Heavican,,,No,346,217,125,4
+Sarpy,,Retain William B. Cassel,,,Yes,10586,6553,3932,101
+Sarpy,Precinct 46,Retain William B. Cassel,,,Yes,550,342,207,1
+Sarpy,Precinct 47,Retain William B. Cassel,,,Yes,427,325,96,6
+Sarpy,Precinct 51,Retain William B. Cassel,,,Yes,1326,834,481,11
+Sarpy,Precinct 52,Retain William B. Cassel,,,Yes,1266,727,525,14
+Sarpy,Precinct 53,Retain William B. Cassel,,,Yes,1061,598,449,14
+Sarpy,Precinct 54,Retain William B. Cassel,,,Yes,1031,582,441,8
+Sarpy,Precinct 55,Retain William B. Cassel,,,Yes,1185,761,412,12
+Sarpy,Precinct 58,Retain William B. Cassel,,,Yes,649,437,205,7
+Sarpy,Precinct 59,Retain William B. Cassel,,,Yes,678,468,203,7
+Sarpy,Precinct 60,Retain William B. Cassel,,,Yes,656,447,208,1
+Sarpy,Precinct 61,Retain William B. Cassel,,,Yes,1483,840,625,18
+Sarpy,Precinct 62,Retain William B. Cassel,,,Yes,274,192,80,2
+Sarpy,,Retain William B. Cassel,,,No,4505,2891,1583,31
+Sarpy,Precinct 46,Retain William B. Cassel,,,No,258,163,94,1
+Sarpy,Precinct 47,Retain William B. Cassel,,,No,228,179,49,0
+Sarpy,Precinct 51,Retain William B. Cassel,,,No,510,322,188,0
+Sarpy,Precinct 52,Retain William B. Cassel,,,No,504,289,209,6
+Sarpy,Precinct 53,Retain William B. Cassel,,,No,448,264,181,3
+Sarpy,Precinct 54,Retain William B. Cassel,,,No,425,244,174,7
+Sarpy,Precinct 55,Retain William B. Cassel,,,No,529,359,164,6
+Sarpy,Precinct 58,Retain William B. Cassel,,,No,231,163,67,1
+Sarpy,Precinct 59,Retain William B. Cassel,,,No,314,217,97,0
+Sarpy,Precinct 60,Retain William B. Cassel,,,No,277,204,72,1
+Sarpy,Precinct 61,Retain William B. Cassel,,,No,637,395,237,5
+Sarpy,Precinct 62,Retain William B. Cassel,,,No,144,92,51,1
+Sarpy,,Retain Francie Riedmann Weis,,,Yes,10671,6542,4027,102
+Sarpy,Precinct 46,Retain Francie Riedmann Weis,,,Yes,534,330,203,1
+Sarpy,Precinct 47,Retain Francie Riedmann Weis,,,Yes,437,332,99,6
+Sarpy,Precinct 51,Retain Francie Riedmann Weis,,,Yes,1324,825,489,10
+Sarpy,Precinct 52,Retain Francie Riedmann Weis,,,Yes,1266,712,540,14
+Sarpy,Precinct 53,Retain Francie Riedmann Weis,,,Yes,1061,592,455,14
+Sarpy,Precinct 54,Retain Francie Riedmann Weis,,,Yes,1023,567,448,8
+Sarpy,Precinct 55,Retain Francie Riedmann Weis,,,Yes,1202,766,423,13
+Sarpy,Precinct 58,Retain Francie Riedmann Weis,,,Yes,666,453,207,6
+Sarpy,Precinct 59,Retain Francie Riedmann Weis,,,Yes,690,475,207,8
+Sarpy,Precinct 60,Retain Francie Riedmann Weis,,,Yes,668,443,223,2
+Sarpy,Precinct 61,Retain Francie Riedmann Weis,,,Yes,1517,855,644,18
+Sarpy,Precinct 62,Retain Francie Riedmann Weis,,,Yes,283,192,89,2
+Sarpy,,Retain Francie Riedmann Weis,,,No,4381,2870,1481,30
+Sarpy,Precinct 46,Retain Francie Riedmann Weis,,,No,272,174,97,1
+Sarpy,Precinct 47,Retain Francie Riedmann Weis,,,No,212,167,45,0
+Sarpy,Precinct 51,Retain Francie Riedmann Weis,,,No,506,325,180,1
+Sarpy,Precinct 52,Retain Francie Riedmann Weis,,,No,495,299,190,6
+Sarpy,Precinct 53,Retain Francie Riedmann Weis,,,No,437,263,171,3
+Sarpy,Precinct 54,Retain Francie Riedmann Weis,,,No,422,252,163,7
+Sarpy,Precinct 55,Retain Francie Riedmann Weis,,,No,513,359,149,5
+Sarpy,Precinct 58,Retain Francie Riedmann Weis,,,No,213,149,63,1
+Sarpy,Precinct 59,Retain Francie Riedmann Weis,,,No,301,209,91,1
+Sarpy,Precinct 60,Retain Francie Riedmann Weis,,,No,266,206,60,0
+Sarpy,Precinct 61,Retain Francie Riedmann Weis,,,No,608,377,227,4
+Sarpy,Precinct 62,Retain Francie Riedmann Weis,,,No,136,90,45,1
+Sarpy,,Retain Daniel R. Fridrich,,,Yes,46750,27996,18229,525
+Sarpy,Precinct 1,Retain Daniel R. Fridrich,,,Yes,600,410,184,6
+Sarpy,Precinct 2,Retain Daniel R. Fridrich,,,Yes,584,422,155,7
+Sarpy,Precinct 3,Retain Daniel R. Fridrich,,,Yes,907,511,382,14
+Sarpy,Precinct 4,Retain Daniel R. Fridrich,,,Yes,776,514,254,8
+Sarpy,Precinct 5,Retain Daniel R. Fridrich,,,Yes,684,384,290,10
+Sarpy,Precinct 6,Retain Daniel R. Fridrich,,,Yes,815,549,250,16
+Sarpy,Precinct 7,Retain Daniel R. Fridrich,,,Yes,727,435,275,17
+Sarpy,Precinct 8,Retain Daniel R. Fridrich,,,Yes,704,458,237,9
+Sarpy,Precinct 9,Retain Daniel R. Fridrich,,,Yes,741,524,208,9
+Sarpy,Precinct 10,Retain Daniel R. Fridrich,,,Yes,541,386,141,14
+Sarpy,Precinct 11,Retain Daniel R. Fridrich,,,Yes,1063,586,466,11
+Sarpy,Precinct 12,Retain Daniel R. Fridrich,,,Yes,859,552,294,13
+Sarpy,Precinct 13,Retain Daniel R. Fridrich,,,Yes,968,518,434,16
+Sarpy,Precinct 16,Retain Daniel R. Fridrich,,,Yes,848,510,331,7
+Sarpy,Precinct 17,Retain Daniel R. Fridrich,,,Yes,826,510,307,9
+Sarpy,Precinct 18,Retain Daniel R. Fridrich,,,Yes,665,431,232,2
+Sarpy,Precinct 19,Retain Daniel R. Fridrich,,,Yes,1292,546,731,15
+Sarpy,Precinct 20,Retain Daniel R. Fridrich,,,Yes,974,589,377,8
+Sarpy,Precinct 21,Retain Daniel R. Fridrich,,,Yes,1235,635,589,11
+Sarpy,Precinct 22,Retain Daniel R. Fridrich,,,Yes,868,542,315,11
+Sarpy,Precinct 23,Retain Daniel R. Fridrich,,,Yes,1249,620,606,23
+Sarpy,Precinct 24,Retain Daniel R. Fridrich,,,Yes,580,338,235,7
+Sarpy,Precinct 25,Retain Daniel R. Fridrich,,,Yes,666,417,234,15
+Sarpy,Precinct 26,Retain Daniel R. Fridrich,,,Yes,853,533,306,14
+Sarpy,Precinct 31,Retain Daniel R. Fridrich,,,Yes,1410,887,507,16
+Sarpy,Precinct 32,Retain Daniel R. Fridrich,,,Yes,682,434,240,8
+Sarpy,Precinct 33,Retain Daniel R. Fridrich,,,Yes,849,516,317,16
+Sarpy,Precinct 34,Retain Daniel R. Fridrich,,,Yes,1007,647,351,9
+Sarpy,Precinct 35,Retain Daniel R. Fridrich,,,Yes,817,505,308,4
+Sarpy,Precinct 36,Retain Daniel R. Fridrich,,,Yes,889,512,372,5
+Sarpy,Precinct 37,Retain Daniel R. Fridrich,,,Yes,1432,816,602,14
+Sarpy,Precinct 38,Retain Daniel R. Fridrich,,,Yes,910,577,325,8
+Sarpy,Precinct 39,Retain Daniel R. Fridrich,,,Yes,970,534,435,1
+Sarpy,Precinct 40,Retain Daniel R. Fridrich,,,Yes,861,524,326,11
+Sarpy,Precinct 41,Retain Daniel R. Fridrich,,,Yes,1134,588,537,9
+Sarpy,Precinct 42,Retain Daniel R. Fridrich,,,Yes,949,512,428,9
+Sarpy,Precinct 46,Retain Daniel R. Fridrich,,,Yes,582,365,216,1
+Sarpy,Precinct 47,Retain Daniel R. Fridrich,,,Yes,428,326,96,6
+Sarpy,Precinct 48,Retain Daniel R. Fridrich,,,Yes,1008,494,506,8
+Sarpy,Precinct 49,Retain Daniel R. Fridrich,,,Yes,1101,594,496,11
+Sarpy,Precinct 51,Retain Daniel R. Fridrich,,,Yes,1314,833,471,10
+Sarpy,Precinct 52,Retain Daniel R. Fridrich,,,Yes,1291,737,539,15
+Sarpy,Precinct 53,Retain Daniel R. Fridrich,,,Yes,1050,602,436,12
+Sarpy,Precinct 54,Retain Daniel R. Fridrich,,,Yes,1022,563,447,12
+Sarpy,Precinct 55,Retain Daniel R. Fridrich,,,Yes,1196,781,404,11
+Sarpy,Precinct 56,Retain Daniel R. Fridrich,,,Yes,777,509,266,2
+Sarpy,Precinct 57,Retain Daniel R. Fridrich,,,Yes,721,497,216,8
+Sarpy,Precinct 58,Retain Daniel R. Fridrich,,,Yes,654,443,205,6
+Sarpy,Precinct 59,Retain Daniel R. Fridrich,,,Yes,671,466,198,7
+Sarpy,Precinct 60,Retain Daniel R. Fridrich,,,Yes,651,442,209,0
+Sarpy,Precinct 61,Retain Daniel R. Fridrich,,,Yes,1472,828,627,17
+Sarpy,Precinct 62,Retain Daniel R. Fridrich,,,Yes,877,544,316,17
+Sarpy,,Retain Daniel R. Fridrich,,,No,17814,11124,6536,154
+Sarpy,Precinct 1,Retain Daniel R. Fridrich,,,No,250,164,82,4
+Sarpy,Precinct 2,Retain Daniel R. Fridrich,,,No,236,172,62,2
+Sarpy,Precinct 3,Retain Daniel R. Fridrich,,,No,345,202,139,4
+Sarpy,Precinct 4,Retain Daniel R. Fridrich,,,No,321,208,110,3
+Sarpy,Precinct 5,Retain Daniel R. Fridrich,,,No,234,146,87,1
+Sarpy,Precinct 6,Retain Daniel R. Fridrich,,,No,304,202,98,4
+Sarpy,Precinct 7,Retain Daniel R. Fridrich,,,No,282,192,85,5
+Sarpy,Precinct 8,Retain Daniel R. Fridrich,,,No,276,168,107,1
+Sarpy,Precinct 9,Retain Daniel R. Fridrich,,,No,283,212,66,5
+Sarpy,Precinct 10,Retain Daniel R. Fridrich,,,No,207,158,45,4
+Sarpy,Precinct 11,Retain Daniel R. Fridrich,,,No,397,241,154,2
+Sarpy,Precinct 12,Retain Daniel R. Fridrich,,,No,388,243,141,4
+Sarpy,Precinct 13,Retain Daniel R. Fridrich,,,No,364,236,126,2
+Sarpy,Precinct 16,Retain Daniel R. Fridrich,,,No,414,237,177,0
+Sarpy,Precinct 17,Retain Daniel R. Fridrich,,,No,397,250,142,5
+Sarpy,Precinct 18,Retain Daniel R. Fridrich,,,No,317,197,116,4
+Sarpy,Precinct 19,Retain Daniel R. Fridrich,,,No,446,196,243,7
+Sarpy,Precinct 20,Retain Daniel R. Fridrich,,,No,374,214,158,2
+Sarpy,Precinct 21,Retain Daniel R. Fridrich,,,No,422,230,188,4
+Sarpy,Precinct 22,Retain Daniel R. Fridrich,,,No,316,204,109,3
+Sarpy,Precinct 23,Retain Daniel R. Fridrich,,,No,382,187,189,6
+Sarpy,Precinct 24,Retain Daniel R. Fridrich,,,No,227,149,77,1
+Sarpy,Precinct 25,Retain Daniel R. Fridrich,,,No,232,150,76,6
+Sarpy,Precinct 26,Retain Daniel R. Fridrich,,,No,273,175,97,1
+Sarpy,Precinct 31,Retain Daniel R. Fridrich,,,No,549,345,196,8
+Sarpy,Precinct 32,Retain Daniel R. Fridrich,,,No,288,181,106,1
+Sarpy,Precinct 33,Retain Daniel R. Fridrich,,,No,308,197,108,3
+Sarpy,Precinct 34,Retain Daniel R. Fridrich,,,No,335,213,117,5
+Sarpy,Precinct 35,Retain Daniel R. Fridrich,,,No,312,227,83,2
+Sarpy,Precinct 36,Retain Daniel R. Fridrich,,,No,307,189,118,0
+Sarpy,Precinct 37,Retain Daniel R. Fridrich,,,No,418,250,165,3
+Sarpy,Precinct 38,Retain Daniel R. Fridrich,,,No,292,197,93,2
+Sarpy,Precinct 39,Retain Daniel R. Fridrich,,,No,353,228,124,1
+Sarpy,Precinct 40,Retain Daniel R. Fridrich,,,No,357,249,105,3
+Sarpy,Precinct 41,Retain Daniel R. Fridrich,,,No,366,196,166,4
+Sarpy,Precinct 42,Retain Daniel R. Fridrich,,,No,344,195,146,3
+Sarpy,Precinct 46,Retain Daniel R. Fridrich,,,No,272,171,100,1
+Sarpy,Precinct 47,Retain Daniel R. Fridrich,,,No,214,167,47,0
+Sarpy,Precinct 48,Retain Daniel R. Fridrich,,,No,430,243,186,1
+Sarpy,Precinct 49,Retain Daniel R. Fridrich,,,No,344,189,150,5
+Sarpy,Precinct 51,Retain Daniel R. Fridrich,,,No,487,311,175,1
+Sarpy,Precinct 52,Retain Daniel R. Fridrich,,,No,444,260,179,5
+Sarpy,Precinct 53,Retain Daniel R. Fridrich,,,No,427,245,177,5
+Sarpy,Precinct 54,Retain Daniel R. Fridrich,,,No,426,256,167,3
+Sarpy,Precinct 55,Retain Daniel R. Fridrich,,,No,502,331,164,7
+Sarpy,Precinct 56,Retain Daniel R. Fridrich,,,No,360,228,131,1
+Sarpy,Precinct 57,Retain Daniel R. Fridrich,,,No,324,217,107,0
+Sarpy,Precinct 58,Retain Daniel R. Fridrich,,,No,208,143,64,1
+Sarpy,Precinct 59,Retain Daniel R. Fridrich,,,No,304,202,102,0
+Sarpy,Precinct 60,Retain Daniel R. Fridrich,,,No,265,197,67,1
+Sarpy,Precinct 61,Retain Daniel R. Fridrich,,,No,599,378,216,5
+Sarpy,Precinct 62,Retain Daniel R. Fridrich,,,No,292,186,103,3
+Sarpy,,Retain John R. Hoffert,,,Yes,46378,27872,17979,527
+Sarpy,Precinct 1,Retain John R. Hoffert,,,Yes,582,394,182,6
+Sarpy,Precinct 2,Retain John R. Hoffert,,,Yes,599,432,157,10
+Sarpy,Precinct 3,Retain John R. Hoffert,,,Yes,899,507,379,13
+Sarpy,Precinct 4,Retain John R. Hoffert,,,Yes,782,515,259,8
+Sarpy,Precinct 5,Retain John R. Hoffert,,,Yes,675,378,288,9
+Sarpy,Precinct 6,Retain John R. Hoffert,,,Yes,811,544,251,16
+Sarpy,Precinct 7,Retain John R. Hoffert,,,Yes,709,429,264,16
+Sarpy,Precinct 8,Retain John R. Hoffert,,,Yes,707,453,245,9
+Sarpy,Precinct 9,Retain John R. Hoffert,,,Yes,752,533,208,11
+Sarpy,Precinct 10,Retain John R. Hoffert,,,Yes,528,379,136,13
+Sarpy,Precinct 11,Retain John R. Hoffert,,,Yes,1067,592,464,11
+Sarpy,Precinct 12,Retain John R. Hoffert,,,Yes,853,545,294,14
+Sarpy,Precinct 13,Retain John R. Hoffert,,,Yes,955,521,419,15
+Sarpy,Precinct 16,Retain John R. Hoffert,,,Yes,835,499,329,7
+Sarpy,Precinct 17,Retain John R. Hoffert,,,Yes,827,509,311,7
+Sarpy,Precinct 18,Retain John R. Hoffert,,,Yes,676,445,229,2
+Sarpy,Precinct 19,Retain John R. Hoffert,,,Yes,1272,546,711,15
+Sarpy,Precinct 20,Retain John R. Hoffert,,,Yes,958,580,370,8
+Sarpy,Precinct 21,Retain John R. Hoffert,,,Yes,1225,632,582,11
+Sarpy,Precinct 22,Retain John R. Hoffert,,,Yes,855,545,299,11
+Sarpy,Precinct 23,Retain John R. Hoffert,,,Yes,1247,628,596,23
+Sarpy,Precinct 24,Retain John R. Hoffert,,,Yes,574,340,227,7
+Sarpy,Precinct 25,Retain John R. Hoffert,,,Yes,670,423,232,15
+Sarpy,Precinct 26,Retain John R. Hoffert,,,Yes,854,534,307,13
+Sarpy,Precinct 31,Retain John R. Hoffert,,,Yes,1419,892,510,17
+Sarpy,Precinct 32,Retain John R. Hoffert,,,Yes,685,437,240,8
+Sarpy,Precinct 33,Retain John R. Hoffert,,,Yes,843,511,315,17
+Sarpy,Precinct 34,Retain John R. Hoffert,,,Yes,998,636,353,9
+Sarpy,Precinct 35,Retain John R. Hoffert,,,Yes,810,506,300,4
+Sarpy,Precinct 36,Retain John R. Hoffert,,,Yes,879,514,360,5
+Sarpy,Precinct 37,Retain John R. Hoffert,,,Yes,1407,811,583,13
+Sarpy,Precinct 38,Retain John R. Hoffert,,,Yes,884,563,313,8
+Sarpy,Precinct 39,Retain John R. Hoffert,,,Yes,961,533,427,1
+Sarpy,Precinct 40,Retain John R. Hoffert,,,Yes,861,527,322,12
+Sarpy,Precinct 41,Retain John R. Hoffert,,,Yes,1121,583,529,9
+Sarpy,Precinct 42,Retain John R. Hoffert,,,Yes,941,508,424,9
+Sarpy,Precinct 46,Retain John R. Hoffert,,,Yes,557,346,210,1
+Sarpy,Precinct 47,Retain John R. Hoffert,,,Yes,425,322,96,7
+Sarpy,Precinct 48,Retain John R. Hoffert,,,Yes,1007,491,508,8
+Sarpy,Precinct 49,Retain John R. Hoffert,,,Yes,1091,583,496,12
+Sarpy,Precinct 51,Retain John R. Hoffert,,,Yes,1286,820,455,11
+Sarpy,Precinct 52,Retain John R. Hoffert,,,Yes,1258,729,515,14
+Sarpy,Precinct 53,Retain John R. Hoffert,,,Yes,1062,609,440,13
+Sarpy,Precinct 54,Retain John R. Hoffert,,,Yes,1013,560,444,9
+Sarpy,Precinct 55,Retain John R. Hoffert,,,Yes,1186,785,388,13
+Sarpy,Precinct 56,Retain John R. Hoffert,,,Yes,773,503,268,2
+Sarpy,Precinct 57,Retain John R. Hoffert,,,Yes,723,499,216,8
+Sarpy,Precinct 58,Retain John R. Hoffert,,,Yes,642,433,203,6
+Sarpy,Precinct 59,Retain John R. Hoffert,,,Yes,670,464,199,7
+Sarpy,Precinct 60,Retain John R. Hoffert,,,Yes,646,439,207,0
+Sarpy,Precinct 61,Retain John R. Hoffert,,,Yes,1456,827,611,18
+Sarpy,Precinct 62,Retain John R. Hoffert,,,Yes,862,538,308,16
+Sarpy,,Retain John R. Hoffert,,,No,17986,11116,6718,152
+Sarpy,Precinct 1,Retain John R. Hoffert,,,No,268,180,84,4
+Sarpy,Precinct 2,Retain John R. Hoffert,,,No,228,162,66,0
+Sarpy,Precinct 3,Retain John R. Hoffert,,,No,351,205,141,5
+Sarpy,Precinct 4,Retain John R. Hoffert,,,No,320,209,108,3
+Sarpy,Precinct 5,Retain John R. Hoffert,,,No,239,151,86,2
+Sarpy,Precinct 6,Retain John R. Hoffert,,,No,299,200,94,5
+Sarpy,Precinct 7,Retain John R. Hoffert,,,No,289,192,91,6
+Sarpy,Precinct 8,Retain John R. Hoffert,,,No,270,169,101,0
+Sarpy,Precinct 9,Retain John R. Hoffert,,,No,275,203,69,3
+Sarpy,Precinct 10,Retain John R. Hoffert,,,No,218,164,50,4
+Sarpy,Precinct 11,Retain John R. Hoffert,,,No,391,235,153,3
+Sarpy,Precinct 12,Retain John R. Hoffert,,,No,389,242,144,3
+Sarpy,Precinct 13,Retain John R. Hoffert,,,No,371,234,134,3
+Sarpy,Precinct 16,Retain John R. Hoffert,,,No,417,241,176,0
+Sarpy,Precinct 17,Retain John R. Hoffert,,,No,393,249,138,6
+Sarpy,Precinct 18,Retain John R. Hoffert,,,No,311,188,119,4
+Sarpy,Precinct 19,Retain John R. Hoffert,,,No,450,192,252,6
+Sarpy,Precinct 20,Retain John R. Hoffert,,,No,388,218,168,2
+Sarpy,Precinct 21,Retain John R. Hoffert,,,No,422,227,191,4
+Sarpy,Precinct 22,Retain John R. Hoffert,,,No,325,199,122,4
+Sarpy,Precinct 23,Retain John R. Hoffert,,,No,394,183,205,6
+Sarpy,Precinct 24,Retain John R. Hoffert,,,No,233,147,85,1
+Sarpy,Precinct 25,Retain John R. Hoffert,,,No,229,147,76,6
+Sarpy,Precinct 26,Retain John R. Hoffert,,,No,269,173,94,2
+Sarpy,Precinct 31,Retain John R. Hoffert,,,No,533,336,190,7
+Sarpy,Precinct 32,Retain John R. Hoffert,,,No,287,178,108,1
+Sarpy,Precinct 33,Retain John R. Hoffert,,,No,308,197,109,2
+Sarpy,Precinct 34,Retain John R. Hoffert,,,No,349,226,118,5
+Sarpy,Precinct 35,Retain John R. Hoffert,,,No,306,221,84,1
+Sarpy,Precinct 36,Retain John R. Hoffert,,,No,315,187,128,0
+Sarpy,Precinct 37,Retain John R. Hoffert,,,No,436,245,187,4
+Sarpy,Precinct 38,Retain John R. Hoffert,,,No,311,205,104,2
+Sarpy,Precinct 39,Retain John R. Hoffert,,,No,354,225,128,1
+Sarpy,Precinct 40,Retain John R. Hoffert,,,No,358,249,106,3
+Sarpy,Precinct 41,Retain John R. Hoffert,,,No,374,196,174,4
+Sarpy,Precinct 42,Retain John R. Hoffert,,,No,346,197,146,3
+Sarpy,Precinct 46,Retain John R. Hoffert,,,No,276,178,97,1
+Sarpy,Precinct 47,Retain John R. Hoffert,,,No,212,166,46,0
+Sarpy,Precinct 48,Retain John R. Hoffert,,,No,429,241,186,2
+Sarpy,Precinct 49,Retain John R. Hoffert,,,No,355,197,154,4
+Sarpy,Precinct 51,Retain John R. Hoffert,,,No,506,316,190,0
+Sarpy,Precinct 52,Retain John R. Hoffert,,,No,475,269,201,5
+Sarpy,Precinct 53,Retain John R. Hoffert,,,No,406,233,169,4
+Sarpy,Precinct 54,Retain John R. Hoffert,,,No,427,255,166,6
+Sarpy,Precinct 55,Retain John R. Hoffert,,,No,506,326,175,5
+Sarpy,Precinct 56,Retain John R. Hoffert,,,No,362,233,128,1
+Sarpy,Precinct 57,Retain John R. Hoffert,,,No,322,215,107,0
+Sarpy,Precinct 58,Retain John R. Hoffert,,,No,216,152,63,1
+Sarpy,Precinct 59,Retain John R. Hoffert,,,No,297,199,98,0
+Sarpy,Precinct 60,Retain John R. Hoffert,,,No,261,194,66,1
+Sarpy,Precinct 61,Retain John R. Hoffert,,,No,612,379,230,3
+Sarpy,Precinct 62,Retain John R. Hoffert,,,No,308,191,113,4
+Sarpy,,Retain James R. Coe,,,Yes,45383,27382,17478,523
+Sarpy,Precinct 1,Retain James R. Coe,,,Yes,583,392,185,6
+Sarpy,Precinct 2,Retain James R. Coe,,,Yes,563,405,149,9
+Sarpy,Precinct 3,Retain James R. Coe,,,Yes,885,502,369,14
+Sarpy,Precinct 4,Retain James R. Coe,,,Yes,752,499,245,8
+Sarpy,Precinct 5,Retain James R. Coe,,,Yes,673,376,289,8
+Sarpy,Precinct 6,Retain James R. Coe,,,Yes,794,536,241,17
+Sarpy,Precinct 7,Retain James R. Coe,,,Yes,709,424,268,17
+Sarpy,Precinct 8,Retain James R. Coe,,,Yes,684,446,229,9
+Sarpy,Precinct 9,Retain James R. Coe,,,Yes,729,518,201,10
+Sarpy,Precinct 10,Retain James R. Coe,,,Yes,521,373,134,14
+Sarpy,Precinct 11,Retain James R. Coe,,,Yes,1050,578,460,12
+Sarpy,Precinct 12,Retain James R. Coe,,,Yes,839,539,285,15
+Sarpy,Precinct 13,Retain James R. Coe,,,Yes,946,511,420,15
+Sarpy,Precinct 16,Retain James R. Coe,,,Yes,832,511,315,6
+Sarpy,Precinct 17,Retain James R. Coe,,,Yes,806,499,299,8
+Sarpy,Precinct 18,Retain James R. Coe,,,Yes,660,432,227,1
+Sarpy,Precinct 19,Retain James R. Coe,,,Yes,1253,541,697,15
+Sarpy,Precinct 20,Retain James R. Coe,,,Yes,940,567,365,8
+Sarpy,Precinct 21,Retain James R. Coe,,,Yes,1170,610,551,9
+Sarpy,Precinct 22,Retain James R. Coe,,,Yes,831,525,295,11
+Sarpy,Precinct 23,Retain James R. Coe,,,Yes,1204,604,580,20
+Sarpy,Precinct 24,Retain James R. Coe,,,Yes,560,339,215,6
+Sarpy,Precinct 25,Retain James R. Coe,,,Yes,653,418,222,13
+Sarpy,Precinct 26,Retain James R. Coe,,,Yes,825,522,289,14
+Sarpy,Precinct 31,Retain James R. Coe,,,Yes,1383,875,491,17
+Sarpy,Precinct 32,Retain James R. Coe,,,Yes,674,419,246,9
+Sarpy,Precinct 33,Retain James R. Coe,,,Yes,832,503,312,17
+Sarpy,Precinct 34,Retain James R. Coe,,,Yes,992,639,344,9
+Sarpy,Precinct 35,Retain James R. Coe,,,Yes,786,497,285,4
+Sarpy,Precinct 36,Retain James R. Coe,,,Yes,858,501,352,5
+Sarpy,Precinct 37,Retain James R. Coe,,,Yes,1388,799,573,16
+Sarpy,Precinct 38,Retain James R. Coe,,,Yes,873,552,313,8
+Sarpy,Precinct 39,Retain James R. Coe,,,Yes,959,533,425,1
+Sarpy,Precinct 40,Retain James R. Coe,,,Yes,843,525,307,11
+Sarpy,Precinct 41,Retain James R. Coe,,,Yes,1094,569,515,10
+Sarpy,Precinct 42,Retain James R. Coe,,,Yes,914,499,406,9
+Sarpy,Precinct 46,Retain James R. Coe,,,Yes,551,349,201,1
+Sarpy,Precinct 47,Retain James R. Coe,,,Yes,410,313,91,6
+Sarpy,Precinct 48,Retain James R. Coe,,,Yes,992,491,493,8
+Sarpy,Precinct 49,Retain James R. Coe,,,Yes,1058,566,480,12
+Sarpy,Precinct 51,Retain James R. Coe,,,Yes,1253,804,439,10
+Sarpy,Precinct 52,Retain James R. Coe,,,Yes,1228,722,491,15
+Sarpy,Precinct 53,Retain James R. Coe,,,Yes,1027,588,426,13
+Sarpy,Precinct 54,Retain James R. Coe,,,Yes,990,562,420,8
+Sarpy,Precinct 55,Retain James R. Coe,,,Yes,1161,759,390,12
+Sarpy,Precinct 56,Retain James R. Coe,,,Yes,754,494,258,2
+Sarpy,Precinct 57,Retain James R. Coe,,,Yes,702,485,209,8
+Sarpy,Precinct 58,Retain James R. Coe,,,Yes,625,426,194,5
+Sarpy,Precinct 59,Retain James R. Coe,,,Yes,660,461,192,7
+Sarpy,Precinct 60,Retain James R. Coe,,,Yes,629,421,207,1
+Sarpy,Precinct 61,Retain James R. Coe,,,Yes,1438,826,595,17
+Sarpy,Precinct 62,Retain James R. Coe,,,Yes,847,537,293,17
+Sarpy,,Retain James R. Coe,,,No,18706,11423,7132,151
+Sarpy,Precinct 1,Retain James R. Coe,,,No,259,176,79,4
+Sarpy,Precinct 2,Retain James R. Coe,,,No,246,175,71,0
+Sarpy,Precinct 3,Retain James R. Coe,,,No,360,207,149,4
+Sarpy,Precinct 4,Retain James R. Coe,,,No,348,225,120,3
+Sarpy,Precinct 5,Retain James R. Coe,,,No,238,151,84,3
+Sarpy,Precinct 6,Retain James R. Coe,,,No,309,203,103,3
+Sarpy,Precinct 7,Retain James R. Coe,,,No,290,198,87,5
+Sarpy,Precinct 8,Retain James R. Coe,,,No,284,171,112,1
+Sarpy,Precinct 9,Retain James R. Coe,,,No,290,216,70,4
+Sarpy,Precinct 10,Retain James R. Coe,,,No,221,164,53,4
+Sarpy,Precinct 11,Retain James R. Coe,,,No,403,246,156,1
+Sarpy,Precinct 12,Retain James R. Coe,,,No,390,240,149,1
+Sarpy,Precinct 13,Retain James R. Coe,,,No,378,240,135,3
+Sarpy,Precinct 16,Retain James R. Coe,,,No,415,232,182,1
+Sarpy,Precinct 17,Retain James R. Coe,,,No,402,254,145,3
+Sarpy,Precinct 18,Retain James R. Coe,,,No,322,196,122,4
+Sarpy,Precinct 19,Retain James R. Coe,,,No,452,188,256,8
+Sarpy,Precinct 20,Retain James R. Coe,,,No,400,231,167,2
+Sarpy,Precinct 21,Retain James R. Coe,,,No,463,239,218,6
+Sarpy,Precinct 22,Retain James R. Coe,,,No,344,214,126,4
+Sarpy,Precinct 23,Retain James R. Coe,,,No,424,194,221,9
+Sarpy,Precinct 24,Retain James R. Coe,,,No,241,146,95,0
+Sarpy,Precinct 25,Retain James R. Coe,,,No,236,148,80,8
+Sarpy,Precinct 26,Retain James R. Coe,,,No,291,182,108,1
+Sarpy,Precinct 31,Retain James R. Coe,,,No,562,347,208,7
+Sarpy,Precinct 32,Retain James R. Coe,,,No,291,189,102,0
+Sarpy,Precinct 33,Retain James R. Coe,,,No,321,206,113,2
+Sarpy,Precinct 34,Retain James R. Coe,,,No,353,222,126,5
+Sarpy,Precinct 35,Retain James R. Coe,,,No,329,227,101,1
+Sarpy,Precinct 36,Retain James R. Coe,,,No,337,199,138,0
+Sarpy,Precinct 37,Retain James R. Coe,,,No,452,255,195,2
+Sarpy,Precinct 38,Retain James R. Coe,,,No,321,215,104,2
+Sarpy,Precinct 39,Retain James R. Coe,,,No,358,223,134,1
+Sarpy,Precinct 40,Retain James R. Coe,,,No,371,247,120,4
+Sarpy,Precinct 41,Retain James R. Coe,,,No,400,211,186,3
+Sarpy,Precinct 42,Retain James R. Coe,,,No,371,204,164,3
+Sarpy,Precinct 46,Retain James R. Coe,,,No,285,177,107,1
+Sarpy,Precinct 47,Retain James R. Coe,,,No,226,175,51,0
+Sarpy,Precinct 48,Retain James R. Coe,,,No,446,246,198,2
+Sarpy,Precinct 49,Retain James R. Coe,,,No,382,213,165,4
+Sarpy,Precinct 51,Retain James R. Coe,,,No,540,331,208,1
+Sarpy,Precinct 52,Retain James R. Coe,,,No,501,272,224,5
+Sarpy,Precinct 53,Retain James R. Coe,,,No,437,249,184,4
+Sarpy,Precinct 54,Retain James R. Coe,,,No,447,253,187,7
+Sarpy,Precinct 55,Retain James R. Coe,,,No,525,345,175,5
+Sarpy,Precinct 56,Retain James R. Coe,,,No,368,231,136,1
+Sarpy,Precinct 57,Retain James R. Coe,,,No,326,216,110,0
+Sarpy,Precinct 58,Retain James R. Coe,,,No,232,159,71,2
+Sarpy,Precinct 59,Retain James R. Coe,,,No,304,201,103,0
+Sarpy,Precinct 60,Retain James R. Coe,,,No,277,211,66,0
+Sarpy,Precinct 61,Retain James R. Coe,,,No,624,377,243,4
+Sarpy,Precinct 62,Retain James R. Coe,,,No,314,186,125,3
+Sarpy,,Retain Robert C. Wester,,,Yes,45392,27263,17613,516
+Sarpy,Precinct 1,Retain Robert C. Wester,,,Yes,557,374,178,5
+Sarpy,Precinct 2,Retain Robert C. Wester,,,Yes,575,409,157,9
+Sarpy,Precinct 3,Retain Robert C. Wester,,,Yes,879,495,370,14
+Sarpy,Precinct 4,Retain Robert C. Wester,,,Yes,756,491,258,7
+Sarpy,Precinct 5,Retain Robert C. Wester,,,Yes,675,376,290,9
+Sarpy,Precinct 6,Retain Robert C. Wester,,,Yes,789,532,242,15
+Sarpy,Precinct 7,Retain Robert C. Wester,,,Yes,699,419,264,16
+Sarpy,Precinct 8,Retain Robert C. Wester,,,Yes,680,443,229,8
+Sarpy,Precinct 9,Retain Robert C. Wester,,,Yes,746,524,211,11
+Sarpy,Precinct 10,Retain Robert C. Wester,,,Yes,514,365,137,12
+Sarpy,Precinct 11,Retain Robert C. Wester,,,Yes,1024,555,458,11
+Sarpy,Precinct 12,Retain Robert C. Wester,,,Yes,833,534,285,14
+Sarpy,Precinct 13,Retain Robert C. Wester,,,Yes,954,505,435,14
+Sarpy,Precinct 16,Retain Robert C. Wester,,,Yes,822,490,326,6
+Sarpy,Precinct 17,Retain Robert C. Wester,,,Yes,796,477,310,9
+Sarpy,Precinct 18,Retain Robert C. Wester,,,Yes,640,415,223,2
+Sarpy,Precinct 19,Retain Robert C. Wester,,,Yes,1241,534,693,14
+Sarpy,Precinct 20,Retain Robert C. Wester,,,Yes,945,572,365,8
+Sarpy,Precinct 21,Retain Robert C. Wester,,,Yes,1170,600,559,11
+Sarpy,Precinct 22,Retain Robert C. Wester,,,Yes,826,520,296,10
+Sarpy,Precinct 23,Retain Robert C. Wester,,,Yes,1198,601,573,24
+Sarpy,Precinct 24,Retain Robert C. Wester,,,Yes,555,337,212,6
+Sarpy,Precinct 25,Retain Robert C. Wester,,,Yes,659,412,230,17
+Sarpy,Precinct 26,Retain Robert C. Wester,,,Yes,807,507,287,13
+Sarpy,Precinct 31,Retain Robert C. Wester,,,Yes,1400,891,494,15
+Sarpy,Precinct 32,Retain Robert C. Wester,,,Yes,689,442,238,9
+Sarpy,Precinct 33,Retain Robert C. Wester,,,Yes,817,496,305,16
+Sarpy,Precinct 34,Retain Robert C. Wester,,,Yes,985,633,343,9
+Sarpy,Precinct 35,Retain Robert C. Wester,,,Yes,805,508,292,5
+Sarpy,Precinct 36,Retain Robert C. Wester,,,Yes,893,525,363,5
+Sarpy,Precinct 37,Retain Robert C. Wester,,,Yes,1374,790,571,13
+Sarpy,Precinct 38,Retain Robert C. Wester,,,Yes,888,570,310,8
+Sarpy,Precinct 39,Retain Robert C. Wester,,,Yes,955,538,416,1
+Sarpy,Precinct 40,Retain Robert C. Wester,,,Yes,856,530,317,9
+Sarpy,Precinct 41,Retain Robert C. Wester,,,Yes,1113,580,524,9
+Sarpy,Precinct 42,Retain Robert C. Wester,,,Yes,923,512,402,9
+Sarpy,Precinct 46,Retain Robert C. Wester,,,Yes,553,346,206,1
+Sarpy,Precinct 47,Retain Robert C. Wester,,,Yes,434,332,96,6
+Sarpy,Precinct 48,Retain Robert C. Wester,,,Yes,1004,489,507,8
+Sarpy,Precinct 49,Retain Robert C. Wester,,,Yes,1076,574,489,13
+Sarpy,Precinct 51,Retain Robert C. Wester,,,Yes,1277,821,446,10
+Sarpy,Precinct 52,Retain Robert C. Wester,,,Yes,1227,704,510,13
+Sarpy,Precinct 53,Retain Robert C. Wester,,,Yes,1027,594,420,13
+Sarpy,Precinct 54,Retain Robert C. Wester,,,Yes,986,548,429,9
+Sarpy,Precinct 55,Retain Robert C. Wester,,,Yes,1181,768,400,13
+Sarpy,Precinct 56,Retain Robert C. Wester,,,Yes,752,478,272,2
+Sarpy,Precinct 57,Retain Robert C. Wester,,,Yes,696,480,208,8
+Sarpy,Precinct 58,Retain Robert C. Wester,,,Yes,619,426,188,5
+Sarpy,Precinct 59,Retain Robert C. Wester,,,Yes,655,460,188,7
+Sarpy,Precinct 60,Retain Robert C. Wester,,,Yes,610,406,203,1
+Sarpy,Precinct 61,Retain Robert C. Wester,,,Yes,1416,808,591,17
+Sarpy,Precinct 62,Retain Robert C. Wester,,,Yes,841,527,297,17
+Sarpy,,Retain Robert C. Wester,,,No,19043,11668,7218,157
+Sarpy,Precinct 1,Retain Robert C. Wester,,,No,287,194,88,5
+Sarpy,Precinct 2,Retain Robert C. Wester,,,No,245,175,70,0
+Sarpy,Precinct 3,Retain Robert C. Wester,,,No,364,216,144,4
+Sarpy,Precinct 4,Retain Robert C. Wester,,,No,351,235,112,4
+Sarpy,Precinct 5,Retain Robert C. Wester,,,No,237,151,84,2
+Sarpy,Precinct 6,Retain Robert C. Wester,,,No,317,210,103,4
+Sarpy,Precinct 7,Retain Robert C. Wester,,,No,317,212,99,6
+Sarpy,Precinct 8,Retain Robert C. Wester,,,No,290,172,116,2
+Sarpy,Precinct 9,Retain Robert C. Wester,,,No,284,208,73,3
+Sarpy,Precinct 10,Retain Robert C. Wester,,,No,235,179,51,5
+Sarpy,Precinct 11,Retain Robert C. Wester,,,No,431,268,161,2
+Sarpy,Precinct 12,Retain Robert C. Wester,,,No,401,249,150,2
+Sarpy,Precinct 13,Retain Robert C. Wester,,,No,382,246,133,3
+Sarpy,Precinct 16,Retain Robert C. Wester,,,No,429,250,178,1
+Sarpy,Precinct 17,Retain Robert C. Wester,,,No,415,269,142,4
+Sarpy,Precinct 18,Retain Robert C. Wester,,,No,343,215,125,3
+Sarpy,Precinct 19,Retain Robert C. Wester,,,No,479,197,275,7
+Sarpy,Precinct 20,Retain Robert C. Wester,,,No,408,234,172,2
+Sarpy,Precinct 21,Retain Robert C. Wester,,,No,473,256,213,4
+Sarpy,Precinct 22,Retain Robert C. Wester,,,No,353,219,130,4
+Sarpy,Precinct 23,Retain Robert C. Wester,,,No,428,197,225,6
+Sarpy,Precinct 24,Retain Robert C. Wester,,,No,250,149,101,0
+Sarpy,Precinct 25,Retain Robert C. Wester,,,No,237,158,73,6
+Sarpy,Precinct 26,Retain Robert C. Wester,,,No,309,199,108,2
+Sarpy,Precinct 31,Retain Robert C. Wester,,,No,543,331,204,8
+Sarpy,Precinct 32,Retain Robert C. Wester,,,No,289,175,113,1
+Sarpy,Precinct 33,Retain Robert C. Wester,,,No,326,210,113,3
+Sarpy,Precinct 34,Retain Robert C. Wester,,,No,362,226,131,5
+Sarpy,Precinct 35,Retain Robert C. Wester,,,No,317,218,99,0
+Sarpy,Precinct 36,Retain Robert C. Wester,,,No,325,188,137,0
+Sarpy,Precinct 37,Retain Robert C. Wester,,,No,483,271,209,3
+Sarpy,Precinct 38,Retain Robert C. Wester,,,No,316,202,112,2
+Sarpy,Precinct 39,Retain Robert C. Wester,,,No,374,230,143,1
+Sarpy,Precinct 40,Retain Robert C. Wester,,,No,384,250,128,6
+Sarpy,Precinct 41,Retain Robert C. Wester,,,No,390,201,185,4
+Sarpy,Precinct 42,Retain Robert C. Wester,,,No,374,199,172,3
+Sarpy,Precinct 46,Retain Robert C. Wester,,,No,297,184,112,1
+Sarpy,Precinct 47,Retain Robert C. Wester,,,No,215,171,44,0
+Sarpy,Precinct 48,Retain Robert C. Wester,,,No,446,246,198,2
+Sarpy,Precinct 49,Retain Robert C. Wester,,,No,372,203,165,4
+Sarpy,Precinct 51,Retain Robert C. Wester,,,No,520,312,207,1
+Sarpy,Precinct 52,Retain Robert C. Wester,,,No,503,287,210,6
+Sarpy,Precinct 53,Retain Robert C. Wester,,,No,448,251,193,4
+Sarpy,Precinct 54,Retain Robert C. Wester,,,No,439,258,175,6
+Sarpy,Precinct 55,Retain Robert C. Wester,,,No,516,342,170,4
+Sarpy,Precinct 56,Retain Robert C. Wester,,,No,375,246,128,1
+Sarpy,Precinct 57,Retain Robert C. Wester,,,No,349,228,121,0
+Sarpy,Precinct 58,Retain Robert C. Wester,,,No,235,160,72,3
+Sarpy,Precinct 59,Retain Robert C. Wester,,,No,303,201,102,0
+Sarpy,Precinct 60,Retain Robert C. Wester,,,No,302,225,77,0
+Sarpy,Precinct 61,Retain Robert C. Wester,,,No,646,393,248,5
+Sarpy,Precinct 62,Retain Robert C. Wester,,,No,329,202,124,3
+Sarpy,,Govs Bd Mem Metro CC,1,,Linda McDermitt,5173,2997,2125,51
+Sarpy,Precinct 51,Govs Bd Mem Metro CC,1,,Linda McDermitt,1712,1092,608,12
+Sarpy,Precinct 52,Govs Bd Mem Metro CC,1,,Linda McDermitt,1614,927,668,19
+Sarpy,Precinct 53,Govs Bd Mem Metro CC,1,,Linda McDermitt,1383,788,579,16
+Sarpy,Precinct 54,Govs Bd Mem Metro CC,1,,Linda McDermitt,464,190,270,4
+Sarpy,,Govs Bd Mem Metro CC,1,,WRITE-IN,73,50,23,0
+Sarpy,Precinct 51,Govs Bd Mem Metro CC,1,,WRITE-IN,26,18,8,0
+Sarpy,Precinct 52,Govs Bd Mem Metro CC,1,,WRITE-IN,18,15,3,0
+Sarpy,Precinct 53,Govs Bd Mem Metro CC,1,,WRITE-IN,23,13,10,0
+Sarpy,Precinct 54,Govs Bd Mem Metro CC,1,,WRITE-IN,6,4,2,0
+Sarpy,,Govs Bd Mem Metro CC,5,,Michelle Nekuda,34181,19383,14494,304
+Sarpy,Precinct 1,Govs Bd Mem Metro CC,5,,Michelle Nekuda,477,324,148,5
+Sarpy,Precinct 2,Govs Bd Mem Metro CC,5,,Michelle Nekuda,435,299,132,4
+Sarpy,Precinct 3,Govs Bd Mem Metro CC,5,,Michelle Nekuda,748,399,339,10
+Sarpy,Precinct 4,Govs Bd Mem Metro CC,5,,Michelle Nekuda,624,403,217,4
+Sarpy,Precinct 5,Govs Bd Mem Metro CC,5,,Michelle Nekuda,537,306,224,7
+Sarpy,Precinct 6,Govs Bd Mem Metro CC,5,,Michelle Nekuda,626,402,215,9
+Sarpy,Precinct 7,Govs Bd Mem Metro CC,5,,Michelle Nekuda,580,341,229,10
+Sarpy,Precinct 8,Govs Bd Mem Metro CC,5,,Michelle Nekuda,541,303,234,4
+Sarpy,Precinct 9,Govs Bd Mem Metro CC,5,,Michelle Nekuda,600,404,188,8
+Sarpy,Precinct 10,Govs Bd Mem Metro CC,5,,Michelle Nekuda,418,287,123,8
+Sarpy,Precinct 11,Govs Bd Mem Metro CC,5,,Michelle Nekuda,934,491,436,7
+Sarpy,Precinct 12,Govs Bd Mem Metro CC,5,,Michelle Nekuda,666,387,274,5
+Sarpy,Precinct 13,Govs Bd Mem Metro CC,5,,Michelle Nekuda,838,436,392,10
+Sarpy,Precinct 16,Govs Bd Mem Metro CC,5,,Michelle Nekuda,717,404,308,5
+Sarpy,Precinct 17,Govs Bd Mem Metro CC,5,,Michelle Nekuda,772,458,308,6
+Sarpy,Precinct 18,Govs Bd Mem Metro CC,5,,Michelle Nekuda,586,357,224,5
+Sarpy,Precinct 19,Govs Bd Mem Metro CC,5,,Michelle Nekuda,1034,410,613,11
+Sarpy,Precinct 20,Govs Bd Mem Metro CC,5,,Michelle Nekuda,748,406,336,6
+Sarpy,Precinct 21,Govs Bd Mem Metro CC,5,,Michelle Nekuda,1015,484,521,10
+Sarpy,Precinct 22,Govs Bd Mem Metro CC,5,,Michelle Nekuda,664,402,257,5
+Sarpy,Precinct 23,Govs Bd Mem Metro CC,5,,Michelle Nekuda,953,440,497,16
+Sarpy,Precinct 24,Govs Bd Mem Metro CC,5,,Michelle Nekuda,461,256,203,2
+Sarpy,Precinct 25,Govs Bd Mem Metro CC,5,,Michelle Nekuda,520,294,215,11
+Sarpy,Precinct 26,Govs Bd Mem Metro CC,5,,Michelle Nekuda,597,342,247,8
+Sarpy,Precinct 31,Govs Bd Mem Metro CC,5,,Michelle Nekuda,1202,716,475,11
+Sarpy,Precinct 32,Govs Bd Mem Metro CC,5,,Michelle Nekuda,587,353,227,7
+Sarpy,Precinct 33,Govs Bd Mem Metro CC,5,,Michelle Nekuda,754,415,325,14
+Sarpy,Precinct 34,Govs Bd Mem Metro CC,5,,Michelle Nekuda,784,477,300,7
+Sarpy,Precinct 35,Govs Bd Mem Metro CC,5,,Michelle Nekuda,692,433,258,1
+Sarpy,Precinct 36,Govs Bd Mem Metro CC,5,,Michelle Nekuda,662,365,295,2
+Sarpy,Precinct 37,Govs Bd Mem Metro CC,5,,Michelle Nekuda,1139,584,545,10
+Sarpy,Precinct 38,Govs Bd Mem Metro CC,5,,Michelle Nekuda,686,428,257,1
+Sarpy,Precinct 39,Govs Bd Mem Metro CC,5,,Michelle Nekuda,805,432,371,2
+Sarpy,Precinct 40,Govs Bd Mem Metro CC,5,,Michelle Nekuda,644,376,261,7
+Sarpy,Precinct 41,Govs Bd Mem Metro CC,5,,Michelle Nekuda,947,478,466,3
+Sarpy,Precinct 42,Govs Bd Mem Metro CC,5,,Michelle Nekuda,757,390,362,5
+Sarpy,Precinct 46,Govs Bd Mem Metro CC,5,,Michelle Nekuda,432,244,188,0
+Sarpy,Precinct 47,Govs Bd Mem Metro CC,5,,Michelle Nekuda,341,250,88,3
+Sarpy,Precinct 48,Govs Bd Mem Metro CC,5,,Michelle Nekuda,825,375,444,6
+Sarpy,Precinct 49,Govs Bd Mem Metro CC,5,,Michelle Nekuda,842,425,413,4
+Sarpy,Precinct 54,Govs Bd Mem Metro CC,5,,Michelle Nekuda,540,346,192,2
+Sarpy,Precinct 55,Govs Bd Mem Metro CC,5,,Michelle Nekuda,948,574,363,11
+Sarpy,Precinct 56,Govs Bd Mem Metro CC,5,,Michelle Nekuda,666,395,269,2
+Sarpy,Precinct 57,Govs Bd Mem Metro CC,5,,Michelle Nekuda,553,329,222,2
+Sarpy,Precinct 58,Govs Bd Mem Metro CC,5,,Michelle Nekuda,461,303,155,3
+Sarpy,Precinct 59,Govs Bd Mem Metro CC,5,,Michelle Nekuda,504,343,158,3
+Sarpy,Precinct 60,Govs Bd Mem Metro CC,5,,Michelle Nekuda,509,332,177,0
+Sarpy,Precinct 61,Govs Bd Mem Metro CC,5,,Michelle Nekuda,1109,572,527,10
+Sarpy,Precinct 62,Govs Bd Mem Metro CC,5,,Michelle Nekuda,701,413,276,12
+Sarpy,,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,20665,13650,6751,264
+Sarpy,Precinct 1,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,323,215,104,4
+Sarpy,Precinct 2,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,346,258,83,5
+Sarpy,Precinct 3,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,414,261,146,7
+Sarpy,Precinct 4,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,383,264,112,7
+Sarpy,Precinct 5,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,327,186,137,4
+Sarpy,Precinct 6,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,434,316,109,9
+Sarpy,Precinct 7,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,406,265,129,12
+Sarpy,Precinct 8,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,379,278,96,5
+Sarpy,Precinct 9,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,378,300,72,6
+Sarpy,Precinct 10,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,278,219,54,5
+Sarpy,Precinct 11,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,449,287,157,5
+Sarpy,Precinct 12,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,491,342,139,10
+Sarpy,Precinct 13,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,416,259,148,9
+Sarpy,Precinct 16,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,485,307,177,1
+Sarpy,Precinct 17,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,409,273,131,5
+Sarpy,Precinct 18,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,367,253,114,0
+Sarpy,Precinct 19,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,580,269,298,13
+Sarpy,Precinct 20,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,519,349,167,3
+Sarpy,Precinct 21,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,533,310,220,3
+Sarpy,Precinct 22,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,463,304,152,7
+Sarpy,Precinct 23,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,524,279,236,9
+Sarpy,Precinct 24,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,292,194,94,4
+Sarpy,Precinct 25,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,332,238,86,8
+Sarpy,Precinct 26,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,467,320,141,6
+Sarpy,Precinct 31,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,575,381,184,10
+Sarpy,Precinct 32,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,343,230,111,2
+Sarpy,Precinct 33,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,337,243,89,5
+Sarpy,Precinct 34,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,460,319,136,5
+Sarpy,Precinct 35,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,352,249,101,2
+Sarpy,Precinct 36,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,403,259,141,3
+Sarpy,Precinct 37,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,573,377,192,4
+Sarpy,Precinct 38,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,433,289,137,7
+Sarpy,Precinct 39,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,400,249,151,0
+Sarpy,Precinct 40,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,485,319,160,6
+Sarpy,Precinct 41,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,431,242,180,9
+Sarpy,Precinct 42,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,451,271,175,5
+Sarpy,Precinct 46,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,319,208,110,1
+Sarpy,Precinct 47,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,256,201,51,4
+Sarpy,Precinct 48,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,454,261,190,3
+Sarpy,Precinct 49,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,465,272,183,10
+Sarpy,Precinct 54,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,326,210,108,8
+Sarpy,Precinct 55,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,619,429,184,6
+Sarpy,Precinct 56,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,387,276,110,1
+Sarpy,Precinct 57,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,405,314,85,6
+Sarpy,Precinct 58,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,304,221,82,1
+Sarpy,Precinct 59,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,381,268,111,2
+Sarpy,Precinct 60,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,331,255,76,0
+Sarpy,Precinct 61,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,776,497,270,9
+Sarpy,Precinct 62,Govs Bd Mem Metro CC,5,,Bernard F. Barrett,404,264,132,8
+Sarpy,,Govs Bd Mem Metro CC,5,,WRITE-IN,419,282,129,8
+Sarpy,Precinct 1,Govs Bd Mem Metro CC,5,,WRITE-IN,14,11,3,0
+Sarpy,Precinct 2,Govs Bd Mem Metro CC,5,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 3,Govs Bd Mem Metro CC,5,,WRITE-IN,10,8,2,0
+Sarpy,Precinct 4,Govs Bd Mem Metro CC,5,,WRITE-IN,12,6,6,0
+Sarpy,Precinct 5,Govs Bd Mem Metro CC,5,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 6,Govs Bd Mem Metro CC,5,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 7,Govs Bd Mem Metro CC,5,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 8,Govs Bd Mem Metro CC,5,,WRITE-IN,6,5,0,1
+Sarpy,Precinct 9,Govs Bd Mem Metro CC,5,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 10,Govs Bd Mem Metro CC,5,,WRITE-IN,12,7,5,0
+Sarpy,Precinct 11,Govs Bd Mem Metro CC,5,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 12,Govs Bd Mem Metro CC,5,,WRITE-IN,9,6,3,0
+Sarpy,Precinct 13,Govs Bd Mem Metro CC,5,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 16,Govs Bd Mem Metro CC,5,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 17,Govs Bd Mem Metro CC,5,,WRITE-IN,12,6,4,2
+Sarpy,Precinct 18,Govs Bd Mem Metro CC,5,,WRITE-IN,6,2,4,0
+Sarpy,Precinct 19,Govs Bd Mem Metro CC,5,,WRITE-IN,12,7,5,0
+Sarpy,Precinct 20,Govs Bd Mem Metro CC,5,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 21,Govs Bd Mem Metro CC,5,,WRITE-IN,11,7,3,1
+Sarpy,Precinct 22,Govs Bd Mem Metro CC,5,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 23,Govs Bd Mem Metro CC,5,,WRITE-IN,10,5,5,0
+Sarpy,Precinct 24,Govs Bd Mem Metro CC,5,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 25,Govs Bd Mem Metro CC,5,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 26,Govs Bd Mem Metro CC,5,,WRITE-IN,10,7,2,1
+Sarpy,Precinct 31,Govs Bd Mem Metro CC,5,,WRITE-IN,19,13,6,0
+Sarpy,Precinct 32,Govs Bd Mem Metro CC,5,,WRITE-IN,8,4,3,1
+Sarpy,Precinct 33,Govs Bd Mem Metro CC,5,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 34,Govs Bd Mem Metro CC,5,,WRITE-IN,8,4,3,1
+Sarpy,Precinct 35,Govs Bd Mem Metro CC,5,,WRITE-IN,7,3,4,0
+Sarpy,Precinct 36,Govs Bd Mem Metro CC,5,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 37,Govs Bd Mem Metro CC,5,,WRITE-IN,9,8,1,0
+Sarpy,Precinct 38,Govs Bd Mem Metro CC,5,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 39,Govs Bd Mem Metro CC,5,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 40,Govs Bd Mem Metro CC,5,,WRITE-IN,17,11,6,0
+Sarpy,Precinct 41,Govs Bd Mem Metro CC,5,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 42,Govs Bd Mem Metro CC,5,,WRITE-IN,7,0,7,0
+Sarpy,Precinct 46,Govs Bd Mem Metro CC,5,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 47,Govs Bd Mem Metro CC,5,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 48,Govs Bd Mem Metro CC,5,,WRITE-IN,4,3,1,0
+Sarpy,Precinct 49,Govs Bd Mem Metro CC,5,,WRITE-IN,11,10,0,1
+Sarpy,Precinct 54,Govs Bd Mem Metro CC,5,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 55,Govs Bd Mem Metro CC,5,,WRITE-IN,16,11,5,0
+Sarpy,Precinct 56,Govs Bd Mem Metro CC,5,,WRITE-IN,15,9,6,0
+Sarpy,Precinct 57,Govs Bd Mem Metro CC,5,,WRITE-IN,11,7,4,0
+Sarpy,Precinct 58,Govs Bd Mem Metro CC,5,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 59,Govs Bd Mem Metro CC,5,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 60,Govs Bd Mem Metro CC,5,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 61,Govs Bd Mem Metro CC,5,,WRITE-IN,11,7,4,0
+Sarpy,Precinct 62,Govs Bd Mem Metro CC,5,,WRITE-IN,10,8,2,0
+Sarpy,,Douglas/Sarpy LCCC,4,,Allen Hager,7164,4538,2564,62
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,4,,Allen Hager,1073,698,369,6
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,4,,Allen Hager,446,315,126,5
+Sarpy,Precinct 53,Douglas/Sarpy LCCC,4,,Allen Hager,1331,763,552,16
+Sarpy,Precinct 54,Douglas/Sarpy LCCC,4,,Allen Hager,1278,724,541,13
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,4,,Allen Hager,1184,820,352,12
+Sarpy,Precinct 56,Douglas/Sarpy LCCC,4,,Allen Hager,958,604,351,3
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,4,,Allen Hager,894,614,273,7
+Sarpy,,Douglas/Sarpy LCCC,4,,WRITE-IN,145,89,54,2
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,4,,WRITE-IN,24,18,6,0
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,4,,WRITE-IN,14,6,7,1
+Sarpy,Precinct 53,Douglas/Sarpy LCCC,4,,WRITE-IN,20,12,8,0
+Sarpy,Precinct 54,Douglas/Sarpy LCCC,4,,WRITE-IN,27,18,9,0
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,4,,WRITE-IN,19,13,6,0
+Sarpy,Precinct 56,Douglas/Sarpy LCCC,4,,WRITE-IN,20,11,9,0
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,4,,WRITE-IN,21,11,9,1
+Sarpy,,Douglas/Sarpy LCCC,6,,Mike Avery,13049,7766,5164,119
+Sarpy,Precinct 11,Douglas/Sarpy LCCC,6,,Mike Avery,40,19,20,1
+Sarpy,Precinct 12,Douglas/Sarpy LCCC,6,,Mike Avery,181,117,64,0
+Sarpy,Precinct 19,Douglas/Sarpy LCCC,6,,Mike Avery,432,162,261,9
+Sarpy,Precinct 21,Douglas/Sarpy LCCC,6,,Mike Avery,467,234,231,2
+Sarpy,Precinct 22,Douglas/Sarpy LCCC,6,,Mike Avery,254,172,80,2
+Sarpy,Precinct 23,Douglas/Sarpy LCCC,6,,Mike Avery,579,300,268,11
+Sarpy,Precinct 24,Douglas/Sarpy LCCC,6,,Mike Avery,7,4,3,0
+Sarpy,Precinct 31,Douglas/Sarpy LCCC,6,,Mike Avery,639,386,242,11
+Sarpy,Precinct 32,Douglas/Sarpy LCCC,6,,Mike Avery,357,238,116,3
+Sarpy,Precinct 33,Douglas/Sarpy LCCC,6,,Mike Avery,391,250,135,6
+Sarpy,Precinct 34,Douglas/Sarpy LCCC,6,,Mike Avery,387,248,135,4
+Sarpy,Precinct 35,Douglas/Sarpy LCCC,6,,Mike Avery,344,226,118,0
+Sarpy,Precinct 36,Douglas/Sarpy LCCC,6,,Mike Avery,454,272,178,4
+Sarpy,Precinct 37,Douglas/Sarpy LCCC,6,,Mike Avery,637,364,269,4
+Sarpy,Precinct 38,Douglas/Sarpy LCCC,6,,Mike Avery,424,274,147,3
+Sarpy,Precinct 39,Douglas/Sarpy LCCC,6,,Mike Avery,471,286,185,0
+Sarpy,Precinct 40,Douglas/Sarpy LCCC,6,,Mike Avery,459,295,159,5
+Sarpy,Precinct 41,Douglas/Sarpy LCCC,6,,Mike Avery,534,300,230,4
+Sarpy,Precinct 42,Douglas/Sarpy LCCC,6,,Mike Avery,500,277,221,2
+Sarpy,Precinct 46,Douglas/Sarpy LCCC,6,,Mike Avery,465,297,166,2
+Sarpy,Precinct 47,Douglas/Sarpy LCCC,6,,Mike Avery,287,229,55,3
+Sarpy,Precinct 48,Douglas/Sarpy LCCC,6,,Mike Avery,578,269,306,3
+Sarpy,Precinct 49,Douglas/Sarpy LCCC,6,,Mike Avery,498,271,220,7
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,6,,Mike Avery,306,186,118,2
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,6,,Mike Avery,461,250,210,1
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,6,,Mike Avery,145,60,84,1
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,6,,Mike Avery,0,0,0,0
+Sarpy,Precinct 58,Douglas/Sarpy LCCC,6,,Mike Avery,410,281,126,3
+Sarpy,Precinct 59,Douglas/Sarpy LCCC,6,,Mike Avery,523,356,161,6
+Sarpy,Precinct 60,Douglas/Sarpy LCCC,6,,Mike Avery,461,330,130,1
+Sarpy,Precinct 61,Douglas/Sarpy LCCC,6,,Mike Avery,935,543,383,9
+Sarpy,Precinct 62,Douglas/Sarpy LCCC,6,,Mike Avery,423,270,143,10
+Sarpy,,Douglas/Sarpy LCCC,6,,Sherri Shackelford,7036,3883,3097,56
+Sarpy,Precinct 11,Douglas/Sarpy LCCC,6,,Sherri Shackelford,24,9,15,0
+Sarpy,Precinct 12,Douglas/Sarpy LCCC,6,,Sherri Shackelford,135,72,62,1
+Sarpy,Precinct 19,Douglas/Sarpy LCCC,6,,Sherri Shackelford,231,86,139,6
+Sarpy,Precinct 21,Douglas/Sarpy LCCC,6,,Sherri Shackelford,260,135,123,2
+Sarpy,Precinct 22,Douglas/Sarpy LCCC,6,,Sherri Shackelford,150,88,62,0
+Sarpy,Precinct 23,Douglas/Sarpy LCCC,6,,Sherri Shackelford,387,167,211,9
+Sarpy,Precinct 24,Douglas/Sarpy LCCC,6,,Sherri Shackelford,0,0,0,0
+Sarpy,Precinct 31,Douglas/Sarpy LCCC,6,,Sherri Shackelford,393,246,143,4
+Sarpy,Precinct 32,Douglas/Sarpy LCCC,6,,Sherri Shackelford,253,142,110,1
+Sarpy,Precinct 33,Douglas/Sarpy LCCC,6,,Sherri Shackelford,301,165,132,4
+Sarpy,Precinct 34,Douglas/Sarpy LCCC,6,,Sherri Shackelford,331,205,123,3
+Sarpy,Precinct 35,Douglas/Sarpy LCCC,6,,Sherri Shackelford,245,143,102,0
+Sarpy,Precinct 36,Douglas/Sarpy LCCC,6,,Sherri Shackelford,237,139,98,0
+Sarpy,Precinct 37,Douglas/Sarpy LCCC,6,,Sherri Shackelford,337,184,151,2
+Sarpy,Precinct 38,Douglas/Sarpy LCCC,6,,Sherri Shackelford,264,147,114,3
+Sarpy,Precinct 39,Douglas/Sarpy LCCC,6,,Sherri Shackelford,303,156,147,0
+Sarpy,Precinct 40,Douglas/Sarpy LCCC,6,,Sherri Shackelford,234,141,91,2
+Sarpy,Precinct 41,Douglas/Sarpy LCCC,6,,Sherri Shackelford,296,141,153,2
+Sarpy,Precinct 42,Douglas/Sarpy LCCC,6,,Sherri Shackelford,317,168,145,4
+Sarpy,Precinct 46,Douglas/Sarpy LCCC,6,,Sherri Shackelford,117,63,54,0
+Sarpy,Precinct 47,Douglas/Sarpy LCCC,6,,Sherri Shackelford,131,97,34,0
+Sarpy,Precinct 48,Douglas/Sarpy LCCC,6,,Sherri Shackelford,276,144,130,2
+Sarpy,Precinct 49,Douglas/Sarpy LCCC,6,,Sherri Shackelford,273,130,142,1
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,6,,Sherri Shackelford,103,64,39,0
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,6,,Sherri Shackelford,253,136,111,6
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,6,,Sherri Shackelford,68,38,29,1
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,6,,Sherri Shackelford,0,0,0,0
+Sarpy,Precinct 58,Douglas/Sarpy LCCC,6,,Sherri Shackelford,151,96,54,1
+Sarpy,Precinct 59,Douglas/Sarpy LCCC,6,,Sherri Shackelford,146,99,47,0
+Sarpy,Precinct 60,Douglas/Sarpy LCCC,6,,Sherri Shackelford,174,118,56,0
+Sarpy,Precinct 61,Douglas/Sarpy LCCC,6,,Sherri Shackelford,406,223,183,0
+Sarpy,Precinct 62,Douglas/Sarpy LCCC,6,,Sherri Shackelford,240,141,97,2
+Sarpy,,Douglas/Sarpy LCCC,6,,Jill Woodward,11402,6721,4561,120
+Sarpy,Precinct 11,Douglas/Sarpy LCCC,6,,Jill Woodward,44,20,24,0
+Sarpy,Precinct 12,Douglas/Sarpy LCCC,6,,Jill Woodward,190,106,81,3
+Sarpy,Precinct 19,Douglas/Sarpy LCCC,6,,Jill Woodward,372,170,198,4
+Sarpy,Precinct 21,Douglas/Sarpy LCCC,6,,Jill Woodward,379,203,171,5
+Sarpy,Precinct 22,Douglas/Sarpy LCCC,6,,Jill Woodward,253,159,90,4
+Sarpy,Precinct 23,Douglas/Sarpy LCCC,6,,Jill Woodward,497,247,246,4
+Sarpy,Precinct 24,Douglas/Sarpy LCCC,6,,Jill Woodward,2,1,1,0
+Sarpy,Precinct 31,Douglas/Sarpy LCCC,6,,Jill Woodward,714,454,255,5
+Sarpy,Precinct 32,Douglas/Sarpy LCCC,6,,Jill Woodward,292,188,99,5
+Sarpy,Precinct 33,Douglas/Sarpy LCCC,6,,Jill Woodward,382,237,136,9
+Sarpy,Precinct 34,Douglas/Sarpy LCCC,6,,Jill Woodward,512,335,173,4
+Sarpy,Precinct 35,Douglas/Sarpy LCCC,6,,Jill Woodward,422,294,125,3
+Sarpy,Precinct 36,Douglas/Sarpy LCCC,6,,Jill Woodward,365,200,165,0
+Sarpy,Precinct 37,Douglas/Sarpy LCCC,6,,Jill Woodward,680,386,287,7
+Sarpy,Precinct 38,Douglas/Sarpy LCCC,6,,Jill Woodward,424,297,123,4
+Sarpy,Precinct 39,Douglas/Sarpy LCCC,6,,Jill Woodward,426,240,184,2
+Sarpy,Precinct 40,Douglas/Sarpy LCCC,6,,Jill Woodward,425,256,163,6
+Sarpy,Precinct 41,Douglas/Sarpy LCCC,6,,Jill Woodward,514,267,241,6
+Sarpy,Precinct 42,Douglas/Sarpy LCCC,6,,Jill Woodward,396,224,168,4
+Sarpy,Precinct 46,Douglas/Sarpy LCCC,6,,Jill Woodward,227,131,96,0
+Sarpy,Precinct 47,Douglas/Sarpy LCCC,6,,Jill Woodward,194,139,50,5
+Sarpy,Precinct 48,Douglas/Sarpy LCCC,6,,Jill Woodward,462,241,217,4
+Sarpy,Precinct 49,Douglas/Sarpy LCCC,6,,Jill Woodward,528,292,229,7
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,6,,Jill Woodward,214,132,81,1
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,6,,Jill Woodward,438,218,214,6
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,6,,Jill Woodward,115,62,51,2
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,6,,Jill Woodward,0,0,0,0
+Sarpy,Precinct 58,Douglas/Sarpy LCCC,6,,Jill Woodward,249,178,70,1
+Sarpy,Precinct 59,Douglas/Sarpy LCCC,6,,Jill Woodward,319,223,95,1
+Sarpy,Precinct 60,Douglas/Sarpy LCCC,6,,Jill Woodward,271,183,88,0
+Sarpy,Precinct 61,Douglas/Sarpy LCCC,6,,Jill Woodward,664,375,279,10
+Sarpy,Precinct 62,Douglas/Sarpy LCCC,6,,Jill Woodward,432,263,161,8
+Sarpy,,Douglas/Sarpy LCCC,6,,WRITE-IN,234,157,74,3
+Sarpy,Precinct 11,Douglas/Sarpy LCCC,6,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 12,Douglas/Sarpy LCCC,6,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 19,Douglas/Sarpy LCCC,6,,WRITE-IN,6,2,4,0
+Sarpy,Precinct 21,Douglas/Sarpy LCCC,6,,WRITE-IN,6,2,3,1
+Sarpy,Precinct 22,Douglas/Sarpy LCCC,6,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 23,Douglas/Sarpy LCCC,6,,WRITE-IN,15,8,7,0
+Sarpy,Precinct 24,Douglas/Sarpy LCCC,6,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 31,Douglas/Sarpy LCCC,6,,WRITE-IN,17,12,5,0
+Sarpy,Precinct 32,Douglas/Sarpy LCCC,6,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 33,Douglas/Sarpy LCCC,6,,WRITE-IN,10,8,2,0
+Sarpy,Precinct 34,Douglas/Sarpy LCCC,6,,WRITE-IN,6,2,3,1
+Sarpy,Precinct 35,Douglas/Sarpy LCCC,6,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 36,Douglas/Sarpy LCCC,6,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 37,Douglas/Sarpy LCCC,6,,WRITE-IN,18,16,2,0
+Sarpy,Precinct 38,Douglas/Sarpy LCCC,6,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 39,Douglas/Sarpy LCCC,6,,WRITE-IN,14,12,2,0
+Sarpy,Precinct 40,Douglas/Sarpy LCCC,6,,WRITE-IN,15,10,5,0
+Sarpy,Precinct 41,Douglas/Sarpy LCCC,6,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 42,Douglas/Sarpy LCCC,6,,WRITE-IN,7,2,5,0
+Sarpy,Precinct 46,Douglas/Sarpy LCCC,6,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 47,Douglas/Sarpy LCCC,6,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 48,Douglas/Sarpy LCCC,6,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 49,Douglas/Sarpy LCCC,6,,WRITE-IN,11,9,1,1
+Sarpy,Precinct 51,Douglas/Sarpy LCCC,6,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 52,Douglas/Sarpy LCCC,6,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 55,Douglas/Sarpy LCCC,6,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 57,Douglas/Sarpy LCCC,6,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 58,Douglas/Sarpy LCCC,6,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 59,Douglas/Sarpy LCCC,6,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 60,Douglas/Sarpy LCCC,6,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 61,Douglas/Sarpy LCCC,6,,WRITE-IN,13,8,5,0
+Sarpy,Precinct 62,Douglas/Sarpy LCCC,6,,WRITE-IN,7,7,0,0
+Sarpy,,Dir Papio NRD,9,,Patrick Bonnett,2575,1451,1106,18
+Sarpy,Precinct 51,Dir Papio NRD,9,,Patrick Bonnett,782,475,302,5
+Sarpy,Precinct 52,Dir Papio NRD,9,,Patrick Bonnett,687,356,327,4
+Sarpy,Precinct 54,Dir Papio NRD,9,,Patrick Bonnett,608,327,273,8
+Sarpy,Precinct 56,Dir Papio NRD,9,,Patrick Bonnett,498,293,204,1
+Sarpy,,Dir Papio NRD,9,,Mark Gruenewald,2848,1787,1036,25
+Sarpy,Precinct 51,Dir Papio NRD,9,,Mark Gruenewald,806,525,277,4
+Sarpy,Precinct 52,Dir Papio NRD,9,,Mark Gruenewald,848,520,313,15
+Sarpy,Precinct 54,Dir Papio NRD,9,,Mark Gruenewald,686,398,283,5
+Sarpy,Precinct 56,Dir Papio NRD,9,,Mark Gruenewald,508,344,163,1
+Sarpy,,Dir Papio NRD,9,,WRITE-IN,78,50,27,1
+Sarpy,Precinct 51,Dir Papio NRD,9,,WRITE-IN,29,17,12,0
+Sarpy,Precinct 52,Dir Papio NRD,9,,WRITE-IN,18,11,7,0
+Sarpy,Precinct 54,Dir Papio NRD,9,,WRITE-IN,17,13,4,0
+Sarpy,Precinct 56,Dir Papio NRD,9,,WRITE-IN,14,9,4,1
+Sarpy,,Dir Papio NRD,11,,Ron Woodle,10846,6438,4290,118
+Sarpy,Precinct 1,Dir Papio NRD,11,,Ron Woodle,315,214,99,2
+Sarpy,Precinct 2,Dir Papio NRD,11,,Ron Woodle,420,297,120,3
+Sarpy,Precinct 3,Dir Papio NRD,11,,Ron Woodle,516,295,209,12
+Sarpy,Precinct 4,Dir Papio NRD,11,,Ron Woodle,513,334,177,2
+Sarpy,Precinct 5,Dir Papio NRD,11,,Ron Woodle,444,240,201,3
+Sarpy,Precinct 6,Dir Papio NRD,11,,Ron Woodle,522,352,167,3
+Sarpy,Precinct 7,Dir Papio NRD,11,,Ron Woodle,521,313,196,12
+Sarpy,Precinct 8,Dir Papio NRD,11,,Ron Woodle,405,243,162,0
+Sarpy,Precinct 9,Dir Papio NRD,11,,Ron Woodle,495,356,131,8
+Sarpy,Precinct 10,Dir Papio NRD,11,,Ron Woodle,349,250,93,6
+Sarpy,Precinct 11,Dir Papio NRD,11,,Ron Woodle,641,357,279,5
+Sarpy,Precinct 12,Dir Papio NRD,11,,Ron Woodle,512,308,196,8
+Sarpy,Precinct 13,Dir Papio NRD,11,,Ron Woodle,749,390,354,5
+Sarpy,Precinct 17,Dir Papio NRD,11,,Ron Woodle,466,265,198,3
+Sarpy,Precinct 18,Dir Papio NRD,11,,Ron Woodle,424,289,134,1
+Sarpy,Precinct 20,Dir Papio NRD,11,,Ron Woodle,511,276,231,4
+Sarpy,Precinct 21,Dir Papio NRD,11,,Ron Woodle,761,387,366,8
+Sarpy,Precinct 22,Dir Papio NRD,11,,Ron Woodle,472,277,186,9
+Sarpy,Precinct 23,Dir Papio NRD,11,,Ron Woodle,676,331,337,8
+Sarpy,Precinct 24,Dir Papio NRD,11,,Ron Woodle,325,185,138,2
+Sarpy,Precinct 25,Dir Papio NRD,11,,Ron Woodle,393,231,154,8
+Sarpy,Precinct 26,Dir Papio NRD,11,,Ron Woodle,416,248,162,6
+Sarpy,,Dir Papio NRD,11,,John B. Wiese,11970,7515,4280,175
+Sarpy,Precinct 1,Dir Papio NRD,11,,John B. Wiese,461,308,145,8
+Sarpy,Precinct 2,Dir Papio NRD,11,,John B. Wiese,363,262,96,5
+Sarpy,Precinct 3,Dir Papio NRD,11,,John B. Wiese,610,349,255,6
+Sarpy,Precinct 4,Dir Papio NRD,11,,John B. Wiese,495,339,147,9
+Sarpy,Precinct 5,Dir Papio NRD,11,,John B. Wiese,403,246,149,8
+Sarpy,Precinct 6,Dir Papio NRD,11,,John B. Wiese,538,365,157,16
+Sarpy,Precinct 7,Dir Papio NRD,11,,John B. Wiese,453,280,163,10
+Sarpy,Precinct 8,Dir Papio NRD,11,,John B. Wiese,469,316,145,8
+Sarpy,Precinct 9,Dir Papio NRD,11,,John B. Wiese,468,329,132,7
+Sarpy,Precinct 10,Dir Papio NRD,11,,John B. Wiese,362,269,87,6
+Sarpy,Precinct 11,Dir Papio NRD,11,,John B. Wiese,714,396,312,6
+Sarpy,Precinct 12,Dir Papio NRD,11,,John B. Wiese,647,430,210,7
+Sarpy,Precinct 13,Dir Papio NRD,11,,John B. Wiese,530,318,199,13
+Sarpy,Precinct 17,Dir Papio NRD,11,,John B. Wiese,652,422,220,10
+Sarpy,Precinct 18,Dir Papio NRD,11,,John B. Wiese,474,292,178,4
+Sarpy,Precinct 20,Dir Papio NRD,11,,John B. Wiese,719,458,256,5
+Sarpy,Precinct 21,Dir Papio NRD,11,,John B. Wiese,749,394,350,5
+Sarpy,Precinct 22,Dir Papio NRD,11,,John B. Wiese,622,408,211,3
+Sarpy,Precinct 23,Dir Papio NRD,11,,John B. Wiese,777,385,375,17
+Sarpy,Precinct 24,Dir Papio NRD,11,,John B. Wiese,423,263,156,4
+Sarpy,Precinct 25,Dir Papio NRD,11,,John B. Wiese,429,285,135,9
+Sarpy,Precinct 26,Dir Papio NRD,11,,John B. Wiese,612,401,202,9
+Sarpy,,Dir Papio NRD,11,,WRITE-IN,195,130,62,3
+Sarpy,Precinct 1,Dir Papio NRD,11,,WRITE-IN,14,11,3,0
+Sarpy,Precinct 2,Dir Papio NRD,11,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 3,Dir Papio NRD,11,,WRITE-IN,14,11,3,0
+Sarpy,Precinct 4,Dir Papio NRD,11,,WRITE-IN,7,2,5,0
+Sarpy,Precinct 5,Dir Papio NRD,11,,WRITE-IN,9,6,3,0
+Sarpy,Precinct 6,Dir Papio NRD,11,,WRITE-IN,7,3,4,0
+Sarpy,Precinct 7,Dir Papio NRD,11,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 8,Dir Papio NRD,11,,WRITE-IN,10,6,3,1
+Sarpy,Precinct 9,Dir Papio NRD,11,,WRITE-IN,7,6,1,0
+Sarpy,Precinct 10,Dir Papio NRD,11,,WRITE-IN,9,5,4,0
+Sarpy,Precinct 11,Dir Papio NRD,11,,WRITE-IN,10,9,1,0
+Sarpy,Precinct 12,Dir Papio NRD,11,,WRITE-IN,12,7,5,0
+Sarpy,Precinct 13,Dir Papio NRD,11,,WRITE-IN,8,7,1,0
+Sarpy,Precinct 17,Dir Papio NRD,11,,WRITE-IN,7,6,0,1
+Sarpy,Precinct 18,Dir Papio NRD,11,,WRITE-IN,10,5,5,0
+Sarpy,Precinct 20,Dir Papio NRD,11,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 21,Dir Papio NRD,11,,WRITE-IN,11,5,5,1
+Sarpy,Precinct 22,Dir Papio NRD,11,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 23,Dir Papio NRD,11,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 24,Dir Papio NRD,11,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 25,Dir Papio NRD,11,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 26,Dir Papio NRD,11,,WRITE-IN,12,8,4,0
+Sarpy,,Dir OPPD,4,,Fred J. Ulrich,11059,6508,4430,121
+Sarpy,Precinct 11,Dir OPPD,4,,Fred J. Ulrich,658,362,288,8
+Sarpy,Precinct 12,Dir OPPD,4,,Fred J. Ulrich,467,269,190,8
+Sarpy,Precinct 24,Dir OPPD,4,,Fred J. Ulrich,369,211,157,1
+Sarpy,Precinct 26,Dir OPPD,4,,Fred J. Ulrich,430,250,172,8
+Sarpy,Precinct 31,Dir OPPD,4,,Fred J. Ulrich,856,544,302,10
+Sarpy,Precinct 46,Dir OPPD,4,,Fred J. Ulrich,404,225,178,1
+Sarpy,Precinct 47,Dir OPPD,4,,Fred J. Ulrich,268,194,70,4
+Sarpy,Precinct 48,Dir OPPD,4,,Fred J. Ulrich,627,307,315,5
+Sarpy,Precinct 49,Dir OPPD,4,,Fred J. Ulrich,619,330,283,6
+Sarpy,Precinct 52,Dir OPPD,4,,Fred J. Ulrich,746,399,337,10
+Sarpy,Precinct 53,Dir OPPD,4,,Fred J. Ulrich,652,330,316,6
+Sarpy,Precinct 54,Dir OPPD,4,,Fred J. Ulrich,580,312,259,9
+Sarpy,Precinct 55,Dir OPPD,4,,Fred J. Ulrich,806,531,267,8
+Sarpy,Precinct 56,Dir OPPD,4,,Fred J. Ulrich,490,283,205,2
+Sarpy,Precinct 57,Dir OPPD,4,,Fred J. Ulrich,481,326,152,3
+Sarpy,Precinct 58,Dir OPPD,4,,Fred J. Ulrich,366,247,114,5
+Sarpy,Precinct 59,Dir OPPD,4,,Fred J. Ulrich,434,296,137,1
+Sarpy,Precinct 60,Dir OPPD,4,,Fred J. Ulrich,381,270,109,2
+Sarpy,Precinct 61,Dir OPPD,4,,Fred J. Ulrich,920,511,397,12
+Sarpy,Precinct 62,Dir OPPD,4,,Fred J. Ulrich,505,311,182,12
+Sarpy,,Dir OPPD,4,,Rick Yoder,13383,8183,5091,109
+Sarpy,Precinct 11,Dir OPPD,4,,Rick Yoder,766,431,331,4
+Sarpy,Precinct 12,Dir OPPD,4,,Rick Yoder,776,509,259,8
+Sarpy,Precinct 24,Dir OPPD,4,,Rick Yoder,390,235,150,5
+Sarpy,Precinct 26,Dir OPPD,4,,Rick Yoder,642,417,218,7
+Sarpy,Precinct 31,Dir OPPD,4,,Rick Yoder,967,585,372,10
+Sarpy,Precinct 46,Dir OPPD,4,,Rick Yoder,446,297,149,0
+Sarpy,Precinct 47,Dir OPPD,4,,Rick Yoder,372,294,76,2
+Sarpy,Precinct 48,Dir OPPD,4,,Rick Yoder,727,356,367,4
+Sarpy,Precinct 49,Dir OPPD,4,,Rick Yoder,744,394,341,9
+Sarpy,Precinct 52,Dir OPPD,4,,Rick Yoder,911,539,362,10
+Sarpy,Precinct 53,Dir OPPD,4,,Rick Yoder,802,476,315,11
+Sarpy,Precinct 54,Dir OPPD,4,,Rick Yoder,795,454,337,4
+Sarpy,Precinct 55,Dir OPPD,4,,Rick Yoder,825,506,311,8
+Sarpy,Precinct 56,Dir OPPD,4,,Rick Yoder,601,401,200,0
+Sarpy,Precinct 57,Dir OPPD,4,,Rick Yoder,507,337,165,5
+Sarpy,Precinct 58,Dir OPPD,4,,Rick Yoder,423,291,131,1
+Sarpy,Precinct 59,Dir OPPD,4,,Rick Yoder,517,350,163,4
+Sarpy,Precinct 60,Dir OPPD,4,,Rick Yoder,503,347,155,1
+Sarpy,Precinct 61,Dir OPPD,4,,Rick Yoder,1042,584,450,8
+Sarpy,Precinct 62,Dir OPPD,4,,Rick Yoder,627,380,239,8
+Sarpy,,Dir OPPD,4,,WRITE-IN,176,127,46,3
+Sarpy,Precinct 11,Dir OPPD,4,,WRITE-IN,6,6,0,0
+Sarpy,Precinct 12,Dir OPPD,4,,WRITE-IN,12,9,3,0
+Sarpy,Precinct 24,Dir OPPD,4,,WRITE-IN,7,4,3,0
+Sarpy,Precinct 26,Dir OPPD,4,,WRITE-IN,9,5,4,0
+Sarpy,Precinct 31,Dir OPPD,4,,WRITE-IN,13,9,4,0
+Sarpy,Precinct 46,Dir OPPD,4,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 47,Dir OPPD,4,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 48,Dir OPPD,4,,WRITE-IN,8,5,3,0
+Sarpy,Precinct 49,Dir OPPD,4,,WRITE-IN,10,8,1,1
+Sarpy,Precinct 52,Dir OPPD,4,,WRITE-IN,13,11,1,1
+Sarpy,Precinct 53,Dir OPPD,4,,WRITE-IN,10,8,2,0
+Sarpy,Precinct 54,Dir OPPD,4,,WRITE-IN,10,8,2,0
+Sarpy,Precinct 55,Dir OPPD,4,,WRITE-IN,14,10,4,0
+Sarpy,Precinct 56,Dir OPPD,4,,WRITE-IN,14,8,5,1
+Sarpy,Precinct 57,Dir OPPD,4,,WRITE-IN,10,5,5,0
+Sarpy,Precinct 58,Dir OPPD,4,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 59,Dir OPPD,4,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 60,Dir OPPD,4,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 61,Dir OPPD,4,,WRITE-IN,13,10,3,0
+Sarpy,Precinct 62,Dir OPPD,4,,WRITE-IN,8,7,1,0
+Sarpy,,Dir MUD At-Lg,,,Jack Frost,18275,11557,6534,184
+Sarpy,Precinct 1,Dir MUD At-Lg,,,Jack Frost,344,226,116,2
+Sarpy,Precinct 2,Dir MUD At-Lg,,,Jack Frost,369,266,101,2
+Sarpy,Precinct 3,Dir MUD At-Lg,,,Jack Frost,578,345,223,10
+Sarpy,Precinct 4,Dir MUD At-Lg,,,Jack Frost,483,334,144,5
+Sarpy,Precinct 5,Dir MUD At-Lg,,,Jack Frost,432,262,165,5
+Sarpy,Precinct 6,Dir MUD At-Lg,,,Jack Frost,482,334,140,8
+Sarpy,Precinct 7,Dir MUD At-Lg,,,Jack Frost,441,264,168,9
+Sarpy,Precinct 8,Dir MUD At-Lg,,,Jack Frost,433,269,159,5
+Sarpy,Precinct 9,Dir MUD At-Lg,,,Jack Frost,454,330,122,2
+Sarpy,Precinct 10,Dir MUD At-Lg,,,Jack Frost,334,256,74,4
+Sarpy,Precinct 11,Dir MUD At-Lg,,,Jack Frost,644,372,268,4
+Sarpy,Precinct 12,Dir MUD At-Lg,,,Jack Frost,425,291,129,5
+Sarpy,Precinct 13,Dir MUD At-Lg,,,Jack Frost,518,288,224,6
+Sarpy,Precinct 16,Dir MUD At-Lg,,,Jack Frost,541,314,226,1
+Sarpy,Precinct 17,Dir MUD At-Lg,,,Jack Frost,521,310,208,3
+Sarpy,Precinct 18,Dir MUD At-Lg,,,Jack Frost,409,266,141,2
+Sarpy,Precinct 19,Dir MUD At-Lg,,,Jack Frost,332,150,175,7
+Sarpy,Precinct 20,Dir MUD At-Lg,,,Jack Frost,531,321,204,6
+Sarpy,Precinct 21,Dir MUD At-Lg,,,Jack Frost,687,369,314,4
+Sarpy,Precinct 22,Dir MUD At-Lg,,,Jack Frost,569,365,198,6
+Sarpy,Precinct 24,Dir MUD At-Lg,,,Jack Frost,366,216,149,1
+Sarpy,Precinct 25,Dir MUD At-Lg,,,Jack Frost,406,260,141,5
+Sarpy,Precinct 26,Dir MUD At-Lg,,,Jack Frost,501,329,161,11
+Sarpy,Precinct 31,Dir MUD At-Lg,,,Jack Frost,804,502,288,14
+Sarpy,Precinct 32,Dir MUD At-Lg,,,Jack Frost,369,256,111,2
+Sarpy,Precinct 33,Dir MUD At-Lg,,,Jack Frost,444,272,165,7
+Sarpy,Precinct 34,Dir MUD At-Lg,,,Jack Frost,529,352,175,2
+Sarpy,Precinct 35,Dir MUD At-Lg,,,Jack Frost,438,295,141,2
+Sarpy,Precinct 41,Dir MUD At-Lg,,,Jack Frost,32,6,26,0
+Sarpy,Precinct 46,Dir MUD At-Lg,,,Jack Frost,15,10,5,0
+Sarpy,Precinct 47,Dir MUD At-Lg,,,Jack Frost,308,244,60,4
+Sarpy,Precinct 48,Dir MUD At-Lg,,,Jack Frost,0,0,0,0
+Sarpy,Precinct 51,Dir MUD At-Lg,,,Jack Frost,642,434,204,4
+Sarpy,Precinct 52,Dir MUD At-Lg,,,Jack Frost,649,383,259,7
+Sarpy,Precinct 53,Dir MUD At-Lg,,,Jack Frost,696,407,281,8
+Sarpy,Precinct 54,Dir MUD At-Lg,,,Jack Frost,672,387,278,7
+Sarpy,Precinct 55,Dir MUD At-Lg,,,Jack Frost,691,475,212,4
+Sarpy,Precinct 56,Dir MUD At-Lg,,,Jack Frost,514,350,163,1
+Sarpy,Precinct 57,Dir MUD At-Lg,,,Jack Frost,509,338,164,7
+Sarpy,Precinct 61,Dir MUD At-Lg,,,Jack Frost,67,42,24,1
+Sarpy,Precinct 62,Dir MUD At-Lg,,,Jack Frost,96,67,28,1
+Sarpy,,Dir MUD At-Lg,,,Krystal Gabel,17496,10459,6852,185
+Sarpy,Precinct 1,Dir MUD At-Lg,,,Krystal Gabel,347,217,124,6
+Sarpy,Precinct 2,Dir MUD At-Lg,,,Krystal Gabel,348,236,108,4
+Sarpy,Precinct 3,Dir MUD At-Lg,,,Krystal Gabel,543,290,245,8
+Sarpy,Precinct 4,Dir MUD At-Lg,,,Krystal Gabel,484,309,169,6
+Sarpy,Precinct 5,Dir MUD At-Lg,,,Krystal Gabel,392,220,168,4
+Sarpy,Precinct 6,Dir MUD At-Lg,,,Krystal Gabel,513,331,174,8
+Sarpy,Precinct 7,Dir MUD At-Lg,,,Krystal Gabel,443,258,176,9
+Sarpy,Precinct 8,Dir MUD At-Lg,,,Krystal Gabel,408,244,162,2
+Sarpy,Precinct 9,Dir MUD At-Lg,,,Krystal Gabel,442,301,135,6
+Sarpy,Precinct 10,Dir MUD At-Lg,,,Krystal Gabel,323,211,106,6
+Sarpy,Precinct 11,Dir MUD At-Lg,,,Krystal Gabel,556,307,245,4
+Sarpy,Precinct 12,Dir MUD At-Lg,,,Krystal Gabel,404,271,127,6
+Sarpy,Precinct 13,Dir MUD At-Lg,,,Krystal Gabel,532,279,243,10
+Sarpy,Precinct 16,Dir MUD At-Lg,,,Krystal Gabel,514,305,209,0
+Sarpy,Precinct 17,Dir MUD At-Lg,,,Krystal Gabel,471,264,203,4
+Sarpy,Precinct 18,Dir MUD At-Lg,,,Krystal Gabel,409,239,168,2
+Sarpy,Precinct 19,Dir MUD At-Lg,,,Krystal Gabel,342,164,169,9
+Sarpy,Precinct 20,Dir MUD At-Lg,,,Krystal Gabel,594,346,243,5
+Sarpy,Precinct 21,Dir MUD At-Lg,,,Krystal Gabel,642,338,296,8
+Sarpy,Precinct 22,Dir MUD At-Lg,,,Krystal Gabel,517,319,195,3
+Sarpy,Precinct 24,Dir MUD At-Lg,,,Krystal Gabel,312,189,120,3
+Sarpy,Precinct 25,Dir MUD At-Lg,,,Krystal Gabel,382,222,153,7
+Sarpy,Precinct 26,Dir MUD At-Lg,,,Krystal Gabel,470,285,179,6
+Sarpy,Precinct 31,Dir MUD At-Lg,,,Krystal Gabel,733,445,282,6
+Sarpy,Precinct 32,Dir MUD At-Lg,,,Krystal Gabel,376,236,137,3
+Sarpy,Precinct 33,Dir MUD At-Lg,,,Krystal Gabel,525,315,199,11
+Sarpy,Precinct 34,Dir MUD At-Lg,,,Krystal Gabel,563,346,216,1
+Sarpy,Precinct 35,Dir MUD At-Lg,,,Krystal Gabel,427,270,156,1
+Sarpy,Precinct 41,Dir MUD At-Lg,,,Krystal Gabel,20,4,16,0
+Sarpy,Precinct 46,Dir MUD At-Lg,,,Krystal Gabel,16,11,5,0
+Sarpy,Precinct 47,Dir MUD At-Lg,,,Krystal Gabel,266,202,63,1
+Sarpy,Precinct 48,Dir MUD At-Lg,,,Krystal Gabel,1,1,0,0
+Sarpy,Precinct 51,Dir MUD At-Lg,,,Krystal Gabel,562,365,191,6
+Sarpy,Precinct 52,Dir MUD At-Lg,,,Krystal Gabel,596,345,246,5
+Sarpy,Precinct 53,Dir MUD At-Lg,,,Krystal Gabel,624,334,283,7
+Sarpy,Precinct 54,Dir MUD At-Lg,,,Krystal Gabel,623,328,293,2
+Sarpy,Precinct 55,Dir MUD At-Lg,,,Krystal Gabel,691,433,246,12
+Sarpy,Precinct 56,Dir MUD At-Lg,,,Krystal Gabel,469,285,184,0
+Sarpy,Precinct 57,Dir MUD At-Lg,,,Krystal Gabel,443,288,153,2
+Sarpy,Precinct 61,Dir MUD At-Lg,,,Krystal Gabel,85,54,31,0
+Sarpy,Precinct 62,Dir MUD At-Lg,,,Krystal Gabel,88,52,34,2
+Sarpy,,Dir MUD At-Lg,,,Mike McGowan,16493,9832,6519,142
+Sarpy,Precinct 1,Dir MUD At-Lg,,,Mike McGowan,269,178,89,2
+Sarpy,Precinct 2,Dir MUD At-Lg,,,Mike McGowan,326,235,86,5
+Sarpy,Precinct 3,Dir MUD At-Lg,,,Mike McGowan,479,270,203,6
+Sarpy,Precinct 4,Dir MUD At-Lg,,,Mike McGowan,426,258,162,6
+Sarpy,Precinct 5,Dir MUD At-Lg,,,Mike McGowan,375,198,175,2
+Sarpy,Precinct 6,Dir MUD At-Lg,,,Mike McGowan,410,281,125,4
+Sarpy,Precinct 7,Dir MUD At-Lg,,,Mike McGowan,369,227,137,5
+Sarpy,Precinct 8,Dir MUD At-Lg,,,Mike McGowan,414,266,144,4
+Sarpy,Precinct 9,Dir MUD At-Lg,,,Mike McGowan,354,246,103,5
+Sarpy,Precinct 10,Dir MUD At-Lg,,,Mike McGowan,259,187,67,5
+Sarpy,Precinct 11,Dir MUD At-Lg,,,Mike McGowan,578,320,255,3
+Sarpy,Precinct 12,Dir MUD At-Lg,,,Mike McGowan,361,239,121,1
+Sarpy,Precinct 13,Dir MUD At-Lg,,,Mike McGowan,555,293,255,7
+Sarpy,Precinct 16,Dir MUD At-Lg,,,Mike McGowan,433,240,190,3
+Sarpy,Precinct 17,Dir MUD At-Lg,,,Mike McGowan,447,247,196,4
+Sarpy,Precinct 18,Dir MUD At-Lg,,,Mike McGowan,346,217,126,3
+Sarpy,Precinct 19,Dir MUD At-Lg,,,Mike McGowan,347,157,188,2
+Sarpy,Precinct 20,Dir MUD At-Lg,,,Mike McGowan,495,299,194,2
+Sarpy,Precinct 21,Dir MUD At-Lg,,,Mike McGowan,713,346,360,7
+Sarpy,Precinct 22,Dir MUD At-Lg,,,Mike McGowan,428,259,167,2
+Sarpy,Precinct 24,Dir MUD At-Lg,,,Mike McGowan,268,145,122,1
+Sarpy,Precinct 25,Dir MUD At-Lg,,,Mike McGowan,359,225,126,8
+Sarpy,Precinct 26,Dir MUD At-Lg,,,Mike McGowan,479,287,189,3
+Sarpy,Precinct 31,Dir MUD At-Lg,,,Mike McGowan,822,486,329,7
+Sarpy,Precinct 32,Dir MUD At-Lg,,,Mike McGowan,375,221,150,4
+Sarpy,Precinct 33,Dir MUD At-Lg,,,Mike McGowan,487,281,200,6
+Sarpy,Precinct 34,Dir MUD At-Lg,,,Mike McGowan,514,308,204,2
+Sarpy,Precinct 35,Dir MUD At-Lg,,,Mike McGowan,435,287,147,1
+Sarpy,Precinct 41,Dir MUD At-Lg,,,Mike McGowan,18,2,16,0
+Sarpy,Precinct 46,Dir MUD At-Lg,,,Mike McGowan,25,22,3,0
+Sarpy,Precinct 47,Dir MUD At-Lg,,,Mike McGowan,245,175,67,3
+Sarpy,Precinct 48,Dir MUD At-Lg,,,Mike McGowan,1,1,0,0
+Sarpy,Precinct 51,Dir MUD At-Lg,,,Mike McGowan,621,398,220,3
+Sarpy,Precinct 52,Dir MUD At-Lg,,,Mike McGowan,581,321,253,7
+Sarpy,Precinct 53,Dir MUD At-Lg,,,Mike McGowan,596,321,268,7
+Sarpy,Precinct 54,Dir MUD At-Lg,,,Mike McGowan,591,308,279,4
+Sarpy,Precinct 55,Dir MUD At-Lg,,,Mike McGowan,703,439,259,5
+Sarpy,Precinct 56,Dir MUD At-Lg,,,Mike McGowan,447,273,172,2
+Sarpy,Precinct 57,Dir MUD At-Lg,,,Mike McGowan,401,270,131,0
+Sarpy,Precinct 61,Dir MUD At-Lg,,,Mike McGowan,75,56,19,0
+Sarpy,Precinct 62,Dir MUD At-Lg,,,Mike McGowan,66,43,22,1
+Sarpy,,Dir MUD At-Lg,,,Tom Wurtz,15781,9254,6388,139
+Sarpy,Precinct 1,Dir MUD At-Lg,,,Tom Wurtz,347,230,112,5
+Sarpy,Precinct 2,Dir MUD At-Lg,,,Tom Wurtz,322,212,109,1
+Sarpy,Precinct 3,Dir MUD At-Lg,,,Tom Wurtz,422,237,181,4
+Sarpy,Precinct 4,Dir MUD At-Lg,,,Tom Wurtz,430,279,149,2
+Sarpy,Precinct 5,Dir MUD At-Lg,,,Tom Wurtz,320,171,147,2
+Sarpy,Precinct 6,Dir MUD At-Lg,,,Tom Wurtz,439,276,157,6
+Sarpy,Precinct 7,Dir MUD At-Lg,,,Tom Wurtz,417,232,178,7
+Sarpy,Precinct 8,Dir MUD At-Lg,,,Tom Wurtz,329,202,123,4
+Sarpy,Precinct 9,Dir MUD At-Lg,,,Tom Wurtz,350,249,96,5
+Sarpy,Precinct 10,Dir MUD At-Lg,,,Tom Wurtz,269,195,73,1
+Sarpy,Precinct 11,Dir MUD At-Lg,,,Tom Wurtz,470,227,240,3
+Sarpy,Precinct 12,Dir MUD At-Lg,,,Tom Wurtz,311,194,110,7
+Sarpy,Precinct 13,Dir MUD At-Lg,,,Tom Wurtz,576,304,265,7
+Sarpy,Precinct 16,Dir MUD At-Lg,,,Tom Wurtz,502,285,214,3
+Sarpy,Precinct 17,Dir MUD At-Lg,,,Tom Wurtz,518,339,175,4
+Sarpy,Precinct 18,Dir MUD At-Lg,,,Tom Wurtz,407,258,147,2
+Sarpy,Precinct 19,Dir MUD At-Lg,,,Tom Wurtz,392,178,207,7
+Sarpy,Precinct 20,Dir MUD At-Lg,,,Tom Wurtz,563,314,246,3
+Sarpy,Precinct 21,Dir MUD At-Lg,,,Tom Wurtz,620,293,323,4
+Sarpy,Precinct 22,Dir MUD At-Lg,,,Tom Wurtz,392,226,160,6
+Sarpy,Precinct 24,Dir MUD At-Lg,,,Tom Wurtz,286,153,129,4
+Sarpy,Precinct 25,Dir MUD At-Lg,,,Tom Wurtz,278,168,102,8
+Sarpy,Precinct 26,Dir MUD At-Lg,,,Tom Wurtz,366,214,148,4
+Sarpy,Precinct 31,Dir MUD At-Lg,,,Tom Wurtz,700,419,277,4
+Sarpy,Precinct 32,Dir MUD At-Lg,,,Tom Wurtz,447,248,197,2
+Sarpy,Precinct 33,Dir MUD At-Lg,,,Tom Wurtz,419,248,168,3
+Sarpy,Precinct 34,Dir MUD At-Lg,,,Tom Wurtz,473,304,164,5
+Sarpy,Precinct 35,Dir MUD At-Lg,,,Tom Wurtz,463,280,181,2
+Sarpy,Precinct 41,Dir MUD At-Lg,,,Tom Wurtz,22,5,17,0
+Sarpy,Precinct 46,Dir MUD At-Lg,,,Tom Wurtz,20,15,5,0
+Sarpy,Precinct 47,Dir MUD At-Lg,,,Tom Wurtz,211,163,48,0
+Sarpy,Precinct 48,Dir MUD At-Lg,,,Tom Wurtz,0,0,0,0
+Sarpy,Precinct 51,Dir MUD At-Lg,,,Tom Wurtz,538,335,201,2
+Sarpy,Precinct 52,Dir MUD At-Lg,,,Tom Wurtz,593,320,269,4
+Sarpy,Precinct 53,Dir MUD At-Lg,,,Tom Wurtz,529,281,242,6
+Sarpy,Precinct 54,Dir MUD At-Lg,,,Tom Wurtz,481,263,217,1
+Sarpy,Precinct 55,Dir MUD At-Lg,,,Tom Wurtz,635,378,249,8
+Sarpy,Precinct 56,Dir MUD At-Lg,,,Tom Wurtz,421,247,174,0
+Sarpy,Precinct 57,Dir MUD At-Lg,,,Tom Wurtz,359,233,126,0
+Sarpy,Precinct 61,Dir MUD At-Lg,,,Tom Wurtz,65,36,28,1
+Sarpy,Precinct 62,Dir MUD At-Lg,,,Tom Wurtz,79,43,34,2
+Sarpy,,Dir MUD At-Lg,,,WRITE-IN,414,263,140,11
+Sarpy,Precinct 1,Dir MUD At-Lg,,,WRITE-IN,18,12,6,0
+Sarpy,Precinct 2,Dir MUD At-Lg,,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 3,Dir MUD At-Lg,,,WRITE-IN,14,10,4,0
+Sarpy,Precinct 4,Dir MUD At-Lg,,,WRITE-IN,9,4,5,0
+Sarpy,Precinct 5,Dir MUD At-Lg,,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 6,Dir MUD At-Lg,,,WRITE-IN,7,5,1,1
+Sarpy,Precinct 7,Dir MUD At-Lg,,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 8,Dir MUD At-Lg,,,WRITE-IN,8,5,3,0
+Sarpy,Precinct 9,Dir MUD At-Lg,,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 10,Dir MUD At-Lg,,,WRITE-IN,12,7,5,0
+Sarpy,Precinct 11,Dir MUD At-Lg,,,WRITE-IN,8,8,0,0
+Sarpy,Precinct 12,Dir MUD At-Lg,,,WRITE-IN,12,10,2,0
+Sarpy,Precinct 13,Dir MUD At-Lg,,,WRITE-IN,11,8,3,0
+Sarpy,Precinct 16,Dir MUD At-Lg,,,WRITE-IN,12,5,7,0
+Sarpy,Precinct 17,Dir MUD At-Lg,,,WRITE-IN,18,13,2,3
+Sarpy,Precinct 18,Dir MUD At-Lg,,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 19,Dir MUD At-Lg,,,WRITE-IN,8,5,3,0
+Sarpy,Precinct 20,Dir MUD At-Lg,,,WRITE-IN,13,4,9,0
+Sarpy,Precinct 21,Dir MUD At-Lg,,,WRITE-IN,10,5,3,2
+Sarpy,Precinct 22,Dir MUD At-Lg,,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 24,Dir MUD At-Lg,,,WRITE-IN,14,6,8,0
+Sarpy,Precinct 25,Dir MUD At-Lg,,,WRITE-IN,16,10,6,0
+Sarpy,Precinct 26,Dir MUD At-Lg,,,WRITE-IN,13,8,5,0
+Sarpy,Precinct 31,Dir MUD At-Lg,,,WRITE-IN,17,12,5,0
+Sarpy,Precinct 32,Dir MUD At-Lg,,,WRITE-IN,8,3,5,0
+Sarpy,Precinct 33,Dir MUD At-Lg,,,WRITE-IN,14,13,1,0
+Sarpy,Precinct 34,Dir MUD At-Lg,,,WRITE-IN,12,5,5,2
+Sarpy,Precinct 35,Dir MUD At-Lg,,,WRITE-IN,14,7,7,0
+Sarpy,Precinct 41,Dir MUD At-Lg,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 46,Dir MUD At-Lg,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 47,Dir MUD At-Lg,,,WRITE-IN,2,0,2,0
+Sarpy,Precinct 48,Dir MUD At-Lg,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 51,Dir MUD At-Lg,,,WRITE-IN,14,10,4,0
+Sarpy,Precinct 52,Dir MUD At-Lg,,,WRITE-IN,11,9,0,2
+Sarpy,Precinct 53,Dir MUD At-Lg,,,WRITE-IN,9,9,0,0
+Sarpy,Precinct 54,Dir MUD At-Lg,,,WRITE-IN,12,9,3,0
+Sarpy,Precinct 55,Dir MUD At-Lg,,,WRITE-IN,20,14,6,0
+Sarpy,Precinct 56,Dir MUD At-Lg,,,WRITE-IN,15,8,6,1
+Sarpy,Precinct 57,Dir MUD At-Lg,,,WRITE-IN,12,5,7,0
+Sarpy,Precinct 61,Dir MUD At-Lg,,,WRITE-IN,2,2,0,0
+Sarpy,Precinct 62,Dir MUD At-Lg,,,WRITE-IN,1,0,1,0
+Sarpy,,ESU No. 2,4,,George J. Robertson,0,0,0,0
+Sarpy,Precinct 46,ESU No. 2,4,,George J. Robertson,0,0,0,0
+Sarpy,,ESU No. 2,4,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 46,ESU No. 2,4,,WRITE-IN,0,0,0,0
+Sarpy,,ESU No. 3,4,,Mary Scarborough,9582,5943,3548,91
+Sarpy,Precinct 19,ESU No. 3,4,,Mary Scarborough,15,6,9,0
+Sarpy,Precinct 31,ESU No. 3,4,,Mary Scarborough,1744,1097,625,22
+Sarpy,Precinct 32,ESU No. 3,4,,Mary Scarborough,872,556,308,8
+Sarpy,Precinct 33,ESU No. 3,4,,Mary Scarborough,1035,635,379,21
+Sarpy,Precinct 34,ESU No. 3,4,,Mary Scarborough,1197,768,420,9
+Sarpy,Precinct 35,ESU No. 3,4,,Mary Scarborough,994,641,349,4
+Sarpy,Precinct 36,ESU No. 3,4,,Mary Scarborough,1011,594,412,5
+Sarpy,Precinct 37,ESU No. 3,4,,Mary Scarborough,1648,955,681,12
+Sarpy,Precinct 38,ESU No. 3,4,,Mary Scarborough,1066,691,365,10
+Sarpy,,ESU No. 3,4,,WRITE-IN,123,85,36,2
+Sarpy,Precinct 19,ESU No. 3,4,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 31,ESU No. 3,4,,WRITE-IN,23,18,5,0
+Sarpy,Precinct 32,ESU No. 3,4,,WRITE-IN,15,6,8,1
+Sarpy,Precinct 33,ESU No. 3,4,,WRITE-IN,21,17,4,0
+Sarpy,Precinct 34,ESU No. 3,4,,WRITE-IN,15,9,5,1
+Sarpy,Precinct 35,ESU No. 3,4,,WRITE-IN,11,7,4,0
+Sarpy,Precinct 36,ESU No. 3,4,,WRITE-IN,11,10,1,0
+Sarpy,Precinct 37,ESU No. 3,4,,WRITE-IN,17,12,5,0
+Sarpy,Precinct 38,ESU No. 3,4,,WRITE-IN,10,6,4,0
+Sarpy,,ESU No. 3,6,,Alan Moore,8984,5023,3879,82
+Sarpy,Precinct 19,ESU No. 3,6,,Alan Moore,984,413,553,18
+Sarpy,Precinct 21,ESU No. 3,6,,Alan Moore,1398,738,649,11
+Sarpy,Precinct 39,ESU No. 3,6,,Alan Moore,1112,642,468,2
+Sarpy,Precinct 40,ESU No. 3,6,,Alan Moore,1031,645,376,10
+Sarpy,Precinct 41,ESU No. 3,6,,Alan Moore,1287,689,586,12
+Sarpy,Precinct 42,ESU No. 3,6,,Alan Moore,1110,618,484,8
+Sarpy,Precinct 56,ESU No. 3,6,,Alan Moore,956,610,343,3
+Sarpy,Precinct 57,ESU No. 3,6,,Alan Moore,458,282,172,4
+Sarpy,Precinct 62,ESU No. 3,6,,Alan Moore,648,386,248,14
+Sarpy,,ESU No. 3,6,,WRITE-IN,122,64,54,4
+Sarpy,Precinct 19,ESU No. 3,6,,WRITE-IN,14,2,10,2
+Sarpy,Precinct 21,ESU No. 3,6,,WRITE-IN,16,9,6,1
+Sarpy,Precinct 39,ESU No. 3,6,,WRITE-IN,13,10,3,0
+Sarpy,Precinct 40,ESU No. 3,6,,WRITE-IN,23,15,7,1
+Sarpy,Precinct 41,ESU No. 3,6,,WRITE-IN,14,7,7,0
+Sarpy,Precinct 42,ESU No. 3,6,,WRITE-IN,18,5,13,0
+Sarpy,Precinct 56,ESU No. 3,6,,WRITE-IN,10,7,3,0
+Sarpy,Precinct 57,ESU No. 3,6,,WRITE-IN,9,4,5,0
+Sarpy,Precinct 62,ESU No. 3,6,,WRITE-IN,5,5,0,0
+Sarpy,,ESU No. 3,8,,Ron Pearson,14601,9267,5127,207
+Sarpy,Precinct 2,ESU No. 3,8,,Ron Pearson,710,517,185,8
+Sarpy,Precinct 3,ESU No. 3,8,,Ron Pearson,1078,616,444,18
+Sarpy,Precinct 4,ESU No. 3,8,,Ron Pearson,908,604,291,13
+Sarpy,Precinct 5,ESU No. 3,8,,Ron Pearson,839,489,339,11
+Sarpy,Precinct 6,ESU No. 3,8,,Ron Pearson,993,668,308,17
+Sarpy,Precinct 7,ESU No. 3,8,,Ron Pearson,882,542,321,19
+Sarpy,Precinct 8,ESU No. 3,8,,Ron Pearson,830,539,283,8
+Sarpy,Precinct 9,ESU No. 3,8,,Ron Pearson,904,646,245,13
+Sarpy,Precinct 10,ESU No. 3,8,,Ron Pearson,655,478,166,11
+Sarpy,Precinct 11,ESU No. 3,8,,Ron Pearson,1155,668,477,10
+Sarpy,Precinct 12,ESU No. 3,8,,Ron Pearson,607,420,176,11
+Sarpy,Precinct 13,ESU No. 3,8,,Ron Pearson,1151,652,482,17
+Sarpy,Precinct 20,ESU No. 3,8,,Ron Pearson,370,214,155,1
+Sarpy,Precinct 22,ESU No. 3,8,,Ron Pearson,1041,656,373,12
+Sarpy,Precinct 24,ESU No. 3,8,,Ron Pearson,704,425,273,6
+Sarpy,Precinct 25,ESU No. 3,8,,Ron Pearson,775,499,258,18
+Sarpy,Precinct 26,ESU No. 3,8,,Ron Pearson,999,634,351,14
+Sarpy,,ESU No. 3,8,,WRITE-IN,252,169,79,4
+Sarpy,Precinct 2,ESU No. 3,8,,WRITE-IN,15,10,5,0
+Sarpy,Precinct 3,ESU No. 3,8,,WRITE-IN,21,13,8,0
+Sarpy,Precinct 4,ESU No. 3,8,,WRITE-IN,21,14,7,0
+Sarpy,Precinct 5,ESU No. 3,8,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 6,ESU No. 3,8,,WRITE-IN,11,9,2,0
+Sarpy,Precinct 7,ESU No. 3,8,,WRITE-IN,14,9,4,1
+Sarpy,Precinct 8,ESU No. 3,8,,WRITE-IN,14,10,3,1
+Sarpy,Precinct 9,ESU No. 3,8,,WRITE-IN,9,8,1,0
+Sarpy,Precinct 10,ESU No. 3,8,,WRITE-IN,20,12,7,1
+Sarpy,Precinct 11,ESU No. 3,8,,WRITE-IN,17,11,6,0
+Sarpy,Precinct 12,ESU No. 3,8,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 13,ESU No. 3,8,,WRITE-IN,17,15,2,0
+Sarpy,Precinct 20,ESU No. 3,8,,WRITE-IN,9,4,5,0
+Sarpy,Precinct 22,ESU No. 3,8,,WRITE-IN,20,15,5,0
+Sarpy,Precinct 24,ESU No. 3,8,,WRITE-IN,10,5,5,0
+Sarpy,Precinct 25,ESU No. 3,8,,WRITE-IN,19,13,6,0
+Sarpy,Precinct 26,ESU No. 3,8,,WRITE-IN,19,12,6,1
+Sarpy,,Ashland-Greenwood Sch,1,,Suzanne Sapp,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,Suzanne Sapp,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,David Nygren,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,David Nygren,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,Kevin Garner,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,Kevin Garner,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,Jerry Wall,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,Jerry Wall,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,Eric Beranek,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,Eric Beranek,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,Angela Greise,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,Angela Greise,0,0,0,0
+Sarpy,,Ashland-Greenwood Sch,1,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 46,Ashland-Greenwood Sch,1,,WRITE-IN,0,0,0,0
+Sarpy,,BPS Bd Member,,,John L. Carozza,5483,3478,1946,59
+Sarpy,Precinct 2,BPS Bd Member,,,John L. Carozza,254,185,65,4
+Sarpy,Precinct 3,BPS Bd Member,,,John L. Carozza,372,212,158,2
+Sarpy,Precinct 4,BPS Bd Member,,,John L. Carozza,291,185,104,2
+Sarpy,Precinct 5,BPS Bd Member,,,John L. Carozza,230,133,97,0
+Sarpy,Precinct 6,BPS Bd Member,,,John L. Carozza,321,225,93,3
+Sarpy,Precinct 7,BPS Bd Member,,,John L. Carozza,293,186,102,5
+Sarpy,Precinct 8,BPS Bd Member,,,John L. Carozza,386,248,132,6
+Sarpy,Precinct 9,BPS Bd Member,,,John L. Carozza,366,282,78,6
+Sarpy,Precinct 10,BPS Bd Member,,,John L. Carozza,266,205,53,8
+Sarpy,Precinct 11,BPS Bd Member,,,John L. Carozza,612,362,248,2
+Sarpy,Precinct 12,BPS Bd Member,,,John L. Carozza,286,185,97,4
+Sarpy,Precinct 13,BPS Bd Member,,,John L. Carozza,377,203,169,5
+Sarpy,Precinct 20,BPS Bd Member,,,John L. Carozza,127,73,54,0
+Sarpy,Precinct 21,BPS Bd Member,,,John L. Carozza,162,76,86,0
+Sarpy,Precinct 22,BPS Bd Member,,,John L. Carozza,135,90,45,0
+Sarpy,Precinct 24,BPS Bd Member,,,John L. Carozza,270,166,103,1
+Sarpy,Precinct 25,BPS Bd Member,,,John L. Carozza,298,178,114,6
+Sarpy,Precinct 26,BPS Bd Member,,,John L. Carozza,437,284,148,5
+Sarpy,,BPS Bd Member,,,Doug Cook,9153,5825,3214,114
+Sarpy,Precinct 2,BPS Bd Member,,,Doug Cook,505,372,130,3
+Sarpy,Precinct 3,BPS Bd Member,,,Doug Cook,664,382,275,7
+Sarpy,Precinct 4,BPS Bd Member,,,Doug Cook,617,411,200,6
+Sarpy,Precinct 5,BPS Bd Member,,,Doug Cook,499,293,201,5
+Sarpy,Precinct 6,BPS Bd Member,,,Doug Cook,643,431,202,10
+Sarpy,Precinct 7,BPS Bd Member,,,Doug Cook,526,335,181,10
+Sarpy,Precinct 8,BPS Bd Member,,,Doug Cook,535,363,166,6
+Sarpy,Precinct 9,BPS Bd Member,,,Doug Cook,601,430,165,6
+Sarpy,Precinct 10,BPS Bd Member,,,Doug Cook,436,327,101,8
+Sarpy,Precinct 11,BPS Bd Member,,,Doug Cook,709,404,299,6
+Sarpy,Precinct 12,BPS Bd Member,,,Doug Cook,380,259,113,8
+Sarpy,Precinct 13,BPS Bd Member,,,Doug Cook,792,471,312,9
+Sarpy,Precinct 20,BPS Bd Member,,,Doug Cook,190,108,81,1
+Sarpy,Precinct 21,BPS Bd Member,,,Doug Cook,246,132,111,3
+Sarpy,Precinct 22,BPS Bd Member,,,Doug Cook,259,150,106,3
+Sarpy,Precinct 24,BPS Bd Member,,,Doug Cook,432,254,173,5
+Sarpy,Precinct 25,BPS Bd Member,,,Doug Cook,483,307,163,13
+Sarpy,Precinct 26,BPS Bd Member,,,Doug Cook,636,396,235,5
+Sarpy,,BPS Bd Member,,,Sarah F. Centineo,7427,4334,3005,88
+Sarpy,Precinct 2,BPS Bd Member,,,Sarah F. Centineo,314,199,114,1
+Sarpy,Precinct 3,BPS Bd Member,,,Sarah F. Centineo,572,320,247,5
+Sarpy,Precinct 4,BPS Bd Member,,,Sarah F. Centineo,534,346,180,8
+Sarpy,Precinct 5,BPS Bd Member,,,Sarah F. Centineo,427,225,197,5
+Sarpy,Precinct 6,BPS Bd Member,,,Sarah F. Centineo,568,355,203,10
+Sarpy,Precinct 7,BPS Bd Member,,,Sarah F. Centineo,453,247,197,9
+Sarpy,Precinct 8,BPS Bd Member,,,Sarah F. Centineo,399,225,173,1
+Sarpy,Precinct 9,BPS Bd Member,,,Sarah F. Centineo,470,318,144,8
+Sarpy,Precinct 10,BPS Bd Member,,,Sarah F. Centineo,334,220,108,6
+Sarpy,Precinct 11,BPS Bd Member,,,Sarah F. Centineo,553,296,255,2
+Sarpy,Precinct 12,BPS Bd Member,,,Sarah F. Centineo,306,202,100,4
+Sarpy,Precinct 13,BPS Bd Member,,,Sarah F. Centineo,570,299,262,9
+Sarpy,Precinct 20,BPS Bd Member,,,Sarah F. Centineo,225,113,111,1
+Sarpy,Precinct 21,BPS Bd Member,,,Sarah F. Centineo,204,101,102,1
+Sarpy,Precinct 22,BPS Bd Member,,,Sarah F. Centineo,245,152,93,0
+Sarpy,Precinct 24,BPS Bd Member,,,Sarah F. Centineo,382,218,159,5
+Sarpy,Precinct 25,BPS Bd Member,,,Sarah F. Centineo,377,213,158,6
+Sarpy,Precinct 26,BPS Bd Member,,,Sarah F. Centineo,494,285,202,7
+Sarpy,,BPS Bd Member,,,Phil Davidson,6772,4071,2631,70
+Sarpy,Precinct 2,BPS Bd Member,,,Phil Davidson,353,223,127,3
+Sarpy,Precinct 3,BPS Bd Member,,,Phil Davidson,483,268,210,5
+Sarpy,Precinct 4,BPS Bd Member,,,Phil Davidson,422,274,144,4
+Sarpy,Precinct 5,BPS Bd Member,,,Phil Davidson,394,222,168,4
+Sarpy,Precinct 6,BPS Bd Member,,,Phil Davidson,436,291,142,3
+Sarpy,Precinct 7,BPS Bd Member,,,Phil Davidson,353,215,134,4
+Sarpy,Precinct 8,BPS Bd Member,,,Phil Davidson,433,282,147,4
+Sarpy,Precinct 9,BPS Bd Member,,,Phil Davidson,337,229,105,3
+Sarpy,Precinct 10,BPS Bd Member,,,Phil Davidson,256,191,61,4
+Sarpy,Precinct 11,BPS Bd Member,,,Phil Davidson,604,317,283,4
+Sarpy,Precinct 12,BPS Bd Member,,,Phil Davidson,337,204,128,5
+Sarpy,Precinct 13,BPS Bd Member,,,Phil Davidson,574,309,260,5
+Sarpy,Precinct 20,BPS Bd Member,,,Phil Davidson,159,88,70,1
+Sarpy,Precinct 21,BPS Bd Member,,,Phil Davidson,210,103,105,2
+Sarpy,Precinct 22,BPS Bd Member,,,Phil Davidson,221,118,102,1
+Sarpy,Precinct 24,BPS Bd Member,,,Phil Davidson,382,229,151,2
+Sarpy,Precinct 25,BPS Bd Member,,,Phil Davidson,328,199,120,9
+Sarpy,Precinct 26,BPS Bd Member,,,Phil Davidson,490,309,174,7
+Sarpy,,BPS Bd Member,,,Casey S. Putney,4044,2462,1532,50
+Sarpy,Precinct 2,BPS Bd Member,,,Casey S. Putney,161,105,54,2
+Sarpy,Precinct 3,BPS Bd Member,,,Casey S. Putney,305,167,135,3
+Sarpy,Precinct 4,BPS Bd Member,,,Casey S. Putney,216,144,68,4
+Sarpy,Precinct 5,BPS Bd Member,,,Casey S. Putney,232,128,103,1
+Sarpy,Precinct 6,BPS Bd Member,,,Casey S. Putney,292,191,96,5
+Sarpy,Precinct 7,BPS Bd Member,,,Casey S. Putney,287,165,118,4
+Sarpy,Precinct 8,BPS Bd Member,,,Casey S. Putney,222,133,86,3
+Sarpy,Precinct 9,BPS Bd Member,,,Casey S. Putney,238,160,75,3
+Sarpy,Precinct 10,BPS Bd Member,,,Casey S. Putney,162,113,47,2
+Sarpy,Precinct 11,BPS Bd Member,,,Casey S. Putney,326,177,145,4
+Sarpy,Precinct 12,BPS Bd Member,,,Casey S. Putney,165,105,57,3
+Sarpy,Precinct 13,BPS Bd Member,,,Casey S. Putney,338,202,129,7
+Sarpy,Precinct 20,BPS Bd Member,,,Casey S. Putney,100,56,44,0
+Sarpy,Precinct 21,BPS Bd Member,,,Casey S. Putney,104,51,53,0
+Sarpy,Precinct 22,BPS Bd Member,,,Casey S. Putney,136,90,46,0
+Sarpy,Precinct 24,BPS Bd Member,,,Casey S. Putney,187,111,75,1
+Sarpy,Precinct 25,BPS Bd Member,,,Casey S. Putney,259,167,87,5
+Sarpy,Precinct 26,BPS Bd Member,,,Casey S. Putney,314,197,114,3
+Sarpy,,BPS Bd Member,,,Scott Eby,9264,5680,3486,98
+Sarpy,Precinct 2,BPS Bd Member,,,Scott Eby,547,386,158,3
+Sarpy,Precinct 3,BPS Bd Member,,,Scott Eby,652,377,264,11
+Sarpy,Precinct 4,BPS Bd Member,,,Scott Eby,654,421,227,6
+Sarpy,Precinct 5,BPS Bd Member,,,Scott Eby,516,295,217,4
+Sarpy,Precinct 6,BPS Bd Member,,,Scott Eby,679,436,233,10
+Sarpy,Precinct 7,BPS Bd Member,,,Scott Eby,655,383,259,13
+Sarpy,Precinct 8,BPS Bd Member,,,Scott Eby,542,339,199,4
+Sarpy,Precinct 9,BPS Bd Member,,,Scott Eby,597,415,173,9
+Sarpy,Precinct 10,BPS Bd Member,,,Scott Eby,479,346,127,6
+Sarpy,Precinct 11,BPS Bd Member,,,Scott Eby,590,331,257,2
+Sarpy,Precinct 12,BPS Bd Member,,,Scott Eby,333,227,102,4
+Sarpy,Precinct 13,BPS Bd Member,,,Scott Eby,902,488,407,7
+Sarpy,Precinct 20,BPS Bd Member,,,Scott Eby,221,117,103,1
+Sarpy,Precinct 21,BPS Bd Member,,,Scott Eby,250,129,118,3
+Sarpy,Precinct 22,BPS Bd Member,,,Scott Eby,244,134,109,1
+Sarpy,Precinct 24,BPS Bd Member,,,Scott Eby,427,261,161,5
+Sarpy,Precinct 25,BPS Bd Member,,,Scott Eby,420,260,156,4
+Sarpy,Precinct 26,BPS Bd Member,,,Scott Eby,556,335,216,5
+Sarpy,,BPS Bd Member,,,WRITE-IN,237,153,81,3
+Sarpy,Precinct 2,BPS Bd Member,,,WRITE-IN,13,10,3,0
+Sarpy,Precinct 3,BPS Bd Member,,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 4,BPS Bd Member,,,WRITE-IN,18,12,6,0
+Sarpy,Precinct 5,BPS Bd Member,,,WRITE-IN,7,2,5,0
+Sarpy,Precinct 6,BPS Bd Member,,,WRITE-IN,9,5,3,1
+Sarpy,Precinct 7,BPS Bd Member,,,WRITE-IN,19,15,3,1
+Sarpy,Precinct 8,BPS Bd Member,,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 9,BPS Bd Member,,,WRITE-IN,11,9,2,0
+Sarpy,Precinct 10,BPS Bd Member,,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 11,BPS Bd Member,,,WRITE-IN,19,12,7,0
+Sarpy,Precinct 12,BPS Bd Member,,,WRITE-IN,14,11,3,0
+Sarpy,Precinct 13,BPS Bd Member,,,WRITE-IN,16,10,5,1
+Sarpy,Precinct 20,BPS Bd Member,,,WRITE-IN,12,8,4,0
+Sarpy,Precinct 21,BPS Bd Member,,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 22,BPS Bd Member,,,WRITE-IN,8,3,5,0
+Sarpy,Precinct 24,BPS Bd Member,,,WRITE-IN,14,11,3,0
+Sarpy,Precinct 25,BPS Bd Member,,,WRITE-IN,14,9,5,0
+Sarpy,Precinct 26,BPS Bd Member,,,WRITE-IN,16,9,7,0
+Sarpy,,Gretna School,37,,Brinton J. Strohmyer,2777,1653,1104,20
+Sarpy,Precinct 46,Gretna School,37,,Brinton J. Strohmyer,138,74,64,0
+Sarpy,Precinct 51,Gretna School,37,,Brinton J. Strohmyer,266,150,115,1
+Sarpy,Precinct 52,Gretna School,37,,Brinton J. Strohmyer,510,276,228,6
+Sarpy,Precinct 55,Gretna School,37,,Brinton J. Strohmyer,65,31,31,3
+Sarpy,Precinct 58,Gretna School,37,,Brinton J. Strohmyer,312,212,97,3
+Sarpy,Precinct 59,Gretna School,37,,Brinton J. Strohmyer,351,243,108,0
+Sarpy,Precinct 60,Gretna School,37,,Brinton J. Strohmyer,337,229,107,1
+Sarpy,Precinct 61,Gretna School,37,,Brinton J. Strohmyer,798,438,354,6
+Sarpy,,Gretna School,37,,Dawn M. Stock,4875,2884,1952,39
+Sarpy,Precinct 46,Gretna School,37,,Dawn M. Stock,213,122,91,0
+Sarpy,Precinct 51,Gretna School,37,,Dawn M. Stock,400,244,154,2
+Sarpy,Precinct 52,Gretna School,37,,Dawn M. Stock,918,473,434,11
+Sarpy,Precinct 55,Gretna School,37,,Dawn M. Stock,124,57,62,5
+Sarpy,Precinct 58,Gretna School,37,,Dawn M. Stock,579,404,171,4
+Sarpy,Precinct 59,Gretna School,37,,Dawn M. Stock,650,427,217,6
+Sarpy,Precinct 60,Gretna School,37,,Dawn M. Stock,586,407,179,0
+Sarpy,Precinct 61,Gretna School,37,,Dawn M. Stock,1405,750,644,11
+Sarpy,,Gretna School,37,,Rick Hollendieck,4675,2772,1865,38
+Sarpy,Precinct 46,Gretna School,37,,Rick Hollendieck,242,131,110,1
+Sarpy,Precinct 51,Gretna School,37,,Rick Hollendieck,390,234,155,1
+Sarpy,Precinct 52,Gretna School,37,,Rick Hollendieck,726,362,357,7
+Sarpy,Precinct 55,Gretna School,37,,Rick Hollendieck,126,63,61,2
+Sarpy,Precinct 58,Gretna School,37,,Rick Hollendieck,602,403,195,4
+Sarpy,Precinct 59,Gretna School,37,,Rick Hollendieck,649,437,204,8
+Sarpy,Precinct 60,Gretna School,37,,Rick Hollendieck,611,428,182,1
+Sarpy,Precinct 61,Gretna School,37,,Rick Hollendieck,1329,714,601,14
+Sarpy,,Gretna School,37,,Kyle Janssen,5553,3429,2080,44
+Sarpy,Precinct 46,Gretna School,37,,Kyle Janssen,309,174,133,2
+Sarpy,Precinct 51,Gretna School,37,,Kyle Janssen,469,285,180,4
+Sarpy,Precinct 52,Gretna School,37,,Kyle Janssen,780,388,383,9
+Sarpy,Precinct 55,Gretna School,37,,Kyle Janssen,120,59,59,2
+Sarpy,Precinct 58,Gretna School,37,,Kyle Janssen,752,516,230,6
+Sarpy,Precinct 59,Gretna School,37,,Kyle Janssen,843,584,252,7
+Sarpy,Precinct 60,Gretna School,37,,Kyle Janssen,749,525,222,2
+Sarpy,Precinct 61,Gretna School,37,,Kyle Janssen,1531,898,621,12
+Sarpy,,Gretna School,37,,WRITE-IN,127,84,43,0
+Sarpy,Precinct 46,Gretna School,37,,WRITE-IN,7,7,0,0
+Sarpy,Precinct 51,Gretna School,37,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 52,Gretna School,37,,WRITE-IN,22,18,4,0
+Sarpy,Precinct 55,Gretna School,37,,WRITE-IN,4,0,4,0
+Sarpy,Precinct 58,Gretna School,37,,WRITE-IN,22,15,7,0
+Sarpy,Precinct 59,Gretna School,37,,WRITE-IN,31,21,10,0
+Sarpy,Precinct 60,Gretna School,37,,WRITE-IN,13,10,3,0
+Sarpy,Precinct 61,Gretna School,37,,WRITE-IN,23,10,13,0
+Sarpy,,Louisville School Bd,32,,Margaret M. Minchow,5,5,0,0
+Sarpy,Precinct 46,Louisville School Bd,32,,Margaret M. Minchow,5,5,0,0
+Sarpy,,Louisville School Bd,32,,Ashley Christiansen,6,6,0,0
+Sarpy,Precinct 46,Louisville School Bd,32,,Ashley Christiansen,6,6,0,0
+Sarpy,,Louisville School Bd,32,,Jonathan Simon,2,2,0,0
+Sarpy,Precinct 46,Louisville School Bd,32,,Jonathan Simon,2,2,0,0
+Sarpy,,Louisville School Bd,32,,John Winkler,5,5,0,0
+Sarpy,Precinct 46,Louisville School Bd,32,,John Winkler,5,5,0,0
+Sarpy,,Louisville School Bd,32,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 46,Louisville School Bd,32,,WRITE-IN,0,0,0,0
+Sarpy,,MPS Bd,17,,Terry Dale,2560,1639,901,20
+Sarpy,Precinct 51,MPS Bd,17,,Terry Dale,345,214,129,2
+Sarpy,Precinct 52,MPS Bd,17,,Terry Dale,130,99,30,1
+Sarpy,Precinct 53,MPS Bd,17,,Terry Dale,457,257,195,5
+Sarpy,Precinct 54,MPS Bd,17,,Terry Dale,447,249,195,3
+Sarpy,Precinct 55,MPS Bd,17,,Terry Dale,453,340,109,4
+Sarpy,Precinct 56,MPS Bd,17,,Terry Dale,367,239,126,2
+Sarpy,Precinct 57,MPS Bd,17,,Terry Dale,361,241,117,3
+Sarpy,,MPS Bd,17,,Mike Pate,4242,2588,1625,29
+Sarpy,Precinct 51,MPS Bd,17,,Mike Pate,654,423,229,2
+Sarpy,Precinct 52,MPS Bd,17,,Mike Pate,230,158,70,2
+Sarpy,Precinct 53,MPS Bd,17,,Mike Pate,766,408,349,9
+Sarpy,Precinct 54,MPS Bd,17,,Mike Pate,777,419,352,6
+Sarpy,Precinct 55,MPS Bd,17,,Mike Pate,641,429,208,4
+Sarpy,Precinct 56,MPS Bd,17,,Mike Pate,620,380,238,2
+Sarpy,Precinct 57,MPS Bd,17,,Mike Pate,554,371,179,4
+Sarpy,,MPS Bd,17,,Linda Poole,5885,3680,2172,33
+Sarpy,Precinct 51,MPS Bd,17,,Linda Poole,904,576,323,5
+Sarpy,Precinct 52,MPS Bd,17,,Linda Poole,361,241,115,5
+Sarpy,Precinct 53,MPS Bd,17,,Linda Poole,1045,608,428,9
+Sarpy,Precinct 54,MPS Bd,17,,Linda Poole,1073,599,469,5
+Sarpy,Precinct 55,MPS Bd,17,,Linda Poole,946,653,288,5
+Sarpy,Precinct 56,MPS Bd,17,,Linda Poole,852,532,319,1
+Sarpy,Precinct 57,MPS Bd,17,,Linda Poole,704,471,230,3
+Sarpy,,MPS Bd,17,,Amanda McGill Johnson,4221,2495,1696,30
+Sarpy,Precinct 51,MPS Bd,17,,Amanda McGill Johnson,598,380,215,3
+Sarpy,Precinct 52,MPS Bd,17,,Amanda McGill Johnson,245,164,79,2
+Sarpy,Precinct 53,MPS Bd,17,,Amanda McGill Johnson,785,397,379,9
+Sarpy,Precinct 54,MPS Bd,17,,Amanda McGill Johnson,781,421,355,5
+Sarpy,Precinct 55,MPS Bd,17,,Amanda McGill Johnson,683,436,239,8
+Sarpy,Precinct 56,MPS Bd,17,,Amanda McGill Johnson,577,352,225,0
+Sarpy,Precinct 57,MPS Bd,17,,Amanda McGill Johnson,552,345,204,3
+Sarpy,,MPS Bd,17,,Amber Dee Parker,3348,2042,1286,20
+Sarpy,Precinct 51,MPS Bd,17,,Amber Dee Parker,485,303,178,4
+Sarpy,Precinct 52,MPS Bd,17,,Amber Dee Parker,203,131,69,3
+Sarpy,Precinct 53,MPS Bd,17,,Amber Dee Parker,590,321,264,5
+Sarpy,Precinct 54,MPS Bd,17,,Amber Dee Parker,570,313,255,2
+Sarpy,Precinct 55,MPS Bd,17,,Amber Dee Parker,577,380,192,5
+Sarpy,Precinct 56,MPS Bd,17,,Amber Dee Parker,507,321,185,1
+Sarpy,Precinct 57,MPS Bd,17,,Amber Dee Parker,416,273,143,0
+Sarpy,,MPS Bd,17,,WRITE-IN,127,79,48,0
+Sarpy,Precinct 51,MPS Bd,17,,WRITE-IN,22,15,7,0
+Sarpy,Precinct 52,MPS Bd,17,,WRITE-IN,9,7,2,0
+Sarpy,Precinct 53,MPS Bd,17,,WRITE-IN,18,15,3,0
+Sarpy,Precinct 54,MPS Bd,17,,WRITE-IN,21,13,8,0
+Sarpy,Precinct 55,MPS Bd,17,,WRITE-IN,16,11,5,0
+Sarpy,Precinct 56,MPS Bd,17,,WRITE-IN,15,9,6,0
+Sarpy,Precinct 57,MPS Bd,17,,WRITE-IN,26,9,17,0
+Sarpy,,PLS,27,,Jeremy Kinsey,14595,8193,6283,119
+Sarpy,Precinct 19,PLS,27,,Jeremy Kinsey,720,293,417,10
+Sarpy,Precinct 21,PLS,27,,Jeremy Kinsey,709,369,337,3
+Sarpy,Precinct 22,PLS,27,,Jeremy Kinsey,360,227,129,4
+Sarpy,Precinct 23,PLS,27,,Jeremy Kinsey,826,407,404,15
+Sarpy,Precinct 31,PLS,27,,Jeremy Kinsey,1339,840,487,12
+Sarpy,Precinct 32,PLS,27,,Jeremy Kinsey,650,401,247,2
+Sarpy,Precinct 33,PLS,27,,Jeremy Kinsey,719,425,285,9
+Sarpy,Precinct 34,PLS,27,,Jeremy Kinsey,799,498,294,7
+Sarpy,Precinct 35,PLS,27,,Jeremy Kinsey,728,479,247,2
+Sarpy,Precinct 36,PLS,27,,Jeremy Kinsey,742,411,330,1
+Sarpy,Precinct 37,PLS,27,,Jeremy Kinsey,1131,612,510,9
+Sarpy,Precinct 38,PLS,27,,Jeremy Kinsey,754,484,266,4
+Sarpy,Precinct 39,PLS,27,,Jeremy Kinsey,847,478,368,1
+Sarpy,Precinct 40,PLS,27,,Jeremy Kinsey,774,461,304,9
+Sarpy,Precinct 41,PLS,27,,Jeremy Kinsey,905,460,440,5
+Sarpy,Precinct 42,PLS,27,,Jeremy Kinsey,768,405,359,4
+Sarpy,Precinct 48,PLS,27,,Jeremy Kinsey,397,183,210,4
+Sarpy,Precinct 49,PLS,27,,Jeremy Kinsey,985,514,461,10
+Sarpy,Precinct 57,PLS,27,,Jeremy Kinsey,0,0,0,0
+Sarpy,Precinct 62,PLS,27,,Jeremy Kinsey,442,246,188,8
+Sarpy,,PLS,27,,Valerie L. Fisher,16263,9093,7016,154
+Sarpy,Precinct 19,PLS,27,,Valerie L. Fisher,825,323,489,13
+Sarpy,Precinct 21,PLS,27,,Valerie L. Fisher,812,431,375,6
+Sarpy,Precinct 22,PLS,27,,Valerie L. Fisher,505,316,185,4
+Sarpy,Precinct 23,PLS,27,,Valerie L. Fisher,992,488,487,17
+Sarpy,Precinct 31,PLS,27,,Valerie L. Fisher,1304,803,488,13
+Sarpy,Precinct 32,PLS,27,,Valerie L. Fisher,668,409,253,6
+Sarpy,Precinct 33,PLS,27,,Valerie L. Fisher,867,496,357,14
+Sarpy,Precinct 34,PLS,27,,Valerie L. Fisher,963,609,350,4
+Sarpy,Precinct 35,PLS,27,,Valerie L. Fisher,767,502,262,3
+Sarpy,Precinct 36,PLS,27,,Valerie L. Fisher,801,453,344,4
+Sarpy,Precinct 37,PLS,27,,Valerie L. Fisher,1224,661,552,11
+Sarpy,Precinct 38,PLS,27,,Valerie L. Fisher,830,505,320,5
+Sarpy,Precinct 39,PLS,27,,Valerie L. Fisher,923,532,389,2
+Sarpy,Precinct 40,PLS,27,,Valerie L. Fisher,861,519,331,11
+Sarpy,Precinct 41,PLS,27,,Valerie L. Fisher,1043,526,509,8
+Sarpy,Precinct 42,PLS,27,,Valerie L. Fisher,939,493,439,7
+Sarpy,Precinct 48,PLS,27,,Valerie L. Fisher,404,183,219,2
+Sarpy,Precinct 49,PLS,27,,Valerie L. Fisher,1027,557,460,10
+Sarpy,Precinct 57,PLS,27,,Valerie L. Fisher,0,0,0,0
+Sarpy,Precinct 62,PLS,27,,Valerie L. Fisher,508,287,207,14
+Sarpy,,PLS,27,,Bret Brasfield,10716,5919,4706,91
+Sarpy,Precinct 19,PLS,27,,Bret Brasfield,566,228,332,6
+Sarpy,Precinct 21,PLS,27,,Bret Brasfield,517,253,260,4
+Sarpy,Precinct 22,PLS,27,,Bret Brasfield,296,185,110,1
+Sarpy,Precinct 23,PLS,27,,Bret Brasfield,838,431,392,15
+Sarpy,Precinct 31,PLS,27,,Bret Brasfield,815,501,308,6
+Sarpy,Precinct 32,PLS,27,,Bret Brasfield,396,239,153,4
+Sarpy,Precinct 33,PLS,27,,Bret Brasfield,524,302,214,8
+Sarpy,Precinct 34,PLS,27,,Bret Brasfield,613,389,223,1
+Sarpy,Precinct 35,PLS,27,,Bret Brasfield,454,275,177,2
+Sarpy,Precinct 36,PLS,27,,Bret Brasfield,510,282,225,3
+Sarpy,Precinct 37,PLS,27,,Bret Brasfield,845,454,387,4
+Sarpy,Precinct 38,PLS,27,,Bret Brasfield,598,376,220,2
+Sarpy,Precinct 39,PLS,27,,Bret Brasfield,551,295,256,0
+Sarpy,Precinct 40,PLS,27,,Bret Brasfield,544,324,213,7
+Sarpy,Precinct 41,PLS,27,,Bret Brasfield,712,379,328,5
+Sarpy,Precinct 42,PLS,27,,Bret Brasfield,601,314,283,4
+Sarpy,Precinct 48,PLS,27,,Bret Brasfield,281,125,151,5
+Sarpy,Precinct 49,PLS,27,,Bret Brasfield,681,343,332,6
+Sarpy,Precinct 57,PLS,27,,Bret Brasfield,0,0,0,0
+Sarpy,Precinct 62,PLS,27,,Bret Brasfield,374,224,142,8
+Sarpy,,PLS,27,,Charles Zurcher,11930,6853,4989,88
+Sarpy,Precinct 19,PLS,27,,Charles Zurcher,618,248,363,7
+Sarpy,Precinct 21,PLS,27,,Charles Zurcher,554,298,254,2
+Sarpy,Precinct 22,PLS,27,,Charles Zurcher,311,194,115,2
+Sarpy,Precinct 23,PLS,27,,Charles Zurcher,696,366,322,8
+Sarpy,Precinct 31,PLS,27,,Charles Zurcher,1022,626,386,10
+Sarpy,Precinct 32,PLS,27,,Charles Zurcher,466,293,170,3
+Sarpy,Precinct 33,PLS,27,,Charles Zurcher,513,312,195,6
+Sarpy,Precinct 34,PLS,27,,Charles Zurcher,608,382,223,3
+Sarpy,Precinct 35,PLS,27,,Charles Zurcher,553,350,203,0
+Sarpy,Precinct 36,PLS,27,,Charles Zurcher,730,444,282,4
+Sarpy,Precinct 37,PLS,27,,Charles Zurcher,1064,599,457,8
+Sarpy,Precinct 38,PLS,27,,Charles Zurcher,694,450,238,6
+Sarpy,Precinct 39,PLS,27,,Charles Zurcher,742,421,320,1
+Sarpy,Precinct 40,PLS,27,,Charles Zurcher,667,417,245,5
+Sarpy,Precinct 41,PLS,27,,Charles Zurcher,812,416,391,5
+Sarpy,Precinct 42,PLS,27,,Charles Zurcher,654,372,280,2
+Sarpy,Precinct 48,PLS,27,,Charles Zurcher,264,129,133,2
+Sarpy,Precinct 49,PLS,27,,Charles Zurcher,629,339,287,3
+Sarpy,Precinct 57,PLS,27,,Charles Zurcher,0,0,0,0
+Sarpy,Precinct 62,PLS,27,,Charles Zurcher,333,197,125,11
+Sarpy,,PLS,27,,WRITE-IN,372,212,156,4
+Sarpy,Precinct 19,PLS,27,,WRITE-IN,17,5,12,0
+Sarpy,Precinct 21,PLS,27,,WRITE-IN,26,19,6,1
+Sarpy,Precinct 22,PLS,27,,WRITE-IN,12,8,4,0
+Sarpy,Precinct 23,PLS,27,,WRITE-IN,22,6,16,0
+Sarpy,Precinct 31,PLS,27,,WRITE-IN,29,22,7,0
+Sarpy,Precinct 32,PLS,27,,WRITE-IN,18,3,14,1
+Sarpy,Precinct 33,PLS,27,,WRITE-IN,21,12,9,0
+Sarpy,Precinct 34,PLS,27,,WRITE-IN,18,7,9,2
+Sarpy,Precinct 35,PLS,27,,WRITE-IN,18,11,7,0
+Sarpy,Precinct 36,PLS,27,,WRITE-IN,14,7,7,0
+Sarpy,Precinct 37,PLS,27,,WRITE-IN,30,24,6,0
+Sarpy,Precinct 38,PLS,27,,WRITE-IN,17,13,4,0
+Sarpy,Precinct 39,PLS,27,,WRITE-IN,12,6,6,0
+Sarpy,Precinct 40,PLS,27,,WRITE-IN,26,15,11,0
+Sarpy,Precinct 41,PLS,27,,WRITE-IN,11,4,7,0
+Sarpy,Precinct 42,PLS,27,,WRITE-IN,23,9,14,0
+Sarpy,Precinct 48,PLS,27,,WRITE-IN,11,5,6,0
+Sarpy,Precinct 49,PLS,27,,WRITE-IN,36,26,10,0
+Sarpy,Precinct 57,PLS,27,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 62,PLS,27,,WRITE-IN,11,10,1,0
+Sarpy,,Springfield Platteview Bd Member,,,Brenda J. Sherman,1902,1108,780,14
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,Brenda J. Sherman,59,23,35,1
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,Brenda J. Sherman,306,173,130,3
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,Brenda J. Sherman,19,1,18,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,Brenda J. Sherman,82,40,42,0
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,Brenda J. Sherman,2,1,1,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,Brenda J. Sherman,260,170,90,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,Brenda J. Sherman,347,257,85,5
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,Brenda J. Sherman,445,215,227,3
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,Brenda J. Sherman,6,1,5,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,Brenda J. Sherman,100,47,53,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,Brenda J. Sherman,276,180,94,2
+Sarpy,,Springfield Platteview Bd Member,,,Robert Icenogle,1762,1055,697,10
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,Robert Icenogle,56,28,28,0
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,Robert Icenogle,211,123,86,2
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,Robert Icenogle,12,0,12,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,Robert Icenogle,82,27,54,1
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,Robert Icenogle,2,0,2,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,Robert Icenogle,271,178,93,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,Robert Icenogle,370,282,84,4
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,Robert Icenogle,482,238,241,3
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,Robert Icenogle,1,0,1,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,Robert Icenogle,57,28,29,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,Robert Icenogle,218,151,67,0
+Sarpy,,Springfield Platteview Bd Member,,,Kyle R. Fisher,1754,1045,699,10
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,Kyle R. Fisher,48,22,25,1
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,Kyle R. Fisher,229,133,95,1
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,Kyle R. Fisher,18,3,15,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,Kyle R. Fisher,61,32,29,0
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,Kyle R. Fisher,4,2,2,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,Kyle R. Fisher,271,161,110,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,Kyle R. Fisher,355,273,77,5
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,Kyle R. Fisher,494,244,248,2
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,Kyle R. Fisher,5,1,4,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,Kyle R. Fisher,78,39,39,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,Kyle R. Fisher,191,135,55,1
+Sarpy,,Springfield Platteview Bd Member,,,Lisa Roseland,1873,1073,793,7
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,Lisa Roseland,51,25,26,0
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,Lisa Roseland,286,161,122,3
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,Lisa Roseland,24,3,21,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,Lisa Roseland,66,22,43,1
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,Lisa Roseland,7,3,4,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,Lisa Roseland,295,187,108,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,Lisa Roseland,389,295,94,0
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,Lisa Roseland,445,209,234,2
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,Lisa Roseland,4,1,3,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,Lisa Roseland,71,31,40,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,Lisa Roseland,235,136,98,1
+Sarpy,,Springfield Platteview Bd Member,,,Kraig Kingston,1720,1055,656,9
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,Kraig Kingston,42,17,25,0
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,Kraig Kingston,165,100,64,1
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,Kraig Kingston,14,3,11,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,Kraig Kingston,57,19,37,1
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,Kraig Kingston,4,1,3,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,Kraig Kingston,317,217,100,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,Kraig Kingston,387,291,92,4
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,Kraig Kingston,484,255,227,2
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,Kraig Kingston,2,0,2,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,Kraig Kingston,60,30,30,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,Kraig Kingston,188,122,65,1
+Sarpy,,Springfield Platteview Bd Member,,,WRITE-IN,46,26,19,1
+Sarpy,Precinct 11,Springfield Platteview Bd Member,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 12,Springfield Platteview Bd Member,,,WRITE-IN,11,9,1,1
+Sarpy,Precinct 21,Springfield Platteview Bd Member,,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 23,Springfield Platteview Bd Member,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 24,Springfield Platteview Bd Member,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 46,Springfield Platteview Bd Member,,,WRITE-IN,16,6,10,0
+Sarpy,Precinct 47,Springfield Platteview Bd Member,,,WRITE-IN,4,2,2,0
+Sarpy,Precinct 48,Springfield Platteview Bd Member,,,WRITE-IN,7,3,4,0
+Sarpy,Precinct 49,Springfield Platteview Bd Member,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 55,Springfield Platteview Bd Member,,,WRITE-IN,4,4,0,0
+Sarpy,Precinct 62,Springfield Platteview Bd Member,,,WRITE-IN,3,2,1,0
+Sarpy,,Gretna Mayor,,,Jim Timmerman,1886,1322,553,11
+Sarpy,Precinct 59,Gretna Mayor,,,Jim Timmerman,969,677,283,9
+Sarpy,Precinct 60,Gretna Mayor,,,Jim Timmerman,917,645,270,2
+Sarpy,,Gretna Mayor,,,WRITE-IN,103,71,32,0
+Sarpy,Precinct 59,Gretna Mayor,,,WRITE-IN,55,32,23,0
+Sarpy,Precinct 60,Gretna Mayor,,,WRITE-IN,48,39,9,0
+Sarpy,,La Vista Mayor,,,Zach Boiko,1184,773,387,24
+Sarpy,Precinct 31,La Vista Mayor,,,Zach Boiko,212,139,68,5
+Sarpy,Precinct 32,La Vista Mayor,,,Zach Boiko,158,93,59,6
+Sarpy,Precinct 33,La Vista Mayor,,,Zach Boiko,269,177,84,8
+Sarpy,Precinct 34,La Vista Mayor,,,Zach Boiko,275,188,85,2
+Sarpy,Precinct 35,La Vista Mayor,,,Zach Boiko,203,130,73,0
+Sarpy,Precinct 57,La Vista Mayor,,,Zach Boiko,0,0,0,0
+Sarpy,Precinct 62,La Vista Mayor,,,Zach Boiko,67,46,18,3
+Sarpy,,La Vista Mayor,,,Douglas Kindig,5512,3468,1997,47
+Sarpy,Precinct 31,La Vista Mayor,,,Douglas Kindig,1037,638,386,13
+Sarpy,Precinct 32,La Vista Mayor,,,Douglas Kindig,962,612,347,3
+Sarpy,Precinct 33,La Vista Mayor,,,Douglas Kindig,1031,622,395,14
+Sarpy,Precinct 34,La Vista Mayor,,,Douglas Kindig,1219,776,433,10
+Sarpy,Precinct 35,La Vista Mayor,,,Douglas Kindig,1118,735,377,6
+Sarpy,Precinct 57,La Vista Mayor,,,Douglas Kindig,0,0,0,0
+Sarpy,Precinct 62,La Vista Mayor,,,Douglas Kindig,145,85,59,1
+Sarpy,,La Vista Mayor,,,WRITE-IN,36,19,16,1
+Sarpy,Precinct 31,La Vista Mayor,,,WRITE-IN,8,6,2,0
+Sarpy,Precinct 32,La Vista Mayor,,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 33,La Vista Mayor,,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 34,La Vista Mayor,,,WRITE-IN,6,1,4,1
+Sarpy,Precinct 35,La Vista Mayor,,,WRITE-IN,12,5,7,0
+Sarpy,Precinct 57,La Vista Mayor,,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 62,La Vista Mayor,,,WRITE-IN,0,0,0,0
+Sarpy,,Bellevue Council,1,,Thomas Burns,2365,1643,690,32
+Sarpy,Precinct 2,Bellevue Council,1,,Thomas Burns,505,359,139,7
+Sarpy,Precinct 7,Bellevue Council,1,,Thomas Burns,713,431,271,11
+Sarpy,Precinct 9,Bellevue Council,1,,Thomas Burns,619,454,157,8
+Sarpy,Precinct 10,Bellevue Council,1,,Thomas Burns,528,399,123,6
+Sarpy,,Bellevue Council,1,,Steven A. Carmichael,1469,1000,443,26
+Sarpy,Precinct 2,Bellevue Council,1,,Steven A. Carmichael,405,282,121,2
+Sarpy,Precinct 7,Bellevue Council,1,,Steven A. Carmichael,377,239,127,11
+Sarpy,Precinct 9,Bellevue Council,1,,Steven A. Carmichael,401,275,122,4
+Sarpy,Precinct 10,Bellevue Council,1,,Steven A. Carmichael,286,204,73,9
+Sarpy,,Bellevue Council,1,,WRITE-IN,18,10,7,1
+Sarpy,Precinct 2,Bellevue Council,1,,WRITE-IN,3,2,1,0
+Sarpy,Precinct 7,Bellevue Council,1,,WRITE-IN,5,3,1,1
+Sarpy,Precinct 9,Bellevue Council,1,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 10,Bellevue Council,1,,WRITE-IN,4,1,3,0
+Sarpy,,Bellevue Council,3,,Paul Cook,3499,2122,1338,39
+Sarpy,Precinct 8,Bellevue Council,3,,Paul Cook,273,196,76,1
+Sarpy,Precinct 11,Bellevue Council,3,,Paul Cook,667,371,293,3
+Sarpy,Precinct 19,Bellevue Council,3,,Paul Cook,279,141,127,11
+Sarpy,Precinct 21,Bellevue Council,3,,Paul Cook,568,352,208,8
+Sarpy,Precinct 22,Bellevue Council,3,,Paul Cook,331,209,118,4
+Sarpy,Precinct 24,Bellevue Council,3,,Paul Cook,331,201,129,1
+Sarpy,Precinct 25,Bellevue Council,3,,Paul Cook,540,323,213,4
+Sarpy,Precinct 26,Bellevue Council,3,,Paul Cook,510,329,174,7
+Sarpy,,Bellevue Council,3,,WRITE-IN,56,25,28,3
+Sarpy,Precinct 8,Bellevue Council,3,,WRITE-IN,3,1,1,1
+Sarpy,Precinct 11,Bellevue Council,3,,WRITE-IN,8,4,3,1
+Sarpy,Precinct 19,Bellevue Council,3,,WRITE-IN,3,1,2,0
+Sarpy,Precinct 21,Bellevue Council,3,,WRITE-IN,18,5,12,1
+Sarpy,Precinct 22,Bellevue Council,3,,WRITE-IN,1,0,1,0
+Sarpy,Precinct 24,Bellevue Council,3,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 25,Bellevue Council,3,,WRITE-IN,8,4,4,0
+Sarpy,Precinct 26,Bellevue Council,3,,WRITE-IN,9,6,3,0
+Sarpy,,Bellevue Council,5,,Don Preister,1913,1053,849,11
+Sarpy,Precinct 16,Bellevue Council,5,,Don Preister,647,345,299,3
+Sarpy,Precinct 17,Bellevue Council,5,,Don Preister,636,354,277,5
+Sarpy,Precinct 18,Bellevue Council,5,,Don Preister,510,304,203,3
+Sarpy,Precinct 19,Bellevue Council,5,,Don Preister,120,50,70,0
+Sarpy,,Bellevue Council,5,,Andy Mahoney,1831,1210,609,12
+Sarpy,Precinct 16,Bellevue Council,5,,Andy Mahoney,630,407,220,3
+Sarpy,Precinct 17,Bellevue Council,5,,Andy Mahoney,619,416,196,7
+Sarpy,Precinct 18,Bellevue Council,5,,Andy Mahoney,456,324,131,1
+Sarpy,Precinct 19,Bellevue Council,5,,Andy Mahoney,126,63,62,1
+Sarpy,,Bellevue Council,5,,WRITE-IN,27,19,7,1
+Sarpy,Precinct 16,Bellevue Council,5,,WRITE-IN,9,6,3,0
+Sarpy,Precinct 17,Bellevue Council,5,,WRITE-IN,9,8,0,1
+Sarpy,Precinct 18,Bellevue Council,5,,WRITE-IN,7,3,4,0
+Sarpy,Precinct 19,Bellevue Council,5,,WRITE-IN,2,2,0,0
+Sarpy,,Bellevue Council At-Lg,,,Rob Klug,8655,5189,3389,77
+Sarpy,Precinct 1,Bellevue Council At-Lg,,,Rob Klug,291,196,92,3
+Sarpy,Precinct 2,Bellevue Council At-Lg,,,Rob Klug,394,267,126,1
+Sarpy,Precinct 3,Bellevue Council At-Lg,,,Rob Klug,489,281,205,3
+Sarpy,Precinct 4,Bellevue Council At-Lg,,,Rob Klug,612,386,220,6
+Sarpy,Precinct 5,Bellevue Council At-Lg,,,Rob Klug,459,267,188,4
+Sarpy,Precinct 6,Bellevue Council At-Lg,,,Rob Klug,481,309,167,5
+Sarpy,Precinct 7,Bellevue Council At-Lg,,,Rob Klug,483,284,187,12
+Sarpy,Precinct 8,Bellevue Council At-Lg,,,Rob Klug,140,91,47,2
+Sarpy,Precinct 9,Bellevue Council At-Lg,,,Rob Klug,412,272,137,3
+Sarpy,Precinct 10,Bellevue Council At-Lg,,,Rob Klug,346,245,94,7
+Sarpy,Precinct 11,Bellevue Council At-Lg,,,Rob Klug,341,169,172,0
+Sarpy,Precinct 13,Bellevue Council At-Lg,,,Rob Klug,748,388,356,4
+Sarpy,Precinct 16,Bellevue Council At-Lg,,,Rob Klug,532,318,211,3
+Sarpy,Precinct 17,Bellevue Council At-Lg,,,Rob Klug,474,271,201,2
+Sarpy,Precinct 18,Bellevue Council At-Lg,,,Rob Klug,392,240,149,3
+Sarpy,Precinct 19,Bellevue Council At-Lg,,,Rob Klug,248,107,136,5
+Sarpy,Precinct 20,Bellevue Council At-Lg,,,Rob Klug,298,189,107,2
+Sarpy,Precinct 21,Bellevue Council At-Lg,,,Rob Klug,284,157,125,2
+Sarpy,Precinct 22,Bellevue Council At-Lg,,,Rob Klug,489,302,182,5
+Sarpy,Precinct 24,Bellevue Council At-Lg,,,Rob Klug,173,105,68,0
+Sarpy,Precinct 25,Bellevue Council At-Lg,,,Rob Klug,305,182,121,2
+Sarpy,Precinct 26,Bellevue Council At-Lg,,,Rob Klug,264,163,98,3
+Sarpy,,Bellevue Council At-Lg,,,Pat Shannon,10024,6495,3397,132
+Sarpy,Precinct 1,Bellevue Council At-Lg,,,Pat Shannon,442,330,106,6
+Sarpy,Precinct 2,Bellevue Council At-Lg,,,Pat Shannon,452,324,122,6
+Sarpy,Precinct 3,Bellevue Council At-Lg,,,Pat Shannon,500,297,196,7
+Sarpy,Precinct 4,Bellevue Council At-Lg,,,Pat Shannon,497,333,160,4
+Sarpy,Precinct 5,Bellevue Council At-Lg,,,Pat Shannon,443,253,184,6
+Sarpy,Precinct 6,Bellevue Council At-Lg,,,Pat Shannon,649,447,190,12
+Sarpy,Precinct 7,Bellevue Council At-Lg,,,Pat Shannon,548,352,187,9
+Sarpy,Precinct 8,Bellevue Council At-Lg,,,Pat Shannon,164,119,45,0
+Sarpy,Precinct 9,Bellevue Council At-Lg,,,Pat Shannon,578,433,136,9
+Sarpy,Precinct 10,Bellevue Council At-Lg,,,Pat Shannon,425,317,98,10
+Sarpy,Precinct 11,Bellevue Council At-Lg,,,Pat Shannon,369,218,146,5
+Sarpy,Precinct 13,Bellevue Council At-Lg,,,Pat Shannon,626,378,234,14
+Sarpy,Precinct 16,Bellevue Council At-Lg,,,Pat Shannon,691,401,287,3
+Sarpy,Precinct 17,Bellevue Council At-Lg,,,Pat Shannon,727,466,251,10
+Sarpy,Precinct 18,Bellevue Council At-Lg,,,Pat Shannon,526,359,166,1
+Sarpy,Precinct 19,Bellevue Council At-Lg,,,Pat Shannon,294,158,129,7
+Sarpy,Precinct 20,Bellevue Council At-Lg,,,Pat Shannon,393,261,129,3
+Sarpy,Precinct 21,Bellevue Council At-Lg,,,Pat Shannon,343,216,121,6
+Sarpy,Precinct 22,Bellevue Council At-Lg,,,Pat Shannon,608,381,222,5
+Sarpy,Precinct 24,Bellevue Council At-Lg,,,Pat Shannon,178,98,79,1
+Sarpy,Precinct 25,Bellevue Council At-Lg,,,Pat Shannon,290,172,113,5
+Sarpy,Precinct 26,Bellevue Council At-Lg,,,Pat Shannon,281,182,96,3
+Sarpy,,Bellevue Council At-Lg,,,WRITE-IN,167,101,61,5
+Sarpy,Precinct 1,Bellevue Council At-Lg,,,WRITE-IN,12,9,3,0
+Sarpy,Precinct 2,Bellevue Council At-Lg,,,WRITE-IN,4,4,0,0
+Sarpy,Precinct 3,Bellevue Council At-Lg,,,WRITE-IN,7,5,2,0
+Sarpy,Precinct 4,Bellevue Council At-Lg,,,WRITE-IN,10,4,6,0
+Sarpy,Precinct 5,Bellevue Council At-Lg,,,WRITE-IN,4,4,0,0
+Sarpy,Precinct 6,Bellevue Council At-Lg,,,WRITE-IN,11,4,6,1
+Sarpy,Precinct 7,Bellevue Council At-Lg,,,WRITE-IN,8,5,2,1
+Sarpy,Precinct 8,Bellevue Council At-Lg,,,WRITE-IN,1,1,0,0
+Sarpy,Precinct 9,Bellevue Council At-Lg,,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 10,Bellevue Council At-Lg,,,WRITE-IN,11,7,4,0
+Sarpy,Precinct 11,Bellevue Council At-Lg,,,WRITE-IN,6,5,1,0
+Sarpy,Precinct 13,Bellevue Council At-Lg,,,WRITE-IN,8,3,4,1
+Sarpy,Precinct 16,Bellevue Council At-Lg,,,WRITE-IN,10,6,4,0
+Sarpy,Precinct 17,Bellevue Council At-Lg,,,WRITE-IN,18,11,6,1
+Sarpy,Precinct 18,Bellevue Council At-Lg,,,WRITE-IN,12,6,6,0
+Sarpy,Precinct 19,Bellevue Council At-Lg,,,WRITE-IN,5,4,1,0
+Sarpy,Precinct 20,Bellevue Council At-Lg,,,WRITE-IN,8,5,3,0
+Sarpy,Precinct 21,Bellevue Council At-Lg,,,WRITE-IN,6,2,3,1
+Sarpy,Precinct 22,Bellevue Council At-Lg,,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 24,Bellevue Council At-Lg,,,WRITE-IN,2,1,1,0
+Sarpy,Precinct 25,Bellevue Council At-Lg,,,WRITE-IN,8,4,4,0
+Sarpy,Precinct 26,Bellevue Council At-Lg,,,WRITE-IN,5,4,1,0
+Sarpy,,Gretna Council,1,,Logan R. Herring,575,418,157,0
+Sarpy,Precinct 60,Gretna Council,1,,Logan R. Herring,575,418,157,0
+Sarpy,,Gretna Council,1,,Kip Edmonds,401,272,126,3
+Sarpy,Precinct 60,Gretna Council,1,,Kip Edmonds,401,272,126,3
+Sarpy,,Gretna Council,1,,WRITE-IN,16,7,9,0
+Sarpy,Precinct 60,Gretna Council,1,,WRITE-IN,16,7,9,0
+Sarpy,,Gretna Council,2,,Angie Lauritsen,924,634,281,9
+Sarpy,Precinct 59,Gretna Council,2,,Angie Lauritsen,924,634,281,9
+Sarpy,,Gretna Council,2,,WRITE-IN,31,18,13,0
+Sarpy,Precinct 59,Gretna Council,2,,WRITE-IN,31,18,13,0
+Sarpy,,La Vista Council,1,,Mike Crawford,1219,798,416,5
+Sarpy,Precinct 34,La Vista Council,1,,Mike Crawford,311,206,104,1
+Sarpy,Precinct 35,La Vista Council,1,,Mike Crawford,908,592,312,4
+Sarpy,,La Vista Council,1,,WRITE-IN,18,11,7,0
+Sarpy,Precinct 34,La Vista Council,1,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 35,La Vista Council,1,,WRITE-IN,13,8,5,0
+Sarpy,,La Vista Council,2,,Ronald Sheehan,1322,840,467,15
+Sarpy,Precinct 32,La Vista Council,2,,Ronald Sheehan,396,251,138,7
+Sarpy,Precinct 34,La Vista Council,2,,Ronald Sheehan,926,589,329,8
+Sarpy,,La Vista Council,2,,WRITE-IN,21,13,7,1
+Sarpy,Precinct 32,La Vista Council,2,,WRITE-IN,5,1,4,0
+Sarpy,Precinct 34,La Vista Council,2,,WRITE-IN,16,12,3,1
+Sarpy,,La Vista Council,3,,Deb Hale,1267,821,426,20
+Sarpy,Precinct 32,La Vista Council,3,,Deb Hale,515,326,187,2
+Sarpy,Precinct 33,La Vista Council,3,,Deb Hale,623,402,203,18
+Sarpy,Precinct 35,La Vista Council,3,,Deb Hale,129,93,36,0
+Sarpy,,La Vista Council,3,,WRITE-IN,21,12,9,0
+Sarpy,Precinct 32,La Vista Council,3,,WRITE-IN,6,3,3,0
+Sarpy,Precinct 33,La Vista Council,3,,WRITE-IN,10,7,3,0
+Sarpy,Precinct 35,La Vista Council,3,,WRITE-IN,5,2,3,0
+Sarpy,,La Vista Council,4,,Jim Frederick,1632,993,616,23
+Sarpy,Precinct 31,La Vista Council,4,,Jim Frederick,976,611,350,15
+Sarpy,Precinct 33,La Vista Council,4,,Jim Frederick,469,268,198,3
+Sarpy,Precinct 57,La Vista Council,4,,Jim Frederick,0,0,0,0
+Sarpy,Precinct 62,La Vista Council,4,,Jim Frederick,187,114,68,5
+Sarpy,,La Vista Council,4,,WRITE-IN,23,14,9,0
+Sarpy,Precinct 31,La Vista Council,4,,WRITE-IN,17,13,4,0
+Sarpy,Precinct 33,La Vista Council,4,,WRITE-IN,6,1,5,0
+Sarpy,Precinct 57,La Vista Council,4,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 62,La Vista Council,4,,WRITE-IN,0,0,0,0
+Sarpy,,Papillion Council,1,,James Glover,2146,1347,776,23
+Sarpy,Precinct 37,Papillion Council,1,,James Glover,667,385,274,8
+Sarpy,Precinct 38,Papillion Council,1,,James Glover,1174,758,404,12
+Sarpy,Precinct 40,Papillion Council,1,,James Glover,305,204,98,3
+Sarpy,,Papillion Council,1,,WRITE-IN,37,22,15,0
+Sarpy,Precinct 37,Papillion Council,1,,WRITE-IN,13,8,5,0
+Sarpy,Precinct 38,Papillion Council,1,,WRITE-IN,17,9,8,0
+Sarpy,Precinct 40,Papillion Council,1,,WRITE-IN,7,5,2,0
+Sarpy,,Papillion Council,2,,Jason L. Gaines,1146,675,460,11
+Sarpy,Precinct 40,Papillion Council,2,,Jason L. Gaines,281,177,99,5
+Sarpy,Precinct 42,Papillion Council,2,,Jason L. Gaines,865,498,361,6
+Sarpy,,Papillion Council,2,,Christopher McMeekin,648,339,307,2
+Sarpy,Precinct 40,Papillion Council,2,,Christopher McMeekin,151,90,61,0
+Sarpy,Precinct 42,Papillion Council,2,,Christopher McMeekin,497,249,246,2
+Sarpy,,Papillion Council,2,,WRITE-IN,14,7,7,0
+Sarpy,Precinct 40,Papillion Council,2,,WRITE-IN,6,4,2,0
+Sarpy,Precinct 42,Papillion Council,2,,WRITE-IN,8,3,5,0
+Sarpy,,Papillion Council,3,,Lu Ann Kluch,1830,1093,719,18
+Sarpy,Precinct 23,Papillion Council,3,,Lu Ann Kluch,489,267,208,14
+Sarpy,Precinct 39,Papillion Council,3,,Lu Ann Kluch,984,627,355,2
+Sarpy,Precinct 48,Papillion Council,3,,Lu Ann Kluch,2,2,0,0
+Sarpy,Precinct 49,Papillion Council,3,,Lu Ann Kluch,267,149,117,1
+Sarpy,Precinct 62,Papillion Council,3,,Lu Ann Kluch,88,48,39,1
+Sarpy,,Papillion Council,3,,WRITE-IN,33,22,11,0
+Sarpy,Precinct 23,Papillion Council,3,,WRITE-IN,3,1,2,0
+Sarpy,Precinct 39,Papillion Council,3,,WRITE-IN,23,14,9,0
+Sarpy,Precinct 48,Papillion Council,3,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 49,Papillion Council,3,,WRITE-IN,3,3,0,0
+Sarpy,Precinct 62,Papillion Council,3,,WRITE-IN,4,4,0,0
+Sarpy,,Papillion Council,4,,Alexander Samuel A. George,454,257,193,4
+Sarpy,Precinct 36,Papillion Council,4,,Alexander Samuel A. George,208,126,79,3
+Sarpy,Precinct 37,Papillion Council,4,,Alexander Samuel A. George,72,43,29,0
+Sarpy,Precinct 39,Papillion Council,4,,Alexander Samuel A. George,66,23,43,0
+Sarpy,Precinct 40,Papillion Council,4,,Alexander Samuel A. George,108,65,42,1
+Sarpy,,Papillion Council,4,,Bob Stubbe,1798,999,792,7
+Sarpy,Precinct 36,Papillion Council,4,,Bob Stubbe,958,553,403,2
+Sarpy,Precinct 37,Papillion Council,4,,Bob Stubbe,240,134,105,1
+Sarpy,Precinct 39,Papillion Council,4,,Bob Stubbe,217,89,128,0
+Sarpy,Precinct 40,Papillion Council,4,,Bob Stubbe,383,223,156,4
+Sarpy,,Papillion Council,4,,WRITE-IN,16,8,8,0
+Sarpy,Precinct 36,Papillion Council,4,,WRITE-IN,8,3,5,0
+Sarpy,Precinct 37,Papillion Council,4,,WRITE-IN,0,0,0,0
+Sarpy,Precinct 39,Papillion Council,4,,WRITE-IN,5,3,2,0
+Sarpy,Precinct 40,Papillion Council,4,,WRITE-IN,3,2,1,0
+Sarpy,,Springfield Council,,,Roy T. Swenson,513,388,121,4
+Sarpy,Precinct 47,Springfield Council,,,Roy T. Swenson,513,388,121,4
+Sarpy,,Springfield Council,,,Dan Craney,581,428,145,8
+Sarpy,Precinct 47,Springfield Council,,,Dan Craney,581,428,145,8
+Sarpy,,Springfield Council,,,WRITE-IN,31,22,9,0
+Sarpy,Precinct 47,Springfield Council,,,WRITE-IN,31,22,9,0
+Sarpy,,City of Gretna Proposal,,,Yes,1112,787,318,7
+Sarpy,Precinct 59,City of Gretna Proposal,,,Yes,583,420,158,5
+Sarpy,Precinct 60,City of Gretna Proposal,,,Yes,529,367,160,2
+Sarpy,,City of Gretna Proposal,,,No,1263,860,395,8
+Sarpy,Precinct 59,City of Gretna Proposal,,,No,657,430,222,5
+Sarpy,Precinct 60,City of Gretna Proposal,,,No,606,430,173,3
+Sarpy,,Referendum No. 426,,,Retain,28707,16040,12381,286
+Sarpy,Precinct 1,Referendum No. 426,,,Retain,390,267,118,5
+Sarpy,Precinct 2,Referendum No. 426,,,Retain,353,228,122,3
+Sarpy,Precinct 3,Referendum No. 426,,,Retain,543,296,241,6
+Sarpy,Precinct 4,Referendum No. 426,,,Retain,503,296,205,2
+Sarpy,Precinct 5,Referendum No. 426,,,Retain,395,199,193,3
+Sarpy,Precinct 6,Referendum No. 426,,,Retain,498,304,181,13
+Sarpy,Precinct 7,Referendum No. 426,,,Retain,409,231,174,4
+Sarpy,Precinct 8,Referendum No. 426,,,Retain,446,247,197,2
+Sarpy,Precinct 9,Referendum No. 426,,,Retain,383,251,126,6
+Sarpy,Precinct 10,Referendum No. 426,,,Retain,285,189,91,5
+Sarpy,Precinct 11,Referendum No. 426,,,Retain,620,324,292,4
+Sarpy,Precinct 12,Referendum No. 426,,,Retain,507,300,198,9
+Sarpy,Precinct 13,Referendum No. 426,,,Retain,721,377,336,8
+Sarpy,Precinct 16,Referendum No. 426,,,Retain,539,308,229,2
+Sarpy,Precinct 17,Referendum No. 426,,,Retain,527,317,204,6
+Sarpy,Precinct 18,Referendum No. 426,,,Retain,384,219,162,3
+Sarpy,Precinct 19,Referendum No. 426,,,Retain,796,319,466,11
+Sarpy,Precinct 20,Referendum No. 426,,,Retain,659,370,286,3
+Sarpy,Precinct 21,Referendum No. 426,,,Retain,810,382,420,8
+Sarpy,Precinct 22,Referendum No. 426,,,Retain,558,324,230,4
+Sarpy,Precinct 23,Referendum No. 426,,,Retain,707,303,390,14
+Sarpy,Precinct 24,Referendum No. 426,,,Retain,370,201,167,2
+Sarpy,Precinct 25,Referendum No. 426,,,Retain,397,227,162,8
+Sarpy,Precinct 26,Referendum No. 426,,,Retain,498,286,206,6
+Sarpy,Precinct 31,Referendum No. 426,,,Retain,990,626,353,11
+Sarpy,Precinct 32,Referendum No. 426,,,Retain,414,244,166,4
+Sarpy,Precinct 33,Referendum No. 426,,,Retain,554,319,227,8
+Sarpy,Precinct 34,Referendum No. 426,,,Retain,537,315,217,5
+Sarpy,Precinct 35,Referendum No. 426,,,Retain,473,268,201,4
+Sarpy,Precinct 36,Referendum No. 426,,,Retain,525,284,240,1
+Sarpy,Precinct 37,Referendum No. 426,,,Retain,873,467,398,8
+Sarpy,Precinct 38,Referendum No. 426,,,Retain,573,351,218,4
+Sarpy,Precinct 39,Referendum No. 426,,,Retain,583,326,255,2
+Sarpy,Precinct 40,Referendum No. 426,,,Retain,501,282,212,7
+Sarpy,Precinct 41,Referendum No. 426,,,Retain,745,347,392,6
+Sarpy,Precinct 42,Referendum No. 426,,,Retain,578,294,277,7
+Sarpy,Precinct 46,Referendum No. 426,,,Retain,352,214,138,0
+Sarpy,Precinct 47,Referendum No. 426,,,Retain,218,157,58,3
+Sarpy,Precinct 48,Referendum No. 426,,,Retain,643,288,352,3
+Sarpy,Precinct 49,Referendum No. 426,,,Retain,641,323,311,7
+Sarpy,Precinct 51,Referendum No. 426,,,Retain,830,476,347,7
+Sarpy,Precinct 52,Referendum No. 426,,,Retain,777,425,341,11
+Sarpy,Precinct 53,Referendum No. 426,,,Retain,676,360,313,3
+Sarpy,Precinct 54,Referendum No. 426,,,Retain,608,313,289,6
+Sarpy,Precinct 55,Referendum No. 426,,,Retain,760,452,299,9
+Sarpy,Precinct 56,Referendum No. 426,,,Retain,522,301,219,2
+Sarpy,Precinct 57,Referendum No. 426,,,Retain,444,280,161,3
+Sarpy,Precinct 58,Referendum No. 426,,,Retain,342,238,101,3
+Sarpy,Precinct 59,Referendum No. 426,,,Retain,412,263,145,4
+Sarpy,Precinct 60,Referendum No. 426,,,Retain,418,274,143,1
+Sarpy,Precinct 61,Referendum No. 426,,,Retain,903,468,427,8
+Sarpy,Precinct 62,Referendum No. 426,,,Retain,517,320,185,12
+Sarpy,,Referendum No. 426,,,Repeal,49492,30977,18004,511
+Sarpy,Precinct 1,Referendum No. 426,,,Repeal,580,390,185,5
+Sarpy,Precinct 2,Referendum No. 426,,,Repeal,605,445,151,9
+Sarpy,Precinct 3,Referendum No. 426,,,Repeal,921,563,344,14
+Sarpy,Precinct 4,Referendum No. 426,,,Repeal,785,547,227,11
+Sarpy,Precinct 5,Referendum No. 426,,,Repeal,666,399,259,8
+Sarpy,Precinct 6,Referendum No. 426,,,Repeal,798,562,227,9
+Sarpy,Precinct 7,Referendum No. 426,,,Repeal,769,498,251,20
+Sarpy,Precinct 8,Referendum No. 426,,,Repeal,713,493,209,11
+Sarpy,Precinct 9,Referendum No. 426,,,Repeal,810,603,197,10
+Sarpy,Precinct 10,Referendum No. 426,,,Repeal,573,436,124,13
+Sarpy,Precinct 11,Referendum No. 426,,,Repeal,1092,642,438,12
+Sarpy,Precinct 12,Referendum No. 426,,,Repeal,994,644,340,10
+Sarpy,Precinct 13,Referendum No. 426,,,Repeal,906,539,355,12
+Sarpy,Precinct 16,Referendum No. 426,,,Repeal,918,554,358,6
+Sarpy,Precinct 17,Referendum No. 426,,,Repeal,864,547,309,8
+Sarpy,Precinct 18,Referendum No. 426,,,Repeal,730,491,234,5
+Sarpy,Precinct 19,Referendum No. 426,,,Repeal,1339,600,722,17
+Sarpy,Precinct 20,Referendum No. 426,,,Repeal,891,554,330,7
+Sarpy,Precinct 21,Referendum No. 426,,,Repeal,1238,672,558,8
+Sarpy,Precinct 22,Referendum No. 426,,,Repeal,841,537,292,12
+Sarpy,Precinct 23,Referendum No. 426,,,Repeal,1315,705,590,20
+Sarpy,Precinct 24,Referendum No. 426,,,Repeal,618,403,209,6
+Sarpy,Precinct 25,Referendum No. 426,,,Repeal,647,427,205,15
+Sarpy,Precinct 26,Referendum No. 426,,,Repeal,822,525,287,10
+Sarpy,Precinct 31,Referendum No. 426,,,Repeal,1457,917,525,15
+Sarpy,Precinct 32,Referendum No. 426,,,Repeal,733,482,247,4
+Sarpy,Precinct 33,Referendum No. 426,,,Repeal,815,528,273,14
+Sarpy,Precinct 34,Referendum No. 426,,,Repeal,1027,683,335,9
+Sarpy,Precinct 35,Referendum No. 426,,,Repeal,885,608,273,4
+Sarpy,Precinct 36,Referendum No. 426,,,Repeal,890,552,332,6
+Sarpy,Precinct 37,Referendum No. 426,,,Repeal,1415,813,590,12
+Sarpy,Precinct 38,Referendum No. 426,,,Repeal,863,558,294,11
+Sarpy,Precinct 39,Referendum No. 426,,,Repeal,997,586,411,0
+Sarpy,Precinct 40,Referendum No. 426,,,Repeal,944,624,311,9
+Sarpy,Precinct 41,Referendum No. 426,,,Repeal,1113,616,485,12
+Sarpy,Precinct 42,Referendum No. 426,,,Repeal,963,559,399,5
+Sarpy,Precinct 46,Referendum No. 426,,,Repeal,762,468,292,2
+Sarpy,Precinct 47,Referendum No. 426,,,Repeal,566,439,121,6
+Sarpy,Precinct 48,Referendum No. 426,,,Repeal,1156,590,559,7
+Sarpy,Precinct 49,Referendum No. 426,,,Repeal,1135,626,497,12
+Sarpy,Precinct 51,Referendum No. 426,,,Repeal,1438,955,477,6
+Sarpy,Precinct 52,Referendum No. 426,,,Repeal,1478,857,604,17
+Sarpy,Precinct 53,Referendum No. 426,,,Repeal,1162,684,462,16
+Sarpy,Precinct 54,Referendum No. 426,,,Repeal,1185,670,500,15
+Sarpy,Precinct 55,Referendum No. 426,,,Repeal,1401,931,457,13
+Sarpy,Precinct 56,Referendum No. 426,,,Repeal,894,612,280,2
+Sarpy,Precinct 57,Referendum No. 426,,,Repeal,815,561,248,6
+Sarpy,Precinct 58,Referendum No. 426,,,Repeal,749,514,230,5
+Sarpy,Precinct 59,Referendum No. 426,,,Repeal,825,591,228,6
+Sarpy,Precinct 60,Referendum No. 426,,,Repeal,723,528,191,4
+Sarpy,Precinct 61,Referendum No. 426,,,Repeal,1769,1088,660,21
+Sarpy,Precinct 62,Referendum No. 426,,,Repeal,897,561,322,14

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Raw election results for Nebraska elections.
 
 ## Clarify scraper
-Inside `/bin` is a [Clarify](https://github.com/openelections/clarify) scraper that processes precinct-level results from the 2014 general election in Sarpy County.
+Inside `/bin` are two [Clarify](https://github.com/openelections/clarify) scrapers that process precinct-level results from the 2014 and 2016 general elections in Sarpy County.

--- a/bin/parse_2016_general_sarpy_precinct.py
+++ b/bin/parse_2016_general_sarpy_precinct.py
@@ -1,0 +1,133 @@
+from __future__ import print_function
+from zipfile import ZipFile
+
+try:
+    from StringIO import StringIO as ioDuder
+except ImportError:
+    from io import BytesIO as ioDuder
+
+import os
+import unicodecsv
+import requests
+import clarify
+
+
+COUNTY = 'Sarpy'
+
+URL = 'http://results.enr.clarityelections.com/NE/Sarpy/64652/184054/en/summary.html'
+
+ELECTION_TYPE = 'general'
+
+
+def clarify_sarpy():
+    '''
+    1. Fetch zipped XML file.
+    2. Unzip in memory.
+    3. Load into Clarify.
+    4. Loop over results, write to file.
+    '''
+
+    # discover path to zipfile and fetch
+    s = clarify.Jurisdiction(url=URL, level='county')
+    r = requests.get(s.report_url('xml'), stream=True)
+    z = ZipFile(ioDuder(r.content))
+
+    # hand off to clarify
+    p = clarify.Parser()
+    p.parse(z.open('detail.xml'))
+
+    results = []
+
+    # According to the Sarpy County election commissioner, results with a
+    # `vote_type` of "underVotes" -- e.g., only 1 vote cast in a "pick 2"
+    # race -- or "overVotes" -- e.g., 3 votes cast in a "pick 2" race --
+    # are just context information and should not be included in results
+    excluded_vote_types = ['underVotes', 'overVotes']
+
+    for result in p.results:
+
+        if result.vote_type not in excluded_vote_types:
+            candidate = result.choice.text
+            office, district = parse_office(result.contest.text)
+
+            party = result.choice.party
+
+            try:
+                precinct = result.jurisdiction.name
+            except AttributeError:
+                precinct = None
+
+            r = [x for x in results if x['precinct'] == precinct and
+                 x['office'] == office and
+                 x['district'] == district and
+                 x['party'] == party and
+                 x['candidate'] == candidate]
+
+            if r:
+                r[0][result.vote_type] = result.votes
+            else:
+                record = {
+                    'county': COUNTY,
+                    'precinct': precinct,
+                    'office': office,
+                    'district': district,
+                    'party': party,
+                    'candidate': candidate,
+                    result.vote_type: result.votes
+                    }
+                results.append(record)
+
+    # build filename
+    election_date = p.election_date.strftime('%Y%m%d')
+
+    filename = '__'.join([
+        election_date,
+        'ne',
+        ELECTION_TYPE,
+        COUNTY.lower(),
+        'precinct.csv'
+    ])
+
+    # to filter out "total" rows, uncomment the next line
+    # results = [x for x in results if x['precinct']]
+
+    with open(os.path.join(os.pardir, filename), 'wb') as outfile:
+        f = unicodecsv.writer(outfile, encoding='utf-8')
+
+        # headers
+        f.writerow(['county', 'precinct', 'office', 'district', 'party',
+                    'candidate', 'votes', 'election_day', 'early_voting',
+                    'provisional'])
+
+        for row in results:
+            total_votes = row['Early Voting'] + row['Provisionals'] \
+                          + row['Election Day']
+
+            f.writerow([row['county'], row['precinct'], row['office'],
+                       row['district'], row['party'], row['candidate'],
+                       total_votes, row['Election Day'],
+                       row['Early Voting'], row['Provisionals']])
+
+
+def parse_office(office_text):
+    district = None
+    office = office_text
+
+    dist_keywords = ['District', 'Dist', 'Subd', 'Wd']
+
+    dist = list(set(office_text.split(' ')).intersection(dist_keywords))
+
+    if dist and not office_text.endswith('School Bond'):
+        splitter = dist[0]
+        office = office_text.split(splitter)[0]
+        district = office_text.split(splitter)[1].strip().split(' ')[0]
+    if 'US Representative' in office_text:
+        office = 'United States Representative'
+    if 'Senator' in office_text:
+        office = 'United States Senator'
+
+    return [office.strip(), district]
+
+
+if __name__ == '__main__':
+    clarify_sarpy()


### PR DESCRIPTION
This PR advances #3:

* Adds precinct-level data for main races in 2016 general in Sarpy, Hall and Cheyenne Counties
* Adds a Clarify scraper for Sarpy 2016 general
* Adds a .gitignore file (had `.DS_Store` creeping in there)

>Note: Cheyenne County categorizes early/provisional votes and votes by new/former residents as separate "precincts," which [is how the state interprets the results](http://electionresults.sos.ne.gov/resultsPREC.aspx?type=PRS&rid=8457&cty=39&osn=101&pty=0&map=PREC), so I followed suit.