### PR TITLE
Remove leading and trailing whitespace

### DIFF
--- a/2016/20161108__ne__general.csv
+++ b/2016/20161108__ne__general.csv
@@ -1,704 +1,704 @@
-"","county","office","district","party","candidate","votes"
-"1","Burt","President",1,"REP","Donald J. Trump",2367
-"2","Burt","President",1,"DEM","Hillary Clinton",930
-"3","Burt","President",1,"LIB","Gary Johnson",197
-"4","Burt","President",1,"PET","Jill Stein",39
-"5","Burt","President",1,"Write In","Write-ins",25
-"6","Butler","President",1,"REP","Donald J. Trump",3079
-"7","Butler","President",1,"DEM","Hillary Clinton",691
-"8","Butler","President",1,"LIB","Gary Johnson",129
-"9","Butler","President",1,"PET","Jill Stein",27
-"10","Butler","President",1,"Write In","Write-ins",55
-"11","Cass","President",1,"REP","Donald J. Trump",8452
-"12","Cass","President",1,"DEM","Hillary Clinton",3484
-"13","Cass","President",1,"LIB","Gary Johnson",639
-"14","Cass","President",1,"PET","Jill Stein",132
-"15","Cass","President",1,"Write In","Write-ins",226
-"16","Colfax","President",1,"REP","Donald J. Trump",2171
-"17","Colfax","President",1,"DEM","Hillary Clinton",859
-"18","Colfax","President",1,"LIB","Gary Johnson",118
-"19","Colfax","President",1,"PET","Jill Stein",26
-"20","Colfax","President",1,"Write In","Write-ins",40
-"21","Cuming","President",1,"REP","Donald J. Trump",3122
-"22","Cuming","President",1,"DEM","Hillary Clinton",719
-"23","Cuming","President",1,"LIB","Gary Johnson",157
-"24","Cuming","President",1,"PET","Jill Stein",26
-"25","Cuming","President",1,"Write In","Write-ins",50
-"26","Dixon","President",1,"REP","Donald J. Trump",130
-"27","Dixon","President",1,"DEM","Hillary Clinton",54
-"28","Dixon","President",1,"LIB","Gary Johnson",15
-"29","Dixon","President",1,"PET","Jill Stein",1
-"30","Dixon","President",1,"Write In","Write-ins",0
-"31","Dodge","President",1,"REP","Donald J. Trump",9933
-"32","Dodge","President",1,"DEM","Hillary Clinton",4544
-"33","Dodge","President",1,"LIB","Gary Johnson",624
-"34","Dodge","President",1,"PET","Jill Stein",162
-"35","Dodge","President",1,"Write In","Write-ins",266
-"36","Lancaster","President",1,"REP","Donald J. Trump",61588
-"37","Lancaster","President",1,"DEM","Hillary Clinton",61898
-"38","Lancaster","President",1,"LIB","Gary Johnson",7109
-"39","Lancaster","President",1,"PET","Jill Stein",1974
-"40","Lancaster","President",1,"Write In","Write-ins",3654
-"41","Madison","President",1,"REP","Donald J. Trump",10628
-"42","Madison","President",1,"DEM","Hillary Clinton",2711
-"43","Madison","President",1,"LIB","Gary Johnson",669
-"44","Madison","President",1,"PET","Jill Stein",126
-"45","Madison","President",1,"Write In","Write-ins",209
-"46","Otoe","President",1,"REP","Donald J. Trump",4860
-"47","Otoe","President",1,"DEM","Hillary Clinton",2025
-"48","Otoe","President",1,"LIB","Gary Johnson",375
-"49","Otoe","President",1,"PET","Jill Stein",58
-"50","Otoe","President",1,"Write In","Write-ins",139
-"51","Platte","President",1,"REP","Donald J. Trump",10965
-"52","Platte","President",1,"DEM","Hillary Clinton",2646
-"53","Platte","President",1,"LIB","Gary Johnson",495
-"54","Platte","President",1,"PET","Jill Stein",86
-"55","Platte","President",1,"Write In","Write-ins",241
-"56","Polk","President",1,"REP","Donald J. Trump",2028
-"57","Polk","President",1,"DEM","Hillary Clinton",413
-"58","Polk","President",1,"LIB","Gary Johnson",102
-"59","Polk","President",1,"PET","Jill Stein",6
-"60","Polk","President",1,"Write In","Write-ins",33
-"61","Sarpy","President",1,"REP","Donald J. Trump",15656
-"62","Sarpy","President",1,"DEM","Hillary Clinton",10801
-"63","Sarpy","President",1,"LIB","Gary Johnson",1839
-"64","Sarpy","President",1,"PET","Jill Stein",371
-"65","Sarpy","President",1,"Write In","Write-ins",666
-"66","Saunders","President",1,"REP","Donald J. Trump",7555
-"67","Saunders","President",1,"DEM","Hillary Clinton",2523
-"68","Saunders","President",1,"LIB","Gary Johnson",515
-"69","Saunders","President",1,"PET","Jill Stein",97
-"70","Saunders","President",1,"Write In","Write-ins",170
-"71","Seward","President",1,"REP","Donald J. Trump",5454
-"72","Seward","President",1,"DEM","Hillary Clinton",1875
-"73","Seward","President",1,"LIB","Gary Johnson",337
-"74","Seward","President",1,"PET","Jill Stein",84
-"75","Seward","President",1,"Write In","Write-ins",172
-"76","Stanton","President",1,"REP","Donald J. Trump",2187
-"77","Stanton","President",1,"DEM","Hillary Clinton",417
-"78","Stanton","President",1,"LIB","Gary Johnson",144
-"79","Stanton","President",1,"PET","Jill Stein",14
-"80","Stanton","President",1,"Write In","Write-ins",39
-"81","Thurston","President",1,"REP","Donald J. Trump",1043
-"82","Thurston","President",1,"DEM","Hillary Clinton",919
-"83","Thurston","President",1,"LIB","Gary Johnson",56
-"84","Thurston","President",1,"PET","Jill Stein",49
-"85","Thurston","President",1,"Write In","Write-ins",21
-"86","Washington","President",1,"REP","Donald J. Trump",7424
-"87","Washington","President",1,"DEM","Hillary Clinton",2623
-"88","Washington","President",1,"LIB","Gary Johnson",513
-"89","Washington","President",1,"PET","Jill Stein",97
-"90","Washington","President",1,"Write In","Write-ins",175
-"91","Douglas","President",2,"REP","Donald J. Trump",108077
-"92","Douglas","President",2,"DEM","Hillary Clinton",113798
-"93","Douglas","President",2,"LIB","Gary Johnson",10402
-"94","Douglas","President",2,"PET","Jill Stein",2882
-"95","Douglas","President",2,"Write In","Write-ins",5274
-"96","Sarpy","President",2,"REP","Donald J. Trump",29487
-"97","Sarpy","President",2,"DEM","Hillary Clinton",17232
-"98","Sarpy","President",2,"LIB","Gary Johnson",2843
-"99","Sarpy","President",2,"PET","Jill Stein",465
-"100","Sarpy","President",2,"Write In","Write-ins",1220
-"101","Adams","President",3,"REP","Donald J. Trump",9287
-"102","Adams","President",3,"DEM","Hillary Clinton",3302
-"103","Adams","President",3,"LIB","Gary Johnson",594
-"104","Adams","President",3,"PET","Jill Stein",111
-"105","Adams","President",3,"Write In","Write-ins",219
-"106","Antelope","President",3,"REP","Donald J. Trump",2732
-"107","Antelope","President",3,"DEM","Hillary Clinton",383
-"108","Antelope","President",3,"LIB","Gary Johnson",105
-"109","Antelope","President",3,"PET","Jill Stein",19
-"110","Antelope","President",3,"Write In","Write-ins",42
-"111","Arthur","President",3,"REP","Donald J. Trump",244
-"112","Arthur","President",3,"DEM","Hillary Clinton",17
-"113","Arthur","President",3,"LIB","Gary Johnson",11
-"114","Arthur","President",3,"PET","Jill Stein",0
-"115","Arthur","President",3,"Write In","Write-ins",1
-"116","Banner","President",3,"REP","Donald J. Trump",357
-"117","Banner","President",3,"DEM","Hillary Clinton",19
-"118","Banner","President",3,"LIB","Gary Johnson",14
-"119","Banner","President",3,"PET","Jill Stein",3
-"120","Banner","President",3,"Write In","Write-ins",9
-"121","Blaine","President",3,"REP","Donald J. Trump",276
-"122","Blaine","President",3,"DEM","Hillary Clinton",30
-"123","Blaine","President",3,"LIB","Gary Johnson",10
-"124","Blaine","President",3,"PET","Jill Stein",0
-"125","Blaine","President",3,"Write In","Write-ins",1
-"126","Boone","President",3,"REP","Donald J. Trump",2299
-"127","Boone","President",3,"DEM","Hillary Clinton",414
-"128","Boone","President",3,"LIB","Gary Johnson",137
-"129","Boone","President",3,"PET","Jill Stein",17
-"130","Boone","President",3,"Write In","Write-ins",38
-"131","Box Butte","President",3,"REP","Donald J. Trump",3617
-"132","Box Butte","President",3,"DEM","Hillary Clinton",965
-"133","Box Butte","President",3,"LIB","Gary Johnson",230
-"134","Box Butte","President",3,"PET","Jill Stein",36
-"135","Box Butte","President",3,"Write In","Write-ins",76
-"136","Boyd","President",3,"REP","Donald J. Trump",983
-"137","Boyd","President",3,"DEM","Hillary Clinton",128
-"138","Boyd","President",3,"LIB","Gary Johnson",23
-"139","Boyd","President",3,"PET","Jill Stein",13
-"140","Boyd","President",3,"Write In","Write-ins",9
-"141","Brown","President",3,"REP","Donald J. Trump",1385
-"142","Brown","President",3,"DEM","Hillary Clinton",153
-"143","Brown","President",3,"LIB","Gary Johnson",39
-"144","Brown","President",3,"PET","Jill Stein",7
-"145","Brown","President",3,"Write In","Write-ins",13
-"146","Buffalo","President",3,"REP","Donald J. Trump",14569
-"147","Buffalo","President",3,"DEM","Hillary Clinton",4763
-"148","Buffalo","President",3,"LIB","Gary Johnson",1174
-"149","Buffalo","President",3,"PET","Jill Stein",227
-"150","Buffalo","President",3,"Write In","Write-ins",396
-"151","Cedar","President",3,"REP","Donald J. Trump",3532
-"152","Cedar","President",3,"DEM","Hillary Clinton",571
-"153","Cedar","President",3,"LIB","Gary Johnson",224
-"154","Cedar","President",3,"PET","Jill Stein",31
-"155","Cedar","President",3,"Write In","Write-ins",62
-"156","Chase","President",3,"REP","Donald J. Trump",1648
-"157","Chase","President",3,"DEM","Hillary Clinton",171
-"158","Chase","President",3,"LIB","Gary Johnson",54
-"159","Chase","President",3,"PET","Jill Stein",6
-"160","Chase","President",3,"Write In","Write-ins",19
-"161","Cherry","President",3,"REP","Donald J. Trump",2623
-"162","Cherry","President",3,"DEM","Hillary Clinton",317
-"163","Cherry","President",3,"LIB","Gary Johnson",127
-"164","Cherry","President",3,"PET","Jill Stein",15
-"165","Cherry","President",3,"Write In","Write-ins",36
-"166","Cheyenne","President",3,"REP","Donald J. Trump",3665
-"167","Cheyenne","President",3,"DEM","Hillary Clinton",711
-"168","Cheyenne","President",3,"LIB","Gary Johnson",213
-"169","Cheyenne","President",3,"PET","Jill Stein",46
-"170","Cheyenne","President",3,"Write In","Write-ins",76
-"171","Clay","President",3,"REP","Donald J. Trump",2422
-"172","Clay","President",3,"DEM","Hillary Clinton",477
-"173","Clay","President",3,"LIB","Gary Johnson",116
-"174","Clay","President",3,"PET","Jill Stein",15
-"175","Clay","President",3,"Write In","Write-ins",35
-"176","Custer","President",3,"REP","Donald J. Trump",4695
-"177","Custer","President",3,"DEM","Hillary Clinton",641
-"178","Custer","President",3,"LIB","Gary Johnson",206
-"179","Custer","President",3,"PET","Jill Stein",37
-"180","Custer","President",3,"Write In","Write-ins",73
-"181","Dakota","President",3,"REP","Donald J. Trump",3616
-"182","Dakota","President",3,"DEM","Hillary Clinton",2314
-"183","Dakota","President",3,"LIB","Gary Johnson",229
-"184","Dakota","President",3,"PET","Jill Stein",50
-"185","Dakota","President",3,"Write In","Write-ins",70
-"186","Dawes","President",3,"REP","Donald J. Trump",2632
-"187","Dawes","President",3,"DEM","Hillary Clinton",801
-"188","Dawes","President",3,"LIB","Gary Johnson",191
-"189","Dawes","President",3,"PET","Jill Stein",52
-"190","Dawes","President",3,"Write In","Write-ins",75
-"191","Dawson","President",3,"REP","Donald J. Trump",5984
-"192","Dawson","President",3,"DEM","Hillary Clinton",2136
-"193","Dawson","President",3,"LIB","Gary Johnson",381
-"194","Dawson","President",3,"PET","Jill Stein",58
-"195","Dawson","President",3,"Write In","Write-ins",76
-"196","Deuel","President",3,"REP","Donald J. Trump",809
-"197","Deuel","President",3,"DEM","Hillary Clinton",120
-"198","Deuel","President",3,"LIB","Gary Johnson",47
-"199","Deuel","President",3,"PET","Jill Stein",1
-"200","Deuel","President",3,"Write In","Write-ins",7
-"201","Dixon","President",3,"REP","Donald J. Trump",1911
-"202","Dixon","President",3,"DEM","Hillary Clinton",502
-"203","Dixon","President",3,"LIB","Gary Johnson",115
-"204","Dixon","President",3,"PET","Jill Stein",17
-"205","Dixon","President",3,"Write In","Write-ins",38
-"206","Dundy","President",3,"REP","Donald J. Trump",823
-"207","Dundy","President",3,"DEM","Hillary Clinton",89
-"208","Dundy","President",3,"LIB","Gary Johnson",31
-"209","Dundy","President",3,"PET","Jill Stein",6
-"210","Dundy","President",3,"Write In","Write-ins",4
-"211","Fillmore","President",3,"REP","Donald J. Trump",2130
-"212","Fillmore","President",3,"DEM","Hillary Clinton",613
-"213","Fillmore","President",3,"LIB","Gary Johnson",151
-"214","Fillmore","President",3,"PET","Jill Stein",21
-"215","Fillmore","President",3,"Write In","Write-ins",26
-"216","Franklin","President",3,"REP","Donald J. Trump",1347
-"217","Franklin","President",3,"DEM","Hillary Clinton",250
-"218","Franklin","President",3,"LIB","Gary Johnson",54
-"219","Franklin","President",3,"PET","Jill Stein",7
-"220","Franklin","President",3,"Write In","Write-ins",15
-"221","Frontier","President",3,"REP","Donald J. Trump",1110
-"222","Frontier","President",3,"DEM","Hillary Clinton",161
-"223","Frontier","President",3,"LIB","Gary Johnson",36
-"224","Frontier","President",3,"PET","Jill Stein",8
-"225","Frontier","President",3,"Write In","Write-ins",13
-"226","Furnas","President",3,"REP","Donald J. Trump",1921
-"227","Furnas","President",3,"DEM","Hillary Clinton",304
-"228","Furnas","President",3,"LIB","Gary Johnson",85
-"229","Furnas","President",3,"PET","Jill Stein",11
-"230","Furnas","President",3,"Write In","Write-ins",19
-"231","Gage","President",3,"REP","Donald J. Trump",6380
-"232","Gage","President",3,"DEM","Hillary Clinton",2935
-"233","Gage","President",3,"LIB","Gary Johnson",492
-"234","Gage","President",3,"PET","Jill Stein",104
-"235","Gage","President",3,"Write In","Write-ins",137
-"236","Garden","President",3,"REP","Donald J. Trump",869
-"237","Garden","President",3,"DEM","Hillary Clinton",153
-"238","Garden","President",3,"LIB","Gary Johnson",39
-"239","Garden","President",3,"PET","Jill Stein",2
-"240","Garden","President",3,"Write In","Write-ins",12
-"241","Garfield","President",3,"REP","Donald J. Trump",821
-"242","Garfield","President",3,"DEM","Hillary Clinton",121
-"243","Garfield","President",3,"LIB","Gary Johnson",23
-"244","Garfield","President",3,"PET","Jill Stein",5
-"245","Garfield","President",3,"Write In","Write-ins",10
-"246","Gosper","President",3,"REP","Donald J. Trump",794
-"247","Gosper","President",3,"DEM","Hillary Clinton",166
-"248","Gosper","President",3,"LIB","Gary Johnson",38
-"249","Gosper","President",3,"PET","Jill Stein",6
-"250","Gosper","President",3,"Write In","Write-ins",6
-"251","Grant","President",3,"REP","Donald J. Trump",367
-"252","Grant","President",3,"DEM","Hillary Clinton",20
-"253","Grant","President",3,"LIB","Gary Johnson",6
-"254","Grant","President",3,"PET","Jill Stein",1
-"255","Grant","President",3,"Write In","Write-ins",11
-"256","Greeley","President",3,"REP","Donald J. Trump",912
-"257","Greeley","President",3,"DEM","Hillary Clinton",210
-"258","Greeley","President",3,"LIB","Gary Johnson",38
-"259","Greeley","President",3,"PET","Jill Stein",6
-"260","Greeley","President",3,"Write In","Write-ins",9
-"261","Hall","President",3,"REP","Donald J. Trump",14408
-"262","Hall","President",3,"DEM","Hillary Clinton",6282
-"263","Hall","President",3,"LIB","Gary Johnson",895
-"264","Hall","President",3,"PET","Jill Stein",192
-"265","Hall","President",3,"Write In","Write-ins",283
-"266","Hamilton","President",3,"REP","Donald J. Trump",3783
-"267","Hamilton","President",3,"DEM","Hillary Clinton",878
-"268","Hamilton","President",3,"LIB","Gary Johnson",224
-"269","Hamilton","President",3,"PET","Jill Stein",43
-"270","Hamilton","President",3,"Write In","Write-ins",76
-"271","Harlan","President",3,"REP","Donald J. Trump",1496
-"272","Harlan","President",3,"DEM","Hillary Clinton",254
-"273","Harlan","President",3,"LIB","Gary Johnson",62
-"274","Harlan","President",3,"PET","Jill Stein",7
-"275","Harlan","President",3,"Write In","Write-ins",13
-"276","Hayes","President",3,"REP","Donald J. Trump",472
-"277","Hayes","President",3,"DEM","Hillary Clinton",30
-"278","Hayes","President",3,"LIB","Gary Johnson",8
-"279","Hayes","President",3,"PET","Jill Stein",1
-"280","Hayes","President",3,"Write In","Write-ins",3
-"281","Hitchcock","President",3,"REP","Donald J. Trump",1232
-"282","Hitchcock","President",3,"DEM","Hillary Clinton",161
-"283","Hitchcock","President",3,"LIB","Gary Johnson",61
-"284","Hitchcock","President",3,"PET","Jill Stein",7
-"285","Hitchcock","President",3,"Write In","Write-ins",7
-"286","Holt","President",3,"REP","Donald J. Trump",4354
-"287","Holt","President",3,"DEM","Hillary Clinton",531
-"288","Holt","President",3,"LIB","Gary Johnson",162
-"289","Holt","President",3,"PET","Jill Stein",27
-"290","Holt","President",3,"Write In","Write-ins",44
-"291","Hooker","President",3,"REP","Donald J. Trump",355
-"292","Hooker","President",3,"DEM","Hillary Clinton",40
-"293","Hooker","President",3,"LIB","Gary Johnson",16
-"294","Hooker","President",3,"PET","Jill Stein",3
-"295","Hooker","President",3,"Write In","Write-ins",3
-"296","Howard","President",3,"REP","Donald J. Trump",2284
-"297","Howard","President",3,"DEM","Hillary Clinton",544
-"298","Howard","President",3,"LIB","Gary Johnson",108
-"299","Howard","President",3,"PET","Jill Stein",22
-"300","Howard","President",3,"Write In","Write-ins",36
-"301","Jefferson","President",3,"REP","Donald J. Trump",2399
-"302","Jefferson","President",3,"DEM","Hillary Clinton",837
-"303","Jefferson","President",3,"LIB","Gary Johnson",182
-"304","Jefferson","President",3,"PET","Jill Stein",30
-"305","Jefferson","President",3,"Write In","Write-ins",46
-"306","Johnson","President",3,"REP","Donald J. Trump",1355
-"307","Johnson","President",3,"DEM","Hillary Clinton",563
-"308","Johnson","President",3,"LIB","Gary Johnson",122
-"309","Johnson","President",3,"PET","Jill Stein",22
-"310","Johnson","President",3,"Write In","Write-ins",27
-"311","Kearney","President",3,"REP","Donald J. Trump",2531
-"312","Kearney","President",3,"DEM","Hillary Clinton",550
-"313","Kearney","President",3,"LIB","Gary Johnson",148
-"314","Kearney","President",3,"PET","Jill Stein",26
-"315","Kearney","President",3,"Write In","Write-ins",41
-"316","Keith","President",3,"REP","Donald J. Trump",3235
-"317","Keith","President",3,"DEM","Hillary Clinton",571
-"318","Keith","President",3,"LIB","Gary Johnson",164
-"319","Keith","President",3,"PET","Jill Stein",25
-"320","Keith","President",3,"Write In","Write-ins",39
-"321","Keya Paha","President",3,"REP","Donald J. Trump",460
-"322","Keya Paha","President",3,"DEM","Hillary Clinton",40
-"323","Keya Paha","President",3,"LIB","Gary Johnson",17
-"324","Keya Paha","President",3,"PET","Jill Stein",0
-"325","Keya Paha","President",3,"Write In","Write-ins",2
-"326","Kimball","President",3,"REP","Donald J. Trump",1330
-"327","Kimball","President",3,"DEM","Hillary Clinton",230
-"328","Kimball","President",3,"LIB","Gary Johnson",78
-"329","Kimball","President",3,"PET","Jill Stein",18
-"330","Kimball","President",3,"Write In","Write-ins",21
-"331","Knox","President",3,"REP","Donald J. Trump",3188
-"332","Knox","President",3,"DEM","Hillary Clinton",720
-"333","Knox","President",3,"LIB","Gary Johnson",137
-"334","Knox","President",3,"PET","Jill Stein",29
-"335","Knox","President",3,"Write In","Write-ins",41
-"336","Lincoln","President",3,"REP","Donald J. Trump",12164
-"337","Lincoln","President",3,"DEM","Hillary Clinton",2913
-"338","Lincoln","President",3,"LIB","Gary Johnson",711
-"339","Lincoln","President",3,"PET","Jill Stein",107
-"340","Lincoln","President",3,"Write In","Write-ins",236
-"341","Logan","President",3,"REP","Donald J. Trump",400
-"342","Logan","President",3,"DEM","Hillary Clinton",32
-"343","Logan","President",3,"LIB","Gary Johnson",18
-"344","Logan","President",3,"PET","Jill Stein",1
-"345","Logan","President",3,"Write In","Write-ins",2
-"346","Loup","President",3,"REP","Donald J. Trump",323
-"347","Loup","President",3,"DEM","Hillary Clinton",48
-"348","Loup","President",3,"LIB","Gary Johnson",10
-"349","Loup","President",3,"PET","Jill Stein",1
-"350","Loup","President",3,"Write In","Write-ins",3
-"351","McPherson","President",3,"REP","Donald J. Trump",257
-"352","McPherson","President",3,"DEM","Hillary Clinton",14
-"353","McPherson","President",3,"LIB","Gary Johnson",14
-"354","McPherson","President",3,"PET","Jill Stein",1
-"355","McPherson","President",3,"Write In","Write-ins",1
-"356","Merrick","President",3,"REP","Donald J. Trump",2926
-"357","Merrick","President",3,"DEM","Hillary Clinton",602
-"358","Merrick","President",3,"LIB","Gary Johnson",165
-"359","Merrick","President",3,"PET","Jill Stein",29
-"360","Merrick","President",3,"Write In","Write-ins",66
-"361","Morrill","President",3,"REP","Donald J. Trump",1802
-"362","Morrill","President",3,"DEM","Hillary Clinton",284
-"363","Morrill","President",3,"LIB","Gary Johnson",84
-"364","Morrill","President",3,"PET","Jill Stein",14
-"365","Morrill","President",3,"Write In","Write-ins",25
-"366","Nance","President",3,"REP","Donald J. Trump",1261
-"367","Nance","President",3,"DEM","Hillary Clinton",281
-"368","Nance","President",3,"LIB","Gary Johnson",48
-"369","Nance","President",3,"PET","Jill Stein",14
-"370","Nance","President",3,"Write In","Write-ins",17
-"371","Nemaha","President",3,"REP","Donald J. Trump",2116
-"372","Nemaha","President",3,"DEM","Hillary Clinton",785
-"373","Nemaha","President",3,"LIB","Gary Johnson",180
-"374","Nemaha","President",3,"PET","Jill Stein",27
-"375","Nemaha","President",3,"Write In","Write-ins",53
-"376","Nuckolls","President",3,"REP","Donald J. Trump",1726
-"377","Nuckolls","President",3,"DEM","Hillary Clinton",353
-"378","Nuckolls","President",3,"LIB","Gary Johnson",88
-"379","Nuckolls","President",3,"PET","Jill Stein",20
-"380","Nuckolls","President",3,"Write In","Write-ins",18
-"381","Pawnee","President",3,"REP","Donald J. Trump",974
-"382","Pawnee","President",3,"DEM","Hillary Clinton",279
-"383","Pawnee","President",3,"LIB","Gary Johnson",55
-"384","Pawnee","President",3,"PET","Jill Stein",10
-"385","Pawnee","President",3,"Write In","Write-ins",9
-"386","Perkins","President",3,"REP","Donald J. Trump",1217
-"387","Perkins","President",3,"DEM","Hillary Clinton",161
-"388","Perkins","President",3,"LIB","Gary Johnson",54
-"389","Perkins","President",3,"PET","Jill Stein",5
-"390","Perkins","President",3,"Write In","Write-ins",18
-"391","Phelps","President",3,"REP","Donald J. Trump",3849
-"392","Phelps","President",3,"DEM","Hillary Clinton",572
-"393","Phelps","President",3,"LIB","Gary Johnson",190
-"394","Phelps","President",3,"PET","Jill Stein",18
-"395","Phelps","President",3,"Write In","Write-ins",66
-"396","Pierce","President",3,"REP","Donald J. Trump",3052
-"397","Pierce","President",3,"DEM","Hillary Clinton",382
-"398","Pierce","President",3,"LIB","Gary Johnson",125
-"399","Pierce","President",3,"PET","Jill Stein",21
-"400","Pierce","President",3,"Write In","Write-ins",50
-"401","Red Willow","President",3,"REP","Donald J. Trump",4258
-"402","Red Willow","President",3,"DEM","Hillary Clinton",645
-"403","Red Willow","President",3,"LIB","Gary Johnson",191
-"404","Red Willow","President",3,"PET","Jill Stein",26
-"405","Red Willow","President",3,"Write In","Write-ins",50
-"406","Richardson","President",3,"REP","Donald J. Trump",2769
-"407","Richardson","President",3,"DEM","Hillary Clinton",818
-"408","Richardson","President",3,"LIB","Gary Johnson",159
-"409","Richardson","President",3,"PET","Jill Stein",27
-"410","Richardson","President",3,"Write In","Write-ins",32
-"411","Rock","President",3,"REP","Donald J. Trump",687
-"412","Rock","President",3,"DEM","Hillary Clinton",70
-"413","Rock","President",3,"LIB","Gary Johnson",33
-"414","Rock","President",3,"PET","Jill Stein",4
-"415","Rock","President",3,"Write In","Write-ins",4
-"416","Saline","President",3,"REP","Donald J. Trump",3004
-"417","Saline","President",3,"DEM","Hillary Clinton",1733
-"418","Saline","President",3,"LIB","Gary Johnson",284
-"419","Saline","President",3,"PET","Jill Stein",52
-"420","Saline","President",3,"Write In","Write-ins",63
-"421","Scotts Bluff","President",3,"REP","Donald J. Trump",10076
-"422","Scotts Bluff","President",3,"DEM","Hillary Clinton",3207
-"423","Scotts Bluff","President",3,"LIB","Gary Johnson",683
-"424","Scotts Bluff","President",3,"PET","Jill Stein",126
-"425","Scotts Bluff","President",3,"Write In","Write-ins",225
-"426","Sheridan","President",3,"REP","Donald J. Trump",2211
-"427","Sheridan","President",3,"DEM","Hillary Clinton",287
-"428","Sheridan","President",3,"LIB","Gary Johnson",70
-"429","Sheridan","President",3,"PET","Jill Stein",18
-"430","Sheridan","President",3,"Write In","Write-ins",22
-"431","Sherman","President",3,"REP","Donald J. Trump",1150
-"432","Sherman","President",3,"DEM","Hillary Clinton",340
-"433","Sherman","President",3,"LIB","Gary Johnson",59
-"434","Sherman","President",3,"PET","Jill Stein",13
-"435","Sherman","President",3,"Write In","Write-ins",11
-"436","Sioux","President",3,"REP","Donald J. Trump",616
-"437","Sioux","President",3,"DEM","Hillary Clinton",81
-"438","Sioux","President",3,"LIB","Gary Johnson",28
-"439","Sioux","President",3,"PET","Jill Stein",4
-"440","Sioux","President",3,"Write In","Write-ins",7
-"441","Thayer","President",3,"REP","Donald J. Trump",2051
-"442","Thayer","President",3,"DEM","Hillary Clinton",499
-"443","Thayer","President",3,"LIB","Gary Johnson",124
-"444","Thayer","President",3,"PET","Jill Stein",10
-"445","Thayer","President",3,"Write In","Write-ins",6
-"446","Thomas","President",3,"REP","Donald J. Trump",344
-"447","Thomas","President",3,"DEM","Hillary Clinton",30
-"448","Thomas","President",3,"LIB","Gary Johnson",10
-"449","Thomas","President",3,"PET","Jill Stein",3
-"450","Thomas","President",3,"Write In","Write-ins",6
-"451","Valley","President",3,"REP","Donald J. Trump",1780
-"452","Valley","President",3,"DEM","Hillary Clinton",339
-"453","Valley","President",3,"LIB","Gary Johnson",53
-"454","Valley","President",3,"PET","Jill Stein",12
-"455","Valley","President",3,"Write In","Write-ins",21
-"456","Wayne","President",3,"REP","Donald J. Trump",2693
-"457","Wayne","President",3,"DEM","Hillary Clinton",835
-"458","Wayne","President",3,"LIB","Gary Johnson",202
-"459","Wayne","President",3,"PET","Jill Stein",35
-"460","Wayne","President",3,"Write In","Write-ins",11
-"461","Webster","President",3,"REP","Donald J. Trump",1330
-"462","Webster","President",3,"DEM","Hillary Clinton",306
-"463","Webster","President",3,"LIB","Gary Johnson",51
-"464","Webster","President",3,"PET","Jill Stein",10
-"465","Webster","President",3,"Write In","Write-ins",11
-"466","Wheeler","President",3,"REP","Donald J. Trump",377
-"467","Wheeler","President",3,"DEM","Hillary Clinton",62
-"468","Wheeler","President",3,"LIB","Gary Johnson",17
-"469","Wheeler","President",3,"PET","Jill Stein",4
-"470","Wheeler","President",3,"Write In","Write-ins",5
-"471","York","President",3,"REP","Donald J. Trump",4700
-"472","York","President",3,"DEM","Hillary Clinton",1186
-"473","York","President",3,"LIB","Gary Johnson",345
-"474","York","President",3,"PET","Jill Stein",52
-"475","York","President",3,"Write In","Write-ins",98
-"476","Burt","U.S. House",1,"REP","Jeff Fortenberry",2648
-"477","Burt","U.S. House",1,"DEM","Daniel M. Wik",751
-"478","Butler","U.S. House",1,"REP","Jeff Fortenberry",3231
-"479","Butler","U.S. House",1,"DEM","Daniel M. Wik",573
-"480","Cass","U.S. House",1,"REP","Jeff Fortenberry",9323
-"481","Cass","U.S. House",1,"DEM","Daniel M. Wik",2993
-"482","Colfax","U.S. House",1,"REP","Jeff Fortenberry",2416
-"483","Colfax","U.S. House",1,"DEM","Daniel M. Wik",737
-"484","Cuming","U.S. House",1,"REP","Jeff Fortenberry",3447
-"485","Cuming","U.S. House",1,"DEM","Daniel M. Wik",527
-"486","Dixon","U.S. House",1,"REP","Jeff Fortenberry",64
-"487","Dixon","U.S. House",1,"DEM","Daniel M. Wik",26
-"488","Dodge","U.S. House",1,"REP","Jeff Fortenberry",11481
-"489","Dodge","U.S. House",1,"DEM","Daniel M. Wik",3488
-"490","Lancaster","U.S. House",1,"REP","Jeff Fortenberry",81497
-"491","Lancaster","U.S. House",1,"DEM","Daniel M. Wik",50659
-"492","Madison","U.S. House",1,"REP","Jeff Fortenberry",11336
-"493","Madison","U.S. House",1,"DEM","Daniel M. Wik",2728
-"494","Otoe","U.S. House",1,"REP","Jeff Fortenberry",5649
-"495","Otoe","U.S. House",1,"DEM","Daniel M. Wik",1613
-"496","Platte","U.S. House",1,"REP","Jeff Fortenberry",11389
-"497","Platte","U.S. House",1,"DEM","Daniel M. Wik",2468
-"498","Polk","U.S. House",1,"REP","Jeff Fortenberry",2138
-"499","Polk","U.S. House",1,"DEM","Daniel M. Wik",349
-"500","Sarpy","U.S. House",1,"REP","Jeff Fortenberry",18745
-"501","Sarpy","U.S. House",1,"DEM","Daniel M. Wik",9544
-"502","Saunders","U.S. House",1,"REP","Jeff Fortenberry",8287
-"503","Saunders","U.S. House",1,"DEM","Daniel M. Wik",2203
-"504","Seward","U.S. House",1,"REP","Jeff Fortenberry",6253
-"505","Seward","U.S. House",1,"DEM","Daniel M. Wik",1518
-"506","Stanton","U.S. House",1,"REP","Jeff Fortenberry",2341
-"507","Stanton","U.S. House",1,"DEM","Daniel M. Wik",426
-"508","Thurston","U.S. House",1,"REP","Jeff Fortenberry",1262
-"509","Thurston","U.S. House",1,"DEM","Daniel M. Wik",740
-"510","Washington","U.S. House",1,"REP","Jeff Fortenberry",8264
-"511","Washington","U.S. House",1,"DEM","Daniel M. Wik",2124
-"512","Douglas","U.S. House",2,"REP","Don Bacon",110391
-"513","Douglas","U.S. House",2,"DEM","Brad Ashford",119230
-"514","Douglas","U.S. House",2,"LIB","Steven Laird",7944
-"515","Sarpy","U.S. House",2,"REP","Don Bacon",30675
-"516","Sarpy","U.S. House",2,"DEM","Brad Ashford",18372
-"517","Sarpy","U.S. House",2,"LIB","Steven Laird",1696
-"518","Adams","U.S. House",3,"REP","Adrian Smith",10938
-"519","Antelope","U.S. House",3,"REP","Adrian Smith",2808
-"520","Arthur","U.S. House",3,"REP","Adrian Smith",254
-"521","Banner","U.S. House",3,"REP","Adrian Smith",344
-"522","Blaine","U.S. House",3,"REP","Adrian Smith",276
-"523","Boone","U.S. House",3,"REP","Adrian Smith",2437
-"524","Box Butte","U.S. House",3,"REP","Adrian Smith",4202
-"525","Boyd","U.S. House",3,"REP","Adrian Smith",948
-"526","Brown","U.S. House",3,"REP","Adrian Smith",1381
-"527","Buffalo","U.S. House",3,"REP","Adrian Smith",17654
-"528","Cedar","U.S. House",3,"REP","Adrian Smith",3835
-"529","Chase","U.S. House",3,"REP","Adrian Smith",1697
-"530","Cherry","U.S. House",3,"REP","Adrian Smith",2527
-"531","Cheyenne","U.S. House",3,"REP","Adrian Smith",4160
-"532","Clay","U.S. House",3,"REP","Adrian Smith",2685
-"533","Custer","U.S. House",3,"REP","Adrian Smith",4959
-"534","Dakota","U.S. House",3,"REP","Adrian Smith",4723
-"535","Dawes","U.S. House",3,"REP","Adrian Smith",3169
-"536","Dawson","U.S. House",3,"REP","Adrian Smith",7335
-"537","Deuel","U.S. House",3,"REP","Adrian Smith",876
-"538","Dixon","U.S. House",3,"REP","Adrian Smith",2233
-"539","Dundy","U.S. House",3,"REP","Adrian Smith",841
-"540","Fillmore","U.S. House",3,"REP","Adrian Smith",2526
-"541","Franklin","U.S. House",3,"REP","Adrian Smith",1451
-"542","Frontier","U.S. House",3,"REP","Adrian Smith",1178
-"543","Furnas","U.S. House",3,"REP","Adrian Smith",2119
-"544","Gage","U.S. House",3,"REP","Adrian Smith",8032
-"545","Garden","U.S. House",3,"REP","Adrian Smith",942
-"546","Garfield","U.S. House",3,"REP","Adrian Smith",853
-"547","Gosper","U.S. House",3,"REP","Adrian Smith",890
-"548","Grant","U.S. House",3,"REP","Adrian Smith",362
-"549","Greeley","U.S. House",3,"REP","Adrian Smith",955
-"550","Hall","U.S. House",3,"REP","Adrian Smith",17328
-"551","Hamilton","U.S. House",3,"REP","Adrian Smith",4203
-"552","Harlan","U.S. House",3,"REP","Adrian Smith",1602
-"553","Hayes","U.S. House",3,"REP","Adrian Smith",445
-"554","Hitchcock","U.S. House",3,"REP","Adrian Smith",1306
-"555","Holt","U.S. House",3,"REP","Adrian Smith",4402
-"556","Hooker","U.S. House",3,"REP","Adrian Smith",368
-"557","Howard","U.S. House",3,"REP","Adrian Smith",2483
-"558","Jefferson","U.S. House",3,"REP","Adrian Smith",2973
-"559","Johnson","U.S. House",3,"REP","Adrian Smith",1627
-"560","Kearney","U.S. House",3,"REP","Adrian Smith",2916
-"561","Keith","U.S. House",3,"REP","Adrian Smith",3504
-"562","Keya Paha","U.S. House",3,"REP","Adrian Smith",433
-"563","Kimball","U.S. House",3,"REP","Adrian Smith",1491
-"564","Knox","U.S. House",3,"REP","Adrian Smith",3492
-"565","Lincoln","U.S. House",3,"REP","Adrian Smith",13675
-"566","Logan","U.S. House",3,"REP","Adrian Smith",401
-"567","Loup","U.S. House",3,"REP","Adrian Smith",325
-"568","McPherson","U.S. House",3,"REP","Adrian Smith",256
-"569","Merrick","U.S. House",3,"REP","Adrian Smith",3179
-"570","Morrill","U.S. House",3,"REP","Adrian Smith",1899
-"571","Nance","U.S. House",3,"REP","Adrian Smith",1276
-"572","Nemaha","U.S. House",3,"REP","Adrian Smith",2622
-"573","Nuckolls","U.S. House",3,"REP","Adrian Smith",1909
-"574","Pawnee","U.S. House",3,"REP","Adrian Smith",1113
-"575","Perkins","U.S. House",3,"REP","Adrian Smith",1332
-"576","Phelps","U.S. House",3,"REP","Adrian Smith",4142
-"577","Pierce","U.S. House",3,"REP","Adrian Smith",3172
-"578","Red Willow","U.S. House",3,"REP","Adrian Smith",4589
-"579","Richardson","U.S. House",3,"REP","Adrian Smith",2995
-"580","Rock","U.S. House",3,"REP","Adrian Smith",693
-"581","Saline","U.S. House",3,"REP","Adrian Smith",3996
-"582","Scotts Bluff","U.S. House",3,"REP","Adrian Smith",11678
-"583","Sheridan","U.S. House",3,"REP","Adrian Smith",2203
-"584","Sherman","U.S. House",3,"REP","Adrian Smith",1301
-"585","Sioux","U.S. House",3,"REP","Adrian Smith",624
-"586","Thayer","U.S. House",3,"REP","Adrian Smith",2308
-"587","Thomas","U.S. House",3,"REP","Adrian Smith",340
-"588","Valley","U.S. House",3,"REP","Adrian Smith",1909
-"589","Wayne","U.S. House",3,"REP","Adrian Smith",3222
-"590","Webster","U.S. House",3,"REP","Adrian Smith",1448
-"591","Wheeler","U.S. House",3,"REP","Adrian Smith",406
-"592","York","U.S. House",3,"REP","Adrian Smith",5544
-"593","Johnson","State Legislature",1,"","Dan Watermeier",1731
-"594","Nemaha","State Legislature",1,"","Dan Watermeier",2658
-"595","Otoe","State Legislature",1,"","Dan Watermeier",5351
-"596","Pawnee","State Legislature",1,"","Dan Watermeier",1101
-"597","Richardson","State Legislature",1,"","Dan Watermeier",3075
-"598","Sarpy","State Legislature",3,"","Carol Blood",7959
-"599","Sarpy","State Legislature",3,"","Tommy Garrett",7476
-"600","Douglas","State Legislature",5,"","Gilbert Ayala",3028
-"601","Douglas","State Legislature",5,"","Mike McDonnell",7120
-"602","Douglas","State Legislature",7,"","John Synowiecki",3248
-"603","Douglas","State Legislature",7,"","Tony Vargas",5244
-"604","Douglas","State Legislature",9,"","Larry Roland",2773
-"605","Douglas ","State Legislature",9,"","Sara Howard",10552
-"606","Douglas","State Legislature",11,"","Ernie Chambers",7763
-"607","Douglas","State Legislature",11,"","John Sciara",1726
-"608","Douglas","State Legislature",13,"","Jill Brown",6605
-"609","Douglas","State Legislature",13,"","Justin Wayne",6920
-"610","Dodge","State Legislature",15,"","David A. Schnoor",7189
-"611","Dodge","State Legislature",15,"","Lynne M. Walz",7601
-"612","Dakota","State Legislature",17,"","Ardel Bengtson",2859
-"613","Dakota","State Legislature",17,"","Joni Albrecht",2929
-"614","Thurston","State Legislature",17,"","Ardel Bengtson",533
-"615","Thurston","State Legislature",17,"","Joni Albrecht",1385
-"616","Wayne","State Legislature",17,"","Ardel Bengtson",1059
-"617","Wayne","State Legislature",17,"","Joni Albrecht",2511
-"618","Madison","State Legislature",19,"","Jim Scheer",12040
-"619","Stanton","State Legislature",19,"","Jim Scheer",868
-"620","Lancaster","State Legislature",21,"","Larry Scherer",6567
-"621","Lancaster ","State Legislature",21,"","Mike Hilgers",8588
-"622","Butler","State Legislature",23,"","Bruce Bostelman",2472
-"623","Butler","State Legislature",23,"","Jerry Johnson",1214
-"624","Colfax","State Legislature",23,"","Bruce Bostelman",1114
-"625","Colfax","State Legislature",23,"","Jerry Johnson",1094
-"626","Saunders","State Legislature",23,"","Bruce Bostelman",5107
-"627","Saunders","State Legislature",23,"","Jerry Johnson",4642
-"628","Lancaster","State Legislature",25,"","Jim Gordon",10258
-"629","Lancaster","State Legislature",25,"","Suzanne Geist",12899
-"630","Lancaster ","State Legislature",27,"","Anna Wishart",9930
-"631","Lancaster ","State Legislature",27,"","Dick Clark",3657
-"632","Lancaster","State Legislature",29,"","Kate Bolz",14821
-"633","Lancaster","State Legislature",29,"","Melody Vaccaro",2936
-"634","Douglas","State Legislature",31,"","Ian M. Swanson",8985
-"635","Douglas","State Legislature",31,"","Rick Kolowski",9762
-"636","Adams","State Legislature",33,"","Les Seiler",5150
-"637","Adams","State Legislature",33,"","Steve Halloran",7714
-"638","Hall","State Legislature",33,"","Les Seiler",903
-"639","Hall","State Legislature",33,"","Steve Halloran",1450
-"640","Hall","State Legislature",35,"","Dan Quick",5743
-"641","Hall","State Legislature",35,"","Gregg Neuhaus",5668
-"642","Buffalo","State Legislature",37,"","Bob Lammers",7547
-"643","Buffalo","State Legislature",37,"","John S. Lowe Sr.",8600
-"644","Douglas","State Legislature",39,"","Bill Armbrust",9646
-"645","Douglas","State Legislature",39,"","Lou Ann Linehan",11729
-"646","Antelope","State Legislature",41,"","Tom Briese",2285
-"647","Boone","State Legislature",41,"","Tom Briese",2518
-"648","Garfield","State Legislature",41,"","Tom Briese",655
-"649","Greeley","State Legislature",41,"","Tom Briese",758
-"650","Howard","State Legislature",41,"","Tom Briese",2099
-"651","Pierce","State Legislature",41,"","Tom Briese",2736
-"652","Sherman","State Legislature",41,"","Tom Briese",1092
-"653","Valley","State Legislature",41,"","Tom Briese",1609
-"654","Wheeler","State Legislature",41,"","Tom Briese",328
-"655","Blaine","State Legislature",43,"","Al Davis",130
-"656","Blaine","State Legislature",43,"","Tom Brewer",179
-"657","Box Butte","State Legislature",43,"","Al Davis",2482
-"658","Box Butte","State Legislature",43,"","Tom Brewer",1216
-"659","Brown","State Legislature",43,"","Al Davis",785
-"660","Brown","State Legislature",43,"","Tom Brewer",783
-"661","Cherry","State Legislature",43,"","Al Davis",940
-"662","Cherry","State Legislature",43,"","Tom Brewer",2069
-"663","Dawes","State Legislature",43,"","Al Davis",2113
-"664","Dawes","State Legislature",43,"","Tom Brewer",1526
-"665","Grant","State Legislature",43,"","Al Davis",207
-"666","Grant","State Legislature",43,"","Tom Brewer",192
-"667","Hooker","State Legislature",43,"","Al Davis",199
-"668","Hooker","State Legislature",43,"","Tom Brewer",204
-"669","Keya Paha","State Legislature",43,"","Al Davis",187
-"670","Keya Paha","State Legislature",43,"","Tom Brewer",295
-"671","Logan","State Legislature",43,"","Al Davis",179
-"672","Logan","State Legislature",43,"","Tom Brewer",241
-"673","Loup","State Legislature",43,"","Al Davis",211
-"674","Loup","State Legislature",43,"","Tom Brewer",148
-"675","McPherson","State Legislature",43,"","Al Davis",142
-"676","McPherson","State Legislature",43,"","Tom Brewer",135
-"677","Sheridan","State Legislature",43,"","Al Davis",648
-"678","Sheridan","State Legislature",43,"","Tom Brewer",1950
-"679","Thomas","State Legislature",43,"","Al Davis",153
-"680","Thomas","State Legislature",43,"","Tom Brewer",231
-"681","Sarpy","State Legislature",45,"","Michael J. Cook",6734
-"682","Sarpy","State Legislature",45,"","Sue Crawford",8774
-"683","Arthur","State Legislature",47,"","Karl Elmshaeuser",98
-"684","Arthur","State Legislature",47,"","Steve Erdman",156
-"685","Banner","State Legislature",47,"","Karl Elmshaeuser",90
-"686","Banner","State Legislature",47,"","Steve Erdman",277
-"687","Box Butte","State Legislature",47,"","Karl Elmshaeuser",193
-"688","Box Butte","State Legislature",47,"","Steve Erdman",756
-"689","Cheyenne","State Legislature",47,"","Karl Elmshaeuser",1372
-"690","Cheyenne","State Legislature",47,"","Steve Erdman",3000
-"691","Deuel","State Legislature",47,"","Karl Elmshaeuser",236
-"692","Deuel","State Legislature",47,"","Steve Erdman",691
-"693","Garden","State Legislature",47,"","Karl Elmshaeuser",236
-"694","Garden","State Legislature",47,"","Steve Erdman",761
-"695","Keith","State Legislature",47,"","Karl Elmshaeuser",1657
-"696","Keith","State Legislature",47,"","Steve Erdman",2131
-"697","Kimball","State Legislature",47,"","Karl Elmshaeuser",402
-"698","Kimball","State Legislature",47,"","Steve Erdman",1144
-"699","Morrill","State Legislature",47,"","Karl Elmshaeuser",833
-"700","Morrill","State Legislature",47,"","Steve Erdman",1305
-"701","Sioux","State Legislature",47,"","Karl Elmshaeuser",113
-"702","SIoux","State Legislature",47,"","Steve Erdman",518
-"703","Sarpy","State Legislature",49,"","John Murante",15137
+,county,office,district,party,candidate,votes
+1,Burt,President,1,REP,Donald J. Trump,2367
+2,Burt,President,1,DEM,Hillary Clinton,930
+3,Burt,President,1,LIB,Gary Johnson,197
+4,Burt,President,1,PET,Jill Stein,39
+5,Burt,President,1,Write In,Write-ins,25
+6,Butler,President,1,REP,Donald J. Trump,3079
+7,Butler,President,1,DEM,Hillary Clinton,691
+8,Butler,President,1,LIB,Gary Johnson,129
+9,Butler,President,1,PET,Jill Stein,27
+10,Butler,President,1,Write In,Write-ins,55
+11,Cass,President,1,REP,Donald J. Trump,8452
+12,Cass,President,1,DEM,Hillary Clinton,3484
+13,Cass,President,1,LIB,Gary Johnson,639
+14,Cass,President,1,PET,Jill Stein,132
+15,Cass,President,1,Write In,Write-ins,226
+16,Colfax,President,1,REP,Donald J. Trump,2171
+17,Colfax,President,1,DEM,Hillary Clinton,859
+18,Colfax,President,1,LIB,Gary Johnson,118
+19,Colfax,President,1,PET,Jill Stein,26
+20,Colfax,President,1,Write In,Write-ins,40
+21,Cuming,President,1,REP,Donald J. Trump,3122
+22,Cuming,President,1,DEM,Hillary Clinton,719
+23,Cuming,President,1,LIB,Gary Johnson,157
+24,Cuming,President,1,PET,Jill Stein,26
+25,Cuming,President,1,Write In,Write-ins,50
+26,Dixon,President,1,REP,Donald J. Trump,130
+27,Dixon,President,1,DEM,Hillary Clinton,54
+28,Dixon,President,1,LIB,Gary Johnson,15
+29,Dixon,President,1,PET,Jill Stein,1
+30,Dixon,President,1,Write In,Write-ins,0
+31,Dodge,President,1,REP,Donald J. Trump,9933
+32,Dodge,President,1,DEM,Hillary Clinton,4544
+33,Dodge,President,1,LIB,Gary Johnson,624
+34,Dodge,President,1,PET,Jill Stein,162
+35,Dodge,President,1,Write In,Write-ins,266
+36,Lancaster,President,1,REP,Donald J. Trump,61588
+37,Lancaster,President,1,DEM,Hillary Clinton,61898
+38,Lancaster,President,1,LIB,Gary Johnson,7109
+39,Lancaster,President,1,PET,Jill Stein,1974
+40,Lancaster,President,1,Write In,Write-ins,3654
+41,Madison,President,1,REP,Donald J. Trump,10628
+42,Madison,President,1,DEM,Hillary Clinton,2711
+43,Madison,President,1,LIB,Gary Johnson,669
+44,Madison,President,1,PET,Jill Stein,126
+45,Madison,President,1,Write In,Write-ins,209
+46,Otoe,President,1,REP,Donald J. Trump,4860
+47,Otoe,President,1,DEM,Hillary Clinton,2025
+48,Otoe,President,1,LIB,Gary Johnson,375
+49,Otoe,President,1,PET,Jill Stein,58
+50,Otoe,President,1,Write In,Write-ins,139
+51,Platte,President,1,REP,Donald J. Trump,10965
+52,Platte,President,1,DEM,Hillary Clinton,2646
+53,Platte,President,1,LIB,Gary Johnson,495
+54,Platte,President,1,PET,Jill Stein,86
+55,Platte,President,1,Write In,Write-ins,241
+56,Polk,President,1,REP,Donald J. Trump,2028
+57,Polk,President,1,DEM,Hillary Clinton,413
+58,Polk,President,1,LIB,Gary Johnson,102
+59,Polk,President,1,PET,Jill Stein,6
+60,Polk,President,1,Write In,Write-ins,33
+61,Sarpy,President,1,REP,Donald J. Trump,15656
+62,Sarpy,President,1,DEM,Hillary Clinton,10801
+63,Sarpy,President,1,LIB,Gary Johnson,1839
+64,Sarpy,President,1,PET,Jill Stein,371
+65,Sarpy,President,1,Write In,Write-ins,666
+66,Saunders,President,1,REP,Donald J. Trump,7555
+67,Saunders,President,1,DEM,Hillary Clinton,2523
+68,Saunders,President,1,LIB,Gary Johnson,515
+69,Saunders,President,1,PET,Jill Stein,97
+70,Saunders,President,1,Write In,Write-ins,170
+71,Seward,President,1,REP,Donald J. Trump,5454
+72,Seward,President,1,DEM,Hillary Clinton,1875
+73,Seward,President,1,LIB,Gary Johnson,337
+74,Seward,President,1,PET,Jill Stein,84
+75,Seward,President,1,Write In,Write-ins,172
+76,Stanton,President,1,REP,Donald J. Trump,2187
+77,Stanton,President,1,DEM,Hillary Clinton,417
+78,Stanton,President,1,LIB,Gary Johnson,144
+79,Stanton,President,1,PET,Jill Stein,14
+80,Stanton,President,1,Write In,Write-ins,39
+81,Thurston,President,1,REP,Donald J. Trump,1043
+82,Thurston,President,1,DEM,Hillary Clinton,919
+83,Thurston,President,1,LIB,Gary Johnson,56
+84,Thurston,President,1,PET,Jill Stein,49
+85,Thurston,President,1,Write In,Write-ins,21
+86,Washington,President,1,REP,Donald J. Trump,7424
+87,Washington,President,1,DEM,Hillary Clinton,2623
+88,Washington,President,1,LIB,Gary Johnson,513
+89,Washington,President,1,PET,Jill Stein,97
+90,Washington,President,1,Write In,Write-ins,175
+91,Douglas,President,2,REP,Donald J. Trump,108077
+92,Douglas,President,2,DEM,Hillary Clinton,113798
+93,Douglas,President,2,LIB,Gary Johnson,10402
+94,Douglas,President,2,PET,Jill Stein,2882
+95,Douglas,President,2,Write In,Write-ins,5274
+96,Sarpy,President,2,REP,Donald J. Trump,29487
+97,Sarpy,President,2,DEM,Hillary Clinton,17232
+98,Sarpy,President,2,LIB,Gary Johnson,2843
+99,Sarpy,President,2,PET,Jill Stein,465
+100,Sarpy,President,2,Write In,Write-ins,1220
+101,Adams,President,3,REP,Donald J. Trump,9287
+102,Adams,President,3,DEM,Hillary Clinton,3302
+103,Adams,President,3,LIB,Gary Johnson,594
+104,Adams,President,3,PET,Jill Stein,111
+105,Adams,President,3,Write In,Write-ins,219
+106,Antelope,President,3,REP,Donald J. Trump,2732
+107,Antelope,President,3,DEM,Hillary Clinton,383
+108,Antelope,President,3,LIB,Gary Johnson,105
+109,Antelope,President,3,PET,Jill Stein,19
+110,Antelope,President,3,Write In,Write-ins,42
+111,Arthur,President,3,REP,Donald J. Trump,244
+112,Arthur,President,3,DEM,Hillary Clinton,17
+113,Arthur,President,3,LIB,Gary Johnson,11
+114,Arthur,President,3,PET,Jill Stein,0
+115,Arthur,President,3,Write In,Write-ins,1
+116,Banner,President,3,REP,Donald J. Trump,357
+117,Banner,President,3,DEM,Hillary Clinton,19
+118,Banner,President,3,LIB,Gary Johnson,14
+119,Banner,President,3,PET,Jill Stein,3
+120,Banner,President,3,Write In,Write-ins,9
+121,Blaine,President,3,REP,Donald J. Trump,276
+122,Blaine,President,3,DEM,Hillary Clinton,30
+123,Blaine,President,3,LIB,Gary Johnson,10
+124,Blaine,President,3,PET,Jill Stein,0
+125,Blaine,President,3,Write In,Write-ins,1
+126,Boone,President,3,REP,Donald J. Trump,2299
+127,Boone,President,3,DEM,Hillary Clinton,414
+128,Boone,President,3,LIB,Gary Johnson,137
+129,Boone,President,3,PET,Jill Stein,17
+130,Boone,President,3,Write In,Write-ins,38
+131,Box Butte,President,3,REP,Donald J. Trump,3617
+132,Box Butte,President,3,DEM,Hillary Clinton,965
+133,Box Butte,President,3,LIB,Gary Johnson,230
+134,Box Butte,President,3,PET,Jill Stein,36
+135,Box Butte,President,3,Write In,Write-ins,76
+136,Boyd,President,3,REP,Donald J. Trump,983
+137,Boyd,President,3,DEM,Hillary Clinton,128
+138,Boyd,President,3,LIB,Gary Johnson,23
+139,Boyd,President,3,PET,Jill Stein,13
+140,Boyd,President,3,Write In,Write-ins,9
+141,Brown,President,3,REP,Donald J. Trump,1385
+142,Brown,President,3,DEM,Hillary Clinton,153
+143,Brown,President,3,LIB,Gary Johnson,39
+144,Brown,President,3,PET,Jill Stein,7
+145,Brown,President,3,Write In,Write-ins,13
+146,Buffalo,President,3,REP,Donald J. Trump,14569
+147,Buffalo,President,3,DEM,Hillary Clinton,4763
+148,Buffalo,President,3,LIB,Gary Johnson,1174
+149,Buffalo,President,3,PET,Jill Stein,227
+150,Buffalo,President,3,Write In,Write-ins,396
+151,Cedar,President,3,REP,Donald J. Trump,3532
+152,Cedar,President,3,DEM,Hillary Clinton,571
+153,Cedar,President,3,LIB,Gary Johnson,224
+154,Cedar,President,3,PET,Jill Stein,31
+155,Cedar,President,3,Write In,Write-ins,62
+156,Chase,President,3,REP,Donald J. Trump,1648
+157,Chase,President,3,DEM,Hillary Clinton,171
+158,Chase,President,3,LIB,Gary Johnson,54
+159,Chase,President,3,PET,Jill Stein,6
+160,Chase,President,3,Write In,Write-ins,19
+161,Cherry,President,3,REP,Donald J. Trump,2623
+162,Cherry,President,3,DEM,Hillary Clinton,317
+163,Cherry,President,3,LIB,Gary Johnson,127
+164,Cherry,President,3,PET,Jill Stein,15
+165,Cherry,President,3,Write In,Write-ins,36
+166,Cheyenne,President,3,REP,Donald J. Trump,3665
+167,Cheyenne,President,3,DEM,Hillary Clinton,711
+168,Cheyenne,President,3,LIB,Gary Johnson,213
+169,Cheyenne,President,3,PET,Jill Stein,46
+170,Cheyenne,President,3,Write In,Write-ins,76
+171,Clay,President,3,REP,Donald J. Trump,2422
+172,Clay,President,3,DEM,Hillary Clinton,477
+173,Clay,President,3,LIB,Gary Johnson,116
+174,Clay,President,3,PET,Jill Stein,15
+175,Clay,President,3,Write In,Write-ins,35
+176,Custer,President,3,REP,Donald J. Trump,4695
+177,Custer,President,3,DEM,Hillary Clinton,641
+178,Custer,President,3,LIB,Gary Johnson,206
+179,Custer,President,3,PET,Jill Stein,37
+180,Custer,President,3,Write In,Write-ins,73
+181,Dakota,President,3,REP,Donald J. Trump,3616
+182,Dakota,President,3,DEM,Hillary Clinton,2314
+183,Dakota,President,3,LIB,Gary Johnson,229
+184,Dakota,President,3,PET,Jill Stein,50
+185,Dakota,President,3,Write In,Write-ins,70
+186,Dawes,President,3,REP,Donald J. Trump,2632
+187,Dawes,President,3,DEM,Hillary Clinton,801
+188,Dawes,President,3,LIB,Gary Johnson,191
+189,Dawes,President,3,PET,Jill Stein,52
+190,Dawes,President,3,Write In,Write-ins,75
+191,Dawson,President,3,REP,Donald J. Trump,5984
+192,Dawson,President,3,DEM,Hillary Clinton,2136
+193,Dawson,President,3,LIB,Gary Johnson,381
+194,Dawson,President,3,PET,Jill Stein,58
+195,Dawson,President,3,Write In,Write-ins,76
+196,Deuel,President,3,REP,Donald J. Trump,809
+197,Deuel,President,3,DEM,Hillary Clinton,120
+198,Deuel,President,3,LIB,Gary Johnson,47
+199,Deuel,President,3,PET,Jill Stein,1
+200,Deuel,President,3,Write In,Write-ins,7
+201,Dixon,President,3,REP,Donald J. Trump,1911
+202,Dixon,President,3,DEM,Hillary Clinton,502
+203,Dixon,President,3,LIB,Gary Johnson,115
+204,Dixon,President,3,PET,Jill Stein,17
+205,Dixon,President,3,Write In,Write-ins,38
+206,Dundy,President,3,REP,Donald J. Trump,823
+207,Dundy,President,3,DEM,Hillary Clinton,89
+208,Dundy,President,3,LIB,Gary Johnson,31
+209,Dundy,President,3,PET,Jill Stein,6
+210,Dundy,President,3,Write In,Write-ins,4
+211,Fillmore,President,3,REP,Donald J. Trump,2130
+212,Fillmore,President,3,DEM,Hillary Clinton,613
+213,Fillmore,President,3,LIB,Gary Johnson,151
+214,Fillmore,President,3,PET,Jill Stein,21
+215,Fillmore,President,3,Write In,Write-ins,26
+216,Franklin,President,3,REP,Donald J. Trump,1347
+217,Franklin,President,3,DEM,Hillary Clinton,250
+218,Franklin,President,3,LIB,Gary Johnson,54
+219,Franklin,President,3,PET,Jill Stein,7
+220,Franklin,President,3,Write In,Write-ins,15
+221,Frontier,President,3,REP,Donald J. Trump,1110
+222,Frontier,President,3,DEM,Hillary Clinton,161
+223,Frontier,President,3,LIB,Gary Johnson,36
+224,Frontier,President,3,PET,Jill Stein,8
+225,Frontier,President,3,Write In,Write-ins,13
+226,Furnas,President,3,REP,Donald J. Trump,1921
+227,Furnas,President,3,DEM,Hillary Clinton,304
+228,Furnas,President,3,LIB,Gary Johnson,85
+229,Furnas,President,3,PET,Jill Stein,11
+230,Furnas,President,3,Write In,Write-ins,19
+231,Gage,President,3,REP,Donald J. Trump,6380
+232,Gage,President,3,DEM,Hillary Clinton,2935
+233,Gage,President,3,LIB,Gary Johnson,492
+234,Gage,President,3,PET,Jill Stein,104
+235,Gage,President,3,Write In,Write-ins,137
+236,Garden,President,3,REP,Donald J. Trump,869
+237,Garden,President,3,DEM,Hillary Clinton,153
+238,Garden,President,3,LIB,Gary Johnson,39
+239,Garden,President,3,PET,Jill Stein,2
+240,Garden,President,3,Write In,Write-ins,12
+241,Garfield,President,3,REP,Donald J. Trump,821
+242,Garfield,President,3,DEM,Hillary Clinton,121
+243,Garfield,President,3,LIB,Gary Johnson,23
+244,Garfield,President,3,PET,Jill Stein,5
+245,Garfield,President,3,Write In,Write-ins,10
+246,Gosper,President,3,REP,Donald J. Trump,794
+247,Gosper,President,3,DEM,Hillary Clinton,166
+248,Gosper,President,3,LIB,Gary Johnson,38
+249,Gosper,President,3,PET,Jill Stein,6
+250,Gosper,President,3,Write In,Write-ins,6
+251,Grant,President,3,REP,Donald J. Trump,367
+252,Grant,President,3,DEM,Hillary Clinton,20
+253,Grant,President,3,LIB,Gary Johnson,6
+254,Grant,President,3,PET,Jill Stein,1
+255,Grant,President,3,Write In,Write-ins,11
+256,Greeley,President,3,REP,Donald J. Trump,912
+257,Greeley,President,3,DEM,Hillary Clinton,210
+258,Greeley,President,3,LIB,Gary Johnson,38
+259,Greeley,President,3,PET,Jill Stein,6
+260,Greeley,President,3,Write In,Write-ins,9
+261,Hall,President,3,REP,Donald J. Trump,14408
+262,Hall,President,3,DEM,Hillary Clinton,6282
+263,Hall,President,3,LIB,Gary Johnson,895
+264,Hall,President,3,PET,Jill Stein,192
+265,Hall,President,3,Write In,Write-ins,283
+266,Hamilton,President,3,REP,Donald J. Trump,3783
+267,Hamilton,President,3,DEM,Hillary Clinton,878
+268,Hamilton,President,3,LIB,Gary Johnson,224
+269,Hamilton,President,3,PET,Jill Stein,43
+270,Hamilton,President,3,Write In,Write-ins,76
+271,Harlan,President,3,REP,Donald J. Trump,1496
+272,Harlan,President,3,DEM,Hillary Clinton,254
+273,Harlan,President,3,LIB,Gary Johnson,62
+274,Harlan,President,3,PET,Jill Stein,7
+275,Harlan,President,3,Write In,Write-ins,13
+276,Hayes,President,3,REP,Donald J. Trump,472
+277,Hayes,President,3,DEM,Hillary Clinton,30
+278,Hayes,President,3,LIB,Gary Johnson,8
+279,Hayes,President,3,PET,Jill Stein,1
+280,Hayes,President,3,Write In,Write-ins,3
+281,Hitchcock,President,3,REP,Donald J. Trump,1232
+282,Hitchcock,President,3,DEM,Hillary Clinton,161
+283,Hitchcock,President,3,LIB,Gary Johnson,61
+284,Hitchcock,President,3,PET,Jill Stein,7
+285,Hitchcock,President,3,Write In,Write-ins,7
+286,Holt,President,3,REP,Donald J. Trump,4354
+287,Holt,President,3,DEM,Hillary Clinton,531
+288,Holt,President,3,LIB,Gary Johnson,162
+289,Holt,President,3,PET,Jill Stein,27
+290,Holt,President,3,Write In,Write-ins,44
+291,Hooker,President,3,REP,Donald J. Trump,355
+292,Hooker,President,3,DEM,Hillary Clinton,40
+293,Hooker,President,3,LIB,Gary Johnson,16
+294,Hooker,President,3,PET,Jill Stein,3
+295,Hooker,President,3,Write In,Write-ins,3
+296,Howard,President,3,REP,Donald J. Trump,2284
+297,Howard,President,3,DEM,Hillary Clinton,544
+298,Howard,President,3,LIB,Gary Johnson,108
+299,Howard,President,3,PET,Jill Stein,22
+300,Howard,President,3,Write In,Write-ins,36
+301,Jefferson,President,3,REP,Donald J. Trump,2399
+302,Jefferson,President,3,DEM,Hillary Clinton,837
+303,Jefferson,President,3,LIB,Gary Johnson,182
+304,Jefferson,President,3,PET,Jill Stein,30
+305,Jefferson,President,3,Write In,Write-ins,46
+306,Johnson,President,3,REP,Donald J. Trump,1355
+307,Johnson,President,3,DEM,Hillary Clinton,563
+308,Johnson,President,3,LIB,Gary Johnson,122
+309,Johnson,President,3,PET,Jill Stein,22
+310,Johnson,President,3,Write In,Write-ins,27
+311,Kearney,President,3,REP,Donald J. Trump,2531
+312,Kearney,President,3,DEM,Hillary Clinton,550
+313,Kearney,President,3,LIB,Gary Johnson,148
+314,Kearney,President,3,PET,Jill Stein,26
+315,Kearney,President,3,Write In,Write-ins,41
+316,Keith,President,3,REP,Donald J. Trump,3235
+317,Keith,President,3,DEM,Hillary Clinton,571
+318,Keith,President,3,LIB,Gary Johnson,164
+319,Keith,President,3,PET,Jill Stein,25
+320,Keith,President,3,Write In,Write-ins,39
+321,Keya Paha,President,3,REP,Donald J. Trump,460
+322,Keya Paha,President,3,DEM,Hillary Clinton,40
+323,Keya Paha,President,3,LIB,Gary Johnson,17
+324,Keya Paha,President,3,PET,Jill Stein,0
+325,Keya Paha,President,3,Write In,Write-ins,2
+326,Kimball,President,3,REP,Donald J. Trump,1330
+327,Kimball,President,3,DEM,Hillary Clinton,230
+328,Kimball,President,3,LIB,Gary Johnson,78
+329,Kimball,President,3,PET,Jill Stein,18
+330,Kimball,President,3,Write In,Write-ins,21
+331,Knox,President,3,REP,Donald J. Trump,3188
+332,Knox,President,3,DEM,Hillary Clinton,720
+333,Knox,President,3,LIB,Gary Johnson,137
+334,Knox,President,3,PET,Jill Stein,29
+335,Knox,President,3,Write In,Write-ins,41
+336,Lincoln,President,3,REP,Donald J. Trump,12164
+337,Lincoln,President,3,DEM,Hillary Clinton,2913
+338,Lincoln,President,3,LIB,Gary Johnson,711
+339,Lincoln,President,3,PET,Jill Stein,107
+340,Lincoln,President,3,Write In,Write-ins,236
+341,Logan,President,3,REP,Donald J. Trump,400
+342,Logan,President,3,DEM,Hillary Clinton,32
+343,Logan,President,3,LIB,Gary Johnson,18
+344,Logan,President,3,PET,Jill Stein,1
+345,Logan,President,3,Write In,Write-ins,2
+346,Loup,President,3,REP,Donald J. Trump,323
+347,Loup,President,3,DEM,Hillary Clinton,48
+348,Loup,President,3,LIB,Gary Johnson,10
+349,Loup,President,3,PET,Jill Stein,1
+350,Loup,President,3,Write In,Write-ins,3
+351,McPherson,President,3,REP,Donald J. Trump,257
+352,McPherson,President,3,DEM,Hillary Clinton,14
+353,McPherson,President,3,LIB,Gary Johnson,14
+354,McPherson,President,3,PET,Jill Stein,1
+355,McPherson,President,3,Write In,Write-ins,1
+356,Merrick,President,3,REP,Donald J. Trump,2926
+357,Merrick,President,3,DEM,Hillary Clinton,602
+358,Merrick,President,3,LIB,Gary Johnson,165
+359,Merrick,President,3,PET,Jill Stein,29
+360,Merrick,President,3,Write In,Write-ins,66
+361,Morrill,President,3,REP,Donald J. Trump,1802
+362,Morrill,President,3,DEM,Hillary Clinton,284
+363,Morrill,President,3,LIB,Gary Johnson,84
+364,Morrill,President,3,PET,Jill Stein,14
+365,Morrill,President,3,Write In,Write-ins,25
+366,Nance,President,3,REP,Donald J. Trump,1261
+367,Nance,President,3,DEM,Hillary Clinton,281
+368,Nance,President,3,LIB,Gary Johnson,48
+369,Nance,President,3,PET,Jill Stein,14
+370,Nance,President,3,Write In,Write-ins,17
+371,Nemaha,President,3,REP,Donald J. Trump,2116
+372,Nemaha,President,3,DEM,Hillary Clinton,785
+373,Nemaha,President,3,LIB,Gary Johnson,180
+374,Nemaha,President,3,PET,Jill Stein,27
+375,Nemaha,President,3,Write In,Write-ins,53
+376,Nuckolls,President,3,REP,Donald J. Trump,1726
+377,Nuckolls,President,3,DEM,Hillary Clinton,353
+378,Nuckolls,President,3,LIB,Gary Johnson,88
+379,Nuckolls,President,3,PET,Jill Stein,20
+380,Nuckolls,President,3,Write In,Write-ins,18
+381,Pawnee,President,3,REP,Donald J. Trump,974
+382,Pawnee,President,3,DEM,Hillary Clinton,279
+383,Pawnee,President,3,LIB,Gary Johnson,55
+384,Pawnee,President,3,PET,Jill Stein,10
+385,Pawnee,President,3,Write In,Write-ins,9
+386,Perkins,President,3,REP,Donald J. Trump,1217
+387,Perkins,President,3,DEM,Hillary Clinton,161
+388,Perkins,President,3,LIB,Gary Johnson,54
+389,Perkins,President,3,PET,Jill Stein,5
+390,Perkins,President,3,Write In,Write-ins,18
+391,Phelps,President,3,REP,Donald J. Trump,3849
+392,Phelps,President,3,DEM,Hillary Clinton,572
+393,Phelps,President,3,LIB,Gary Johnson,190
+394,Phelps,President,3,PET,Jill Stein,18
+395,Phelps,President,3,Write In,Write-ins,66
+396,Pierce,President,3,REP,Donald J. Trump,3052
+397,Pierce,President,3,DEM,Hillary Clinton,382
+398,Pierce,President,3,LIB,Gary Johnson,125
+399,Pierce,President,3,PET,Jill Stein,21
+400,Pierce,President,3,Write In,Write-ins,50
+401,Red Willow,President,3,REP,Donald J. Trump,4258
+402,Red Willow,President,3,DEM,Hillary Clinton,645
+403,Red Willow,President,3,LIB,Gary Johnson,191
+404,Red Willow,President,3,PET,Jill Stein,26
+405,Red Willow,President,3,Write In,Write-ins,50
+406,Richardson,President,3,REP,Donald J. Trump,2769
+407,Richardson,President,3,DEM,Hillary Clinton,818
+408,Richardson,President,3,LIB,Gary Johnson,159
+409,Richardson,President,3,PET,Jill Stein,27
+410,Richardson,President,3,Write In,Write-ins,32
+411,Rock,President,3,REP,Donald J. Trump,687
+412,Rock,President,3,DEM,Hillary Clinton,70
+413,Rock,President,3,LIB,Gary Johnson,33
+414,Rock,President,3,PET,Jill Stein,4
+415,Rock,President,3,Write In,Write-ins,4
+416,Saline,President,3,REP,Donald J. Trump,3004
+417,Saline,President,3,DEM,Hillary Clinton,1733
+418,Saline,President,3,LIB,Gary Johnson,284
+419,Saline,President,3,PET,Jill Stein,52
+420,Saline,President,3,Write In,Write-ins,63
+421,Scotts Bluff,President,3,REP,Donald J. Trump,10076
+422,Scotts Bluff,President,3,DEM,Hillary Clinton,3207
+423,Scotts Bluff,President,3,LIB,Gary Johnson,683
+424,Scotts Bluff,President,3,PET,Jill Stein,126
+425,Scotts Bluff,President,3,Write In,Write-ins,225
+426,Sheridan,President,3,REP,Donald J. Trump,2211
+427,Sheridan,President,3,DEM,Hillary Clinton,287
+428,Sheridan,President,3,LIB,Gary Johnson,70
+429,Sheridan,President,3,PET,Jill Stein,18
+430,Sheridan,President,3,Write In,Write-ins,22
+431,Sherman,President,3,REP,Donald J. Trump,1150
+432,Sherman,President,3,DEM,Hillary Clinton,340
+433,Sherman,President,3,LIB,Gary Johnson,59
+434,Sherman,President,3,PET,Jill Stein,13
+435,Sherman,President,3,Write In,Write-ins,11
+436,Sioux,President,3,REP,Donald J. Trump,616
+437,Sioux,President,3,DEM,Hillary Clinton,81
+438,Sioux,President,3,LIB,Gary Johnson,28
+439,Sioux,President,3,PET,Jill Stein,4
+440,Sioux,President,3,Write In,Write-ins,7
+441,Thayer,President,3,REP,Donald J. Trump,2051
+442,Thayer,President,3,DEM,Hillary Clinton,499
+443,Thayer,President,3,LIB,Gary Johnson,124
+444,Thayer,President,3,PET,Jill Stein,10
+445,Thayer,President,3,Write In,Write-ins,6
+446,Thomas,President,3,REP,Donald J. Trump,344
+447,Thomas,President,3,DEM,Hillary Clinton,30
+448,Thomas,President,3,LIB,Gary Johnson,10
+449,Thomas,President,3,PET,Jill Stein,3
+450,Thomas,President,3,Write In,Write-ins,6
+451,Valley,President,3,REP,Donald J. Trump,1780
+452,Valley,President,3,DEM,Hillary Clinton,339
+453,Valley,President,3,LIB,Gary Johnson,53
+454,Valley,President,3,PET,Jill Stein,12
+455,Valley,President,3,Write In,Write-ins,21
+456,Wayne,President,3,REP,Donald J. Trump,2693
+457,Wayne,President,3,DEM,Hillary Clinton,835
+458,Wayne,President,3,LIB,Gary Johnson,202
+459,Wayne,President,3,PET,Jill Stein,35
+460,Wayne,President,3,Write In,Write-ins,11
+461,Webster,President,3,REP,Donald J. Trump,1330
+462,Webster,President,3,DEM,Hillary Clinton,306
+463,Webster,President,3,LIB,Gary Johnson,51
+464,Webster,President,3,PET,Jill Stein,10
+465,Webster,President,3,Write In,Write-ins,11
+466,Wheeler,President,3,REP,Donald J. Trump,377
+467,Wheeler,President,3,DEM,Hillary Clinton,62
+468,Wheeler,President,3,LIB,Gary Johnson,17
+469,Wheeler,President,3,PET,Jill Stein,4
+470,Wheeler,President,3,Write In,Write-ins,5
+471,York,President,3,REP,Donald J. Trump,4700
+472,York,President,3,DEM,Hillary Clinton,1186
+473,York,President,3,LIB,Gary Johnson,345
+474,York,President,3,PET,Jill Stein,52
+475,York,President,3,Write In,Write-ins,98
+476,Burt,U.S. House,1,REP,Jeff Fortenberry,2648
+477,Burt,U.S. House,1,DEM,Daniel M. Wik,751
+478,Butler,U.S. House,1,REP,Jeff Fortenberry,3231
+479,Butler,U.S. House,1,DEM,Daniel M. Wik,573
+480,Cass,U.S. House,1,REP,Jeff Fortenberry,9323
+481,Cass,U.S. House,1,DEM,Daniel M. Wik,2993
+482,Colfax,U.S. House,1,REP,Jeff Fortenberry,2416
+483,Colfax,U.S. House,1,DEM,Daniel M. Wik,737
+484,Cuming,U.S. House,1,REP,Jeff Fortenberry,3447
+485,Cuming,U.S. House,1,DEM,Daniel M. Wik,527
+486,Dixon,U.S. House,1,REP,Jeff Fortenberry,64
+487,Dixon,U.S. House,1,DEM,Daniel M. Wik,26
+488,Dodge,U.S. House,1,REP,Jeff Fortenberry,11481
+489,Dodge,U.S. House,1,DEM,Daniel M. Wik,3488
+490,Lancaster,U.S. House,1,REP,Jeff Fortenberry,81497
+491,Lancaster,U.S. House,1,DEM,Daniel M. Wik,50659
+492,Madison,U.S. House,1,REP,Jeff Fortenberry,11336
+493,Madison,U.S. House,1,DEM,Daniel M. Wik,2728
+494,Otoe,U.S. House,1,REP,Jeff Fortenberry,5649
+495,Otoe,U.S. House,1,DEM,Daniel M. Wik,1613
+496,Platte,U.S. House,1,REP,Jeff Fortenberry,11389
+497,Platte,U.S. House,1,DEM,Daniel M. Wik,2468
+498,Polk,U.S. House,1,REP,Jeff Fortenberry,2138
+499,Polk,U.S. House,1,DEM,Daniel M. Wik,349
+500,Sarpy,U.S. House,1,REP,Jeff Fortenberry,18745
+501,Sarpy,U.S. House,1,DEM,Daniel M. Wik,9544
+502,Saunders,U.S. House,1,REP,Jeff Fortenberry,8287
+503,Saunders,U.S. House,1,DEM,Daniel M. Wik,2203
+504,Seward,U.S. House,1,REP,Jeff Fortenberry,6253
+505,Seward,U.S. House,1,DEM,Daniel M. Wik,1518
+506,Stanton,U.S. House,1,REP,Jeff Fortenberry,2341
+507,Stanton,U.S. House,1,DEM,Daniel M. Wik,426
+508,Thurston,U.S. House,1,REP,Jeff Fortenberry,1262
+509,Thurston,U.S. House,1,DEM,Daniel M. Wik,740
+510,Washington,U.S. House,1,REP,Jeff Fortenberry,8264
+511,Washington,U.S. House,1,DEM,Daniel M. Wik,2124
+512,Douglas,U.S. House,2,REP,Don Bacon,110391
+513,Douglas,U.S. House,2,DEM,Brad Ashford,119230
+514,Douglas,U.S. House,2,LIB,Steven Laird,7944
+515,Sarpy,U.S. House,2,REP,Don Bacon,30675
+516,Sarpy,U.S. House,2,DEM,Brad Ashford,18372
+517,Sarpy,U.S. House,2,LIB,Steven Laird,1696
+518,Adams,U.S. House,3,REP,Adrian Smith,10938
+519,Antelope,U.S. House,3,REP,Adrian Smith,2808
+520,Arthur,U.S. House,3,REP,Adrian Smith,254
+521,Banner,U.S. House,3,REP,Adrian Smith,344
+522,Blaine,U.S. House,3,REP,Adrian Smith,276
+523,Boone,U.S. House,3,REP,Adrian Smith,2437
+524,Box Butte,U.S. House,3,REP,Adrian Smith,4202
+525,Boyd,U.S. House,3,REP,Adrian Smith,948
+526,Brown,U.S. House,3,REP,Adrian Smith,1381
+527,Buffalo,U.S. House,3,REP,Adrian Smith,17654
+528,Cedar,U.S. House,3,REP,Adrian Smith,3835
+529,Chase,U.S. House,3,REP,Adrian Smith,1697
+530,Cherry,U.S. House,3,REP,Adrian Smith,2527
+531,Cheyenne,U.S. House,3,REP,Adrian Smith,4160
+532,Clay,U.S. House,3,REP,Adrian Smith,2685
+533,Custer,U.S. House,3,REP,Adrian Smith,4959
+534,Dakota,U.S. House,3,REP,Adrian Smith,4723
+535,Dawes,U.S. House,3,REP,Adrian Smith,3169
+536,Dawson,U.S. House,3,REP,Adrian Smith,7335
+537,Deuel,U.S. House,3,REP,Adrian Smith,876
+538,Dixon,U.S. House,3,REP,Adrian Smith,2233
+539,Dundy,U.S. House,3,REP,Adrian Smith,841
+540,Fillmore,U.S. House,3,REP,Adrian Smith,2526
+541,Franklin,U.S. House,3,REP,Adrian Smith,1451
+542,Frontier,U.S. House,3,REP,Adrian Smith,1178
+543,Furnas,U.S. House,3,REP,Adrian Smith,2119
+544,Gage,U.S. House,3,REP,Adrian Smith,8032
+545,Garden,U.S. House,3,REP,Adrian Smith,942
+546,Garfield,U.S. House,3,REP,Adrian Smith,853
+547,Gosper,U.S. House,3,REP,Adrian Smith,890
+548,Grant,U.S. House,3,REP,Adrian Smith,362
+549,Greeley,U.S. House,3,REP,Adrian Smith,955
+550,Hall,U.S. House,3,REP,Adrian Smith,17328
+551,Hamilton,U.S. House,3,REP,Adrian Smith,4203
+552,Harlan,U.S. House,3,REP,Adrian Smith,1602
+553,Hayes,U.S. House,3,REP,Adrian Smith,445
+554,Hitchcock,U.S. House,3,REP,Adrian Smith,1306
+555,Holt,U.S. House,3,REP,Adrian Smith,4402
+556,Hooker,U.S. House,3,REP,Adrian Smith,368
+557,Howard,U.S. House,3,REP,Adrian Smith,2483
+558,Jefferson,U.S. House,3,REP,Adrian Smith,2973
+559,Johnson,U.S. House,3,REP,Adrian Smith,1627
+560,Kearney,U.S. House,3,REP,Adrian Smith,2916
+561,Keith,U.S. House,3,REP,Adrian Smith,3504
+562,Keya Paha,U.S. House,3,REP,Adrian Smith,433
+563,Kimball,U.S. House,3,REP,Adrian Smith,1491
+564,Knox,U.S. House,3,REP,Adrian Smith,3492
+565,Lincoln,U.S. House,3,REP,Adrian Smith,13675
+566,Logan,U.S. House,3,REP,Adrian Smith,401
+567,Loup,U.S. House,3,REP,Adrian Smith,325
+568,McPherson,U.S. House,3,REP,Adrian Smith,256
+569,Merrick,U.S. House,3,REP,Adrian Smith,3179
+570,Morrill,U.S. House,3,REP,Adrian Smith,1899
+571,Nance,U.S. House,3,REP,Adrian Smith,1276
+572,Nemaha,U.S. House,3,REP,Adrian Smith,2622
+573,Nuckolls,U.S. House,3,REP,Adrian Smith,1909
+574,Pawnee,U.S. House,3,REP,Adrian Smith,1113
+575,Perkins,U.S. House,3,REP,Adrian Smith,1332
+576,Phelps,U.S. House,3,REP,Adrian Smith,4142
+577,Pierce,U.S. House,3,REP,Adrian Smith,3172
+578,Red Willow,U.S. House,3,REP,Adrian Smith,4589
+579,Richardson,U.S. House,3,REP,Adrian Smith,2995
+580,Rock,U.S. House,3,REP,Adrian Smith,693
+581,Saline,U.S. House,3,REP,Adrian Smith,3996
+582,Scotts Bluff,U.S. House,3,REP,Adrian Smith,11678
+583,Sheridan,U.S. House,3,REP,Adrian Smith,2203
+584,Sherman,U.S. House,3,REP,Adrian Smith,1301
+585,Sioux,U.S. House,3,REP,Adrian Smith,624
+586,Thayer,U.S. House,3,REP,Adrian Smith,2308
+587,Thomas,U.S. House,3,REP,Adrian Smith,340
+588,Valley,U.S. House,3,REP,Adrian Smith,1909
+589,Wayne,U.S. House,3,REP,Adrian Smith,3222
+590,Webster,U.S. House,3,REP,Adrian Smith,1448
+591,Wheeler,U.S. House,3,REP,Adrian Smith,406
+592,York,U.S. House,3,REP,Adrian Smith,5544
+593,Johnson,State Legislature,1,,Dan Watermeier,1731
+594,Nemaha,State Legislature,1,,Dan Watermeier,2658
+595,Otoe,State Legislature,1,,Dan Watermeier,5351
+596,Pawnee,State Legislature,1,,Dan Watermeier,1101
+597,Richardson,State Legislature,1,,Dan Watermeier,3075
+598,Sarpy,State Legislature,3,,Carol Blood,7959
+599,Sarpy,State Legislature,3,,Tommy Garrett,7476
+600,Douglas,State Legislature,5,,Gilbert Ayala,3028
+601,Douglas,State Legislature,5,,Mike McDonnell,7120
+602,Douglas,State Legislature,7,,John Synowiecki,3248
+603,Douglas,State Legislature,7,,Tony Vargas,5244
+604,Douglas,State Legislature,9,,Larry Roland,2773
+605,Douglas,State Legislature,9,,Sara Howard,10552
+606,Douglas,State Legislature,11,,Ernie Chambers,7763
+607,Douglas,State Legislature,11,,John Sciara,1726
+608,Douglas,State Legislature,13,,Jill Brown,6605
+609,Douglas,State Legislature,13,,Justin Wayne,6920
+610,Dodge,State Legislature,15,,David A. Schnoor,7189
+611,Dodge,State Legislature,15,,Lynne M. Walz,7601
+612,Dakota,State Legislature,17,,Ardel Bengtson,2859
+613,Dakota,State Legislature,17,,Joni Albrecht,2929
+614,Thurston,State Legislature,17,,Ardel Bengtson,533
+615,Thurston,State Legislature,17,,Joni Albrecht,1385
+616,Wayne,State Legislature,17,,Ardel Bengtson,1059
+617,Wayne,State Legislature,17,,Joni Albrecht,2511
+618,Madison,State Legislature,19,,Jim Scheer,12040
+619,Stanton,State Legislature,19,,Jim Scheer,868
+620,Lancaster,State Legislature,21,,Larry Scherer,6567
+621,Lancaster,State Legislature,21,,Mike Hilgers,8588
+622,Butler,State Legislature,23,,Bruce Bostelman,2472
+623,Butler,State Legislature,23,,Jerry Johnson,1214
+624,Colfax,State Legislature,23,,Bruce Bostelman,1114
+625,Colfax,State Legislature,23,,Jerry Johnson,1094
+626,Saunders,State Legislature,23,,Bruce Bostelman,5107
+627,Saunders,State Legislature,23,,Jerry Johnson,4642
+628,Lancaster,State Legislature,25,,Jim Gordon,10258
+629,Lancaster,State Legislature,25,,Suzanne Geist,12899
+630,Lancaster,State Legislature,27,,Anna Wishart,9930
+631,Lancaster,State Legislature,27,,Dick Clark,3657
+632,Lancaster,State Legislature,29,,Kate Bolz,14821
+633,Lancaster,State Legislature,29,,Melody Vaccaro,2936
+634,Douglas,State Legislature,31,,Ian M. Swanson,8985
+635,Douglas,State Legislature,31,,Rick Kolowski,9762
+636,Adams,State Legislature,33,,Les Seiler,5150
+637,Adams,State Legislature,33,,Steve Halloran,7714
+638,Hall,State Legislature,33,,Les Seiler,903
+639,Hall,State Legislature,33,,Steve Halloran,1450
+640,Hall,State Legislature,35,,Dan Quick,5743
+641,Hall,State Legislature,35,,Gregg Neuhaus,5668
+642,Buffalo,State Legislature,37,,Bob Lammers,7547
+643,Buffalo,State Legislature,37,,John S. Lowe Sr.,8600
+644,Douglas,State Legislature,39,,Bill Armbrust,9646
+645,Douglas,State Legislature,39,,Lou Ann Linehan,11729
+646,Antelope,State Legislature,41,,Tom Briese,2285
+647,Boone,State Legislature,41,,Tom Briese,2518
+648,Garfield,State Legislature,41,,Tom Briese,655
+649,Greeley,State Legislature,41,,Tom Briese,758
+650,Howard,State Legislature,41,,Tom Briese,2099
+651,Pierce,State Legislature,41,,Tom Briese,2736
+652,Sherman,State Legislature,41,,Tom Briese,1092
+653,Valley,State Legislature,41,,Tom Briese,1609
+654,Wheeler,State Legislature,41,,Tom Briese,328
+655,Blaine,State Legislature,43,,Al Davis,130
+656,Blaine,State Legislature,43,,Tom Brewer,179
+657,Box Butte,State Legislature,43,,Al Davis,2482
+658,Box Butte,State Legislature,43,,Tom Brewer,1216
+659,Brown,State Legislature,43,,Al Davis,785
+660,Brown,State Legislature,43,,Tom Brewer,783
+661,Cherry,State Legislature,43,,Al Davis,940
+662,Cherry,State Legislature,43,,Tom Brewer,2069
+663,Dawes,State Legislature,43,,Al Davis,2113
+664,Dawes,State Legislature,43,,Tom Brewer,1526
+665,Grant,State Legislature,43,,Al Davis,207
+666,Grant,State Legislature,43,,Tom Brewer,192
+667,Hooker,State Legislature,43,,Al Davis,199
+668,Hooker,State Legislature,43,,Tom Brewer,204
+669,Keya Paha,State Legislature,43,,Al Davis,187
+670,Keya Paha,State Legislature,43,,Tom Brewer,295
+671,Logan,State Legislature,43,,Al Davis,179
+672,Logan,State Legislature,43,,Tom Brewer,241
+673,Loup,State Legislature,43,,Al Davis,211
+674,Loup,State Legislature,43,,Tom Brewer,148
+675,McPherson,State Legislature,43,,Al Davis,142
+676,McPherson,State Legislature,43,,Tom Brewer,135
+677,Sheridan,State Legislature,43,,Al Davis,648
+678,Sheridan,State Legislature,43,,Tom Brewer,1950
+679,Thomas,State Legislature,43,,Al Davis,153
+680,Thomas,State Legislature,43,,Tom Brewer,231
+681,Sarpy,State Legislature,45,,Michael J. Cook,6734
+682,Sarpy,State Legislature,45,,Sue Crawford,8774
+683,Arthur,State Legislature,47,,Karl Elmshaeuser,98
+684,Arthur,State Legislature,47,,Steve Erdman,156
+685,Banner,State Legislature,47,,Karl Elmshaeuser,90
+686,Banner,State Legislature,47,,Steve Erdman,277
+687,Box Butte,State Legislature,47,,Karl Elmshaeuser,193
+688,Box Butte,State Legislature,47,,Steve Erdman,756
+689,Cheyenne,State Legislature,47,,Karl Elmshaeuser,1372
+690,Cheyenne,State Legislature,47,,Steve Erdman,3000
+691,Deuel,State Legislature,47,,Karl Elmshaeuser,236
+692,Deuel,State Legislature,47,,Steve Erdman,691
+693,Garden,State Legislature,47,,Karl Elmshaeuser,236
+694,Garden,State Legislature,47,,Steve Erdman,761
+695,Keith,State Legislature,47,,Karl Elmshaeuser,1657
+696,Keith,State Legislature,47,,Steve Erdman,2131
+697,Kimball,State Legislature,47,,Karl Elmshaeuser,402
+698,Kimball,State Legislature,47,,Steve Erdman,1144
+699,Morrill,State Legislature,47,,Karl Elmshaeuser,833
+700,Morrill,State Legislature,47,,Steve Erdman,1305
+701,Sioux,State Legislature,47,,Karl Elmshaeuser,113
+702,SIoux,State Legislature,47,,Steve Erdman,518
+703,Sarpy,State Legislature,49,,John Murante,15137

--- a/2016/20161108__ne__general__precinct.csv
+++ b/2016/20161108__ne__general__precinct.csv
@@ -399,9 +399,9 @@ Banner,Long Springs,3,U.S. House,,Write-ins,7
 Banner,Long Springs,47,State Legislature,,Karl Elmshaueser,90
 Banner,Long Springs,47,State Legislature,,Steve Erdman,277
 Banner,Long Springs,47,State Legislature,,Write-ins,2
-Blaine,Blaine,,President,     Republican,Donald J. Trump/Pence,276
-Blaine,Blaine,,President,     Democratic,Hillary Clinton/Kaine,30
-Blaine,Blaine,,President,     Libertarian,Gary Johnson/Weld,10
+Blaine,Blaine,,President,Republican,Donald J. Trump/Pence,276
+Blaine,Blaine,,President,Democratic,Hillary Clinton/Kaine,30
+Blaine,Blaine,,President,Libertarian,Gary Johnson/Weld,10
 Blaine,Blaine,,President,,Jill Stein/Baraka,0
 Blaine,Blaine,3,U.S. House,Republican,Adrian Smith,276
 Blaine,Blaine,43,State Legislature,,Al Davis,130
@@ -3101,391 +3101,391 @@ Dixon,Ponca 1st,3,U.S. House,,Write-ins,1
 Dixon,Ponca 2nd,3,U.S. House,,Write-ins,1
 Dixon,Absentee,3,U.S. House,,Write-ins,5
 Dixon,Total,3,U.S. House,,Write-ins,30
-Dodge,Fremont - 1A ,,President,Republican,Donald J. Trump,359
-Dodge,Fremont - 1B ,,President,Republican,Donald J. Trump,286
-Dodge,Fremont - 1C ,,President,Republican,Donald J. Trump,457
-Dodge,Fremont - 1D ,,President,Republican,Donald J. Trump,192
-Dodge,Fremont - 1E ,,President,Republican,Donald J. Trump,326
-Dodge,Fremont - 2A ,,President,Republican,Donald J. Trump,233
-Dodge,Fremont - 2B ,,President,Republican,Donald J. Trump,210
-Dodge,Fremont - 2C ,,President,Republican,Donald J. Trump,471
-Dodge,Fremont - 2D ,,President,Republican,Donald J. Trump,166
-Dodge,Fremont - 2E ,,President,Republican,Donald J. Trump,306
-Dodge,Fremont - 3A ,,President,Republican,Donald J. Trump,156
-Dodge,Fremont - 3B ,,President,Republican,Donald J. Trump,82
-Dodge,Fremont - 3C ,,President,Republican,Donald J. Trump,171
-Dodge,Fremont - 3D ,,President,Republican,Donald J. Trump,263
-Dodge,Fremont - 3E ,,President,Republican,Donald J. Trump,227
-Dodge,Fremont - 4A ,,President,Republican,Donald J. Trump,300
-Dodge,Fremont - 4B ,,President,Republican,Donald J. Trump,196
-Dodge,Fremont - 4C ,,President,Republican,Donald J. Trump,414
-Dodge,Fremont - 4D ,,President,Republican,Donald J. Trump,455
-Dodge,Fremont - 4E ,,President,Republican,Donald J. Trump,163
-Dodge,City of North Bend ,,President,Republican,Donald J. Trump,327
-Dodge,City of Scribner ,,President,Republican,Donald J. Trump,299
-Dodge,CU/EV ,,President,Republican,Donald J. Trump,171
-Dodge,Webster Township ,,President,Republican,Donald J. Trump,298
-Dodge,Pebble Township ,,President,Republican,Donald J. Trump,166
-Dodge,Platte East ,,President,Republican,Donald J. Trump,149
-Dodge,Platte West ,,President,Republican,Donald J. Trump,371
-Dodge,Nickerson Township ,,President,Republican,Donald J. Trump,292
-Dodge,City of Hooper ,,President,Republican,Donald J. Trump,238
-Dodge,HW/LG ,,President,Republican,Donald J. Trump,294
-Dodge,Elkhorn Township ,,President,Republican,Donald J. Trump,124
-Dodge,CT/UN ,,President,Republican,Donald J. Trump,360
-Dodge,New/Former Resident ,,President,Republican,Donald J. Trump,0
-Dodge,ABSENTEE ,,President,Republican,Donald J. Trump,1411
-Dodge,TOTALS ,,President,Republican,Donald J. Trump,9933
-Dodge,Fremont - 1A ,,President,Democratic,Hillary Clinton,167
-Dodge,Fremont - 1B ,,President,Democratic,Hillary Clinton,156
-Dodge,Fremont - 1C ,,President,Democratic,Hillary Clinton,181
-Dodge,Fremont - 1D ,,President,Democratic,Hillary Clinton,75
-Dodge,Fremont - 1E ,,President,Democratic,Hillary Clinton,182
-Dodge,Fremont - 2A ,,President,Democratic,Hillary Clinton,121
-Dodge,Fremont - 2B ,,President,Democratic,Hillary Clinton,98
-Dodge,Fremont - 2C ,,President,Democratic,Hillary Clinton,180
-Dodge,Fremont - 2D ,,President,Democratic,Hillary Clinton,63
-Dodge,Fremont - 2E ,,President,Democratic,Hillary Clinton,115
-Dodge,Fremont - 3A ,,President,Democratic,Hillary Clinton,87
-Dodge,Fremont - 3B ,,President,Democratic,Hillary Clinton,59
-Dodge,Fremont - 3C ,,President,Democratic,Hillary Clinton,99
-Dodge,Fremont - 3D ,,President,Democratic,Hillary Clinton,154
-Dodge,Fremont - 3E ,,President,Democratic,Hillary Clinton,113
-Dodge,Fremont - 4A ,,President,Democratic,Hillary Clinton,127
-Dodge,Fremont - 4B ,,President,Democratic,Hillary Clinton,93
-Dodge,Fremont - 4C ,,President,Democratic,Hillary Clinton,201
-Dodge,Fremont - 4D ,,President,Democratic,Hillary Clinton,192
-Dodge,Fremont - 4E ,,President,Democratic,Hillary Clinton,75
-Dodge,City of North Bend ,,President,Democratic,Hillary Clinton,108
-Dodge,City of Scribner ,,President,Democratic,Hillary Clinton,58
-Dodge,CU/EV ,,President,Democratic,Hillary Clinton,37
-Dodge,Webster Township ,,President,Democratic,Hillary Clinton,64
-Dodge,Pebble Township ,,President,Democratic,Hillary Clinton,23
-Dodge,Platte East ,,President,Democratic,Hillary Clinton,59
-Dodge,Platte West ,,President,Democratic,Hillary Clinton,100
-Dodge,Nickerson Township ,,President,Democratic,Hillary Clinton,93
-Dodge,City of Hooper ,,President,Democratic,Hillary Clinton,89
-Dodge,HW/LG ,,President,Democratic,Hillary Clinton,55
-Dodge,Elkhorn Township ,,President,Democratic,Hillary Clinton,36
-Dodge,CT/UN ,,President,Democratic,Hillary Clinton,71
-Dodge,New/Former Resident ,,President,Democratic,Hillary Clinton,0
-Dodge,ABSENTEE ,,President,Democratic,Hillary Clinton,1213
-Dodge,TOTALS ,,President,Democratic,Hillary Clinton,4544
-Dodge,Fremont - 1A ,,President,Libertarian,Gary Johnson,26
-Dodge,Fremont - 1B ,,President,Libertarian,Gary Johnson,32
-Dodge,Fremont - 1C ,,President,Libertarian,Gary Johnson,18
-Dodge,Fremont - 1D ,,President,Libertarian,Gary Johnson,8
-Dodge,Fremont - 1E ,,President,Libertarian,Gary Johnson,10
-Dodge,Fremont - 2A ,,President,Libertarian,Gary Johnson,14
-Dodge,Fremont - 2B ,,President,Libertarian,Gary Johnson,17
-Dodge,Fremont - 2C ,,President,Libertarian,Gary Johnson,38
-Dodge,Fremont - 2D ,,President,Libertarian,Gary Johnson,12
-Dodge,Fremont - 2E ,,President,Libertarian,Gary Johnson,18
-Dodge,Fremont - 3A ,,President,Libertarian,Gary Johnson,18
-Dodge,Fremont - 3B ,,President,Libertarian,Gary Johnson,7
-Dodge,Fremont - 3C ,,President,Libertarian,Gary Johnson,15
-Dodge,Fremont - 3D ,,President,Libertarian,Gary Johnson,15
-Dodge,Fremont - 3E ,,President,Libertarian,Gary Johnson,17
-Dodge,Fremont - 4A ,,President,Libertarian,Gary Johnson,30
-Dodge,Fremont - 4B ,,President,Libertarian,Gary Johnson,15
-Dodge,Fremont - 4C ,,President,Libertarian,Gary Johnson,30
-Dodge,Fremont - 4D ,,President,Libertarian,Gary Johnson,27
-Dodge,Fremont - 4E ,,President,Libertarian,Gary Johnson,14
-Dodge,City of North Bend ,,President,Libertarian,Gary Johnson,24
-Dodge,City of Scribner ,,President,Libertarian,Gary Johnson,16
-Dodge,CU/EV ,,President,Libertarian,Gary Johnson,10
-Dodge,Webster Township ,,President,Libertarian,Gary Johnson,6
-Dodge,Pebble Township ,,President,Libertarian,Gary Johnson,12
-Dodge,Platte East ,,President,Libertarian,Gary Johnson,6
-Dodge,Platte West ,,President,Libertarian,Gary Johnson,12
-Dodge,Nickerson Township ,,President,Libertarian,Gary Johnson,15
-Dodge,City of Hooper ,,President,Libertarian,Gary Johnson,15
-Dodge,HW/LG ,,President,Libertarian,Gary Johnson,19
-Dodge,Elkhorn Township ,,President,Libertarian,Gary Johnson,7
-Dodge,CT/UN ,,President,Libertarian,Gary Johnson,17
-Dodge,New/Former Resident ,,President,Libertarian,Gary Johnson,0
-Dodge,ABSENTEE ,,President,Libertarian,Gary Johnson,84
-Dodge,TOTALS ,,President,Libertarian,Gary Johnson,624
-Dodge,Fremont - 1A ,,President,,Jill Stein,7
-Dodge,Fremont - 1B ,,President,,Jill Stein,2
-Dodge,Fremont - 1C ,,President,,Jill Stein,3
-Dodge,Fremont - 1D ,,President,,Jill Stein,6
-Dodge,Fremont - 1E ,,President,,Jill Stein,5
-Dodge,Fremont - 2A ,,President,,Jill Stein,11
-Dodge,Fremont - 2B ,,President,,Jill Stein,2
-Dodge,Fremont - 2C ,,President,,Jill Stein,5
-Dodge,Fremont - 2D ,,President,,Jill Stein,3
-Dodge,Fremont - 2E ,,President,,Jill Stein,5
-Dodge,Fremont - 3A ,,President,,Jill Stein,2
-Dodge,Fremont - 3B ,,President,,Jill Stein,3
-Dodge,Fremont - 3C ,,President,,Jill Stein,7
-Dodge,Fremont - 3D ,,President,,Jill Stein,6
-Dodge,Fremont - 3E ,,President,,Jill Stein,8
-Dodge,Fremont - 4A ,,President,,Jill Stein,6
-Dodge,Fremont - 4B ,,President,,Jill Stein,7
-Dodge,Fremont - 4C ,,President,,Jill Stein,4
-Dodge,Fremont - 4D ,,President,,Jill Stein,3
-Dodge,Fremont - 4E ,,President,,Jill Stein,3
-Dodge,City of North Bend ,,President,,Jill Stein,4
-Dodge,City of Scribner ,,President,,Jill Stein,3
-Dodge,CU/EV ,,President,,Jill Stein,3
-Dodge,Webster Township ,,President,,Jill Stein,0
-Dodge,Pebble Township ,,President,,Jill Stein,2
-Dodge,Platte East ,,President,,Jill Stein,1
-Dodge,Platte West ,,President,,Jill Stein,4
-Dodge,Nickerson Township ,,President,,Jill Stein,5
-Dodge,City of Hooper ,,President,,Jill Stein,2
-Dodge,HW/LG ,,President,,Jill Stein,6
-Dodge,Elkhorn Township ,,President,,Jill Stein,0
-Dodge,CT/UN ,,President,,Jill Stein,2
-Dodge,New/Former Resident ,,President,,Jill Stein,0
-Dodge,ABSENTEE ,,President,,Jill Stein,32
-Dodge,TOTALS ,,President,,Jill Stein,162
-Dodge,Fremont - 1A ,,President,,Write-ins,11
-Dodge,Fremont - 1B ,,President,,Write-ins,9
-Dodge,Fremont - 1C ,,President,,Write-ins,20
-Dodge,Fremont - 1D ,,President,,Write-ins,5
-Dodge,Fremont - 1E ,,President,,Write-ins,14
-Dodge,Fremont - 2A ,,President,,Write-ins,5
-Dodge,Fremont - 2B ,,President,,Write-ins,9
-Dodge,Fremont - 2C ,,President,,Write-ins,7
-Dodge,Fremont - 2D ,,President,,Write-ins,6
-Dodge,Fremont - 2E ,,President,,Write-ins,7
-Dodge,Fremont - 3A ,,President,,Write-ins,12
-Dodge,Fremont - 3B ,,President,,Write-ins,1
-Dodge,Fremont - 3C ,,President,,Write-ins,3
-Dodge,Fremont - 3D ,,President,,Write-ins,6
-Dodge,Fremont - 3E ,,President,,Write-ins,8
-Dodge,Fremont - 4A ,,President,,Write-ins,5
-Dodge,Fremont - 4B ,,President,,Write-ins,8
-Dodge,Fremont - 4C ,,President,,Write-ins,13
-Dodge,Fremont - 4D ,,President,,Write-ins,12
-Dodge,Fremont - 4E ,,President,,Write-ins,6
-Dodge,City of North Bend ,,President,,Write-ins,10
-Dodge,City of Scribner ,,President,,Write-ins,6
-Dodge,CU/EV ,,President,,Write-ins,2
-Dodge,Webster Township ,,President,,Write-ins,2
-Dodge,Pebble Township ,,President,,Write-ins,3
-Dodge,Platte East ,,President,,Write-ins,4
-Dodge,Platte West ,,President,,Write-ins,12
-Dodge,Nickerson Township ,,President,,Write-ins,2
-Dodge,City of Hooper ,,President,,Write-ins,2
-Dodge,HW/LG ,,President,,Write-ins,3
-Dodge,Elkhorn Township ,,President,,Write-ins,0
-Dodge,CT/UN ,,President,,Write-ins,8
-Dodge,New/Former Resident ,,President,,Write-ins,0
-Dodge,ABSENTEE ,,President,,Write-ins,45
-Dodge,TOTALS ,,President,,Write-ins,266
-Dodge,Fremont - 1A ,1,U.S. House,Republican,Jeff Fortenberry,425
-Dodge,Fremont - 1B ,1,U.S. House,Republican,Jeff Fortenberry,357
-Dodge,Fremont - 1C ,1,U.S. House,Republican,Jeff Fortenberry,546
-Dodge,Fremont - 1D ,1,U.S. House,Republican,Jeff Fortenberry,218
-Dodge,Fremont - 1E ,1,U.S. House,Republican,Jeff Fortenberry,412
-Dodge,Fremont - 2A ,1,U.S. House,Republican,Jeff Fortenberry,276
-Dodge,Fremont - 2B ,1,U.S. House,Republican,Jeff Fortenberry,255
-Dodge,Fremont - 2C ,1,U.S. House,Republican,Jeff Fortenberry,539
-Dodge,Fremont - 2D ,1,U.S. House,Republican,Jeff Fortenberry,182
-Dodge,Fremont - 2E ,1,U.S. House,Republican,Jeff Fortenberry,350
-Dodge,Fremont - 3A ,1,U.S. House,Republican,Jeff Fortenberry,192
-Dodge,Fremont - 3B ,1,U.S. House,Republican,Jeff Fortenberry,88
-Dodge,Fremont - 3C ,1,U.S. House,Republican,Jeff Fortenberry,191
-Dodge,Fremont - 3D ,1,U.S. House,Republican,Jeff Fortenberry,324
-Dodge,Fremont - 3E ,1,U.S. House,Republican,Jeff Fortenberry,270
-Dodge,Fremont - 4A ,1,U.S. House,Republican,Jeff Fortenberry,356
-Dodge,Fremont - 4B ,1,U.S. House,Republican,Jeff Fortenberry,221
-Dodge,Fremont - 4C ,1,U.S. House,Republican,Jeff Fortenberry,495
-Dodge,Fremont - 4D ,1,U.S. House,Republican,Jeff Fortenberry,561
-Dodge,Fremont - 4E ,1,U.S. House,Republican,Jeff Fortenberry,184
-Dodge,City of North Bend ,1,U.S. House,Republican,Jeff Fortenberry,376
-Dodge,City of Scribner ,1,U.S. House,Republican,Jeff Fortenberry,330
-Dodge,CU/EV ,1,U.S. House,Republican,Jeff Fortenberry,186
-Dodge,Webster Township ,1,U.S. House,Republican,Jeff Fortenberry,289
-Dodge,Pebble Township ,1,U.S. House,Republican,Jeff Fortenberry,178
-Dodge,Platte East ,1,U.S. House,Republican,Jeff Fortenberry,158
-Dodge,Platte West ,1,U.S. House,Republican,Jeff Fortenberry,394
-Dodge,Nickerson Township ,1,U.S. House,Republican,Jeff Fortenberry,314
-Dodge,City of Hooper ,1,U.S. House,Republican,Jeff Fortenberry,271
-Dodge,HW/LG ,1,U.S. House,Republican,Jeff Fortenberry,320
-Dodge,Elkhorn Township ,1,U.S. House,Republican,Jeff Fortenberry,130
-Dodge,CT/UN ,1,U.S. House,Republican,Jeff Fortenberry,380
-Dodge,New/Former Resident ,1,U.S. House,Republican,Jeff Fortenberry,NA
-Dodge,ABSENTEE ,1,U.S. House,Republican,Jeff Fortenberry,1713
-Dodge,TOTALS ,1,U.S. House,Republican,Jeff Fortenberry,11481
-Dodge,Fremont - 1A ,1,U.S. House,Democratic,Daniel M. Wik,115
-Dodge,Fremont - 1B ,1,U.S. House,Democratic,Daniel M. Wik,112
-Dodge,Fremont - 1C ,1,U.S. House,Democratic,Daniel M. Wik,117
-Dodge,Fremont - 1D ,1,U.S. House,Democratic,Daniel M. Wik,52
-Dodge,Fremont - 1E ,1,U.S. House,Democratic,Daniel M. Wik,114
-Dodge,Fremont - 2A ,1,U.S. House,Democratic,Daniel M. Wik,99
-Dodge,Fremont - 2B ,1,U.S. House,Democratic,Daniel M. Wik,76
-Dodge,Fremont - 2C ,1,U.S. House,Democratic,Daniel M. Wik,134
-Dodge,Fremont - 2D ,1,U.S. House,Democratic,Daniel M. Wik,52
-Dodge,Fremont - 2E ,1,U.S. House,Democratic,Daniel M. Wik,89
-Dodge,Fremont - 3A ,1,U.S. House,Democratic,Daniel M. Wik,69
-Dodge,Fremont - 3B ,1,U.S. House,Democratic,Daniel M. Wik,59
-Dodge,Fremont - 3C ,1,U.S. House,Democratic,Daniel M. Wik,94
-Dodge,Fremont - 3D ,1,U.S. House,Democratic,Daniel M. Wik,111
-Dodge,Fremont - 3E ,1,U.S. House,Democratic,Daniel M. Wik,93
-Dodge,Fremont - 4A ,1,U.S. House,Democratic,Daniel M. Wik,100
-Dodge,Fremont - 4B ,1,U.S. House,Democratic,Daniel M. Wik,81
-Dodge,Fremont - 4C ,1,U.S. House,Democratic,Daniel M. Wik,139
-Dodge,Fremont - 4D ,1,U.S. House,Democratic,Daniel M. Wik,111
-Dodge,Fremont - 4E ,1,U.S. House,Democratic,Daniel M. Wik,64
-Dodge,City of North Bend ,1,U.S. House,Democratic,Daniel M. Wik,78
-Dodge,City of Scribner ,1,U.S. House,Democratic,Daniel M. Wik,43
-Dodge,CU/EV ,1,U.S. House,Democratic,Daniel M. Wik,25
-Dodge,Webster Township ,1,U.S. House,Democratic,Daniel M. Wik,60
-Dodge,Pebble Township ,1,U.S. House,Democratic,Daniel M. Wik,20
-Dodge,Platte East ,1,U.S. House,Democratic,Daniel M. Wik,50
-Dodge,Platte West ,1,U.S. House,Democratic,Daniel M. Wik,87
-Dodge,Nickerson Township ,1,U.S. House,Democratic,Daniel M. Wik,81
-Dodge,City of Hooper ,1,U.S. House,Democratic,Daniel M. Wik,69
-Dodge,HW/LG ,1,U.S. House,Democratic,Daniel M. Wik,42
-Dodge,Elkhorn Township ,1,U.S. House,Democratic,Daniel M. Wik,30
-Dodge,CT/UN ,1,U.S. House,Democratic,Daniel M. Wik,63
-Dodge,New/Former Resident ,1,U.S. House,Democratic,Daniel M. Wik,NA
-Dodge,ABSENTEE ,1,U.S. House,Democratic,Daniel M. Wik,959
-Dodge,TOTALS ,1,U.S. House,Democratic,Daniel M. Wik,3488
-Dodge,Fremont - 1A ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 1B ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 1C ,1,U.S. House,,Write-ins,2
-Dodge,Fremont - 1D ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 1E ,1,U.S. House,,Write-ins,2
-Dodge,Fremont - 2A ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 2B ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 2C ,1,U.S. House,,Write-ins,4
-Dodge,Fremont - 2D ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 2E ,1,U.S. House,,Write-ins,3
-Dodge,Fremont - 3A ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 3B ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 3C ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 3D ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 3E ,1,U.S. House,,Write-ins,0
-Dodge,Fremont - 4A ,1,U.S. House,,Write-ins,3
-Dodge,Fremont - 4B ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 4C ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 4D ,1,U.S. House,,Write-ins,1
-Dodge,Fremont - 4E ,1,U.S. House,,Write-ins,0
-Dodge,City of North Bend ,1,U.S. House,,Write-ins,0
-Dodge,City of Scribner ,1,U.S. House,,Write-ins,0
-Dodge,CU/EV ,1,U.S. House,,Write-ins,0
-Dodge,Webster Township ,1,U.S. House,,Write-ins,1
-Dodge,Pebble Township ,1,U.S. House,,Write-ins,1
-Dodge,Platte East ,1,U.S. House,,Write-ins,0
-Dodge,Platte West ,1,U.S. House,,Write-ins,3
-Dodge,Nickerson Township ,1,U.S. House,,Write-ins,0
-Dodge,City of Hooper ,1,U.S. House,,Write-ins,1
-Dodge,HW/LG ,1,U.S. House,,Write-ins,1
-Dodge,Elkhorn Township ,1,U.S. House,,Write-ins,0
-Dodge,CT/UN ,1,U.S. House,,Write-ins,0
-Dodge,New/Former Resident ,1,U.S. House,,Write-ins,NA
-Dodge,ABSENTEE ,1,U.S. House,,Write-ins,6
-Dodge,TOTALS ,1,U.S. House,,Write-ins,34
-Dodge,Fremont - 1A ,15,State Legislature,,David A. Schnoor,269
-Dodge,Fremont - 1B ,15,State Legislature,,David A. Schnoor,178
-Dodge,Fremont - 1C ,15,State Legislature,,David A. Schnoor,347
-Dodge,Fremont - 1D ,15,State Legislature,,David A. Schnoor,118
-Dodge,Fremont - 1E ,15,State Legislature,,David A. Schnoor,249
-Dodge,Fremont - 2A ,15,State Legislature,,David A. Schnoor,152
-Dodge,Fremont - 2B ,15,State Legislature,,David A. Schnoor,115
-Dodge,Fremont - 2C ,15,State Legislature,,David A. Schnoor,294
-Dodge,Fremont - 2D ,15,State Legislature,,David A. Schnoor,123
-Dodge,Fremont - 2E ,15,State Legislature,,David A. Schnoor,196
-Dodge,Fremont - 3A ,15,State Legislature,,David A. Schnoor,115
-Dodge,Fremont - 3B ,15,State Legislature,,David A. Schnoor,66
-Dodge,Fremont - 3C ,15,State Legislature,,David A. Schnoor,120
-Dodge,Fremont - 3D ,15,State Legislature,,David A. Schnoor,229
-Dodge,Fremont - 3E ,15,State Legislature,,David A. Schnoor,169
-Dodge,Fremont - 4A ,15,State Legislature,,David A. Schnoor,192
-Dodge,Fremont - 4B ,15,State Legislature,,David A. Schnoor,134
-Dodge,Fremont - 4C ,15,State Legislature,,David A. Schnoor,276
-Dodge,Fremont - 4D ,15,State Legislature,,David A. Schnoor,278
-Dodge,Fremont - 4E ,15,State Legislature,,David A. Schnoor,107
-Dodge,City of North Bend ,15,State Legislature,,David A. Schnoor,258
-Dodge,City of Scribner ,15,State Legislature,,David A. Schnoor,298
-Dodge,CU/EV ,15,State Legislature,,David A. Schnoor,146
-Dodge,Webster Township ,15,State Legislature,,David A. Schnoor,201
-Dodge,Pebble Township ,15,State Legislature,,David A. Schnoor,124
-Dodge,Platte East ,15,State Legislature,,David A. Schnoor,98
-Dodge,Platte West ,15,State Legislature,,David A. Schnoor,237
-Dodge,Nickerson Township ,15,State Legislature,,David A. Schnoor,193
-Dodge,City of Hooper ,15,State Legislature,,David A. Schnoor,199
-Dodge,HW/LG ,15,State Legislature,,David A. Schnoor,215
-Dodge,Elkhorn Township ,15,State Legislature,,David A. Schnoor,73
-Dodge,CT/UN ,15,State Legislature,,David A. Schnoor,283
-Dodge,New/Former Resident ,15,State Legislature,,David A. Schnoor,NA
-Dodge,ABSENTEE ,15,State Legislature,,David A. Schnoor,1137
-Dodge,TOTALS ,15,State Legislature,,David A. Schnoor,7189
-Dodge,Fremont - 1A ,15,State Legislature,,Lynne M. Walz,273
-Dodge,Fremont - 1B ,15,State Legislature,,Lynne M. Walz,290
-Dodge,Fremont - 1C ,15,State Legislature,,Lynne M. Walz,319
-Dodge,Fremont - 1D ,15,State Legislature,,Lynne M. Walz,154
-Dodge,Fremont - 1E ,15,State Legislature,,Lynne M. Walz,286
-Dodge,Fremont - 2A ,15,State Legislature,,Lynne M. Walz,220
-Dodge,Fremont - 2B ,15,State Legislature,,Lynne M. Walz,206
-Dodge,Fremont - 2C ,15,State Legislature,,Lynne M. Walz,382
-Dodge,Fremont - 2D ,15,State Legislature,,Lynne M. Walz,110
-Dodge,Fremont - 2E ,15,State Legislature,,Lynne M. Walz,236
-Dodge,Fremont - 3A ,15,State Legislature,,Lynne M. Walz,145
-Dodge,Fremont - 3B ,15,State Legislature,,Lynne M. Walz,73
-Dodge,Fremont - 3C ,15,State Legislature,,Lynne M. Walz,157
-Dodge,Fremont - 3D ,15,State Legislature,,Lynne M. Walz,200
-Dodge,Fremont - 3E ,15,State Legislature,,Lynne M. Walz,186
-Dodge,Fremont - 4A ,15,State Legislature,,Lynne M. Walz,262
-Dodge,Fremont - 4B ,15,State Legislature,,Lynne M. Walz,175
-Dodge,Fremont - 4C ,15,State Legislature,,Lynne M. Walz,349
-Dodge,Fremont - 4D ,15,State Legislature,,Lynne M. Walz,396
-Dodge,Fremont - 4E ,15,State Legislature,,Lynne M. Walz,135
-Dodge,City of North Bend ,15,State Legislature,,Lynne M. Walz,188
-Dodge,City of Scribner ,15,State Legislature,,Lynne M. Walz,88
-Dodge,CU/EV ,15,State Legislature,,Lynne M. Walz,69
-Dodge,Webster Township ,15,State Legislature,,Lynne M. Walz,156
-Dodge,Pebble Township ,15,State Legislature,,Lynne M. Walz,77
-Dodge,Platte East ,15,State Legislature,,Lynne M. Walz,104
-Dodge,Platte West ,15,State Legislature,,Lynne M. Walz,227
-Dodge,Nickerson Township ,15,State Legislature,,Lynne M. Walz,189
-Dodge,City of Hooper ,15,State Legislature,,Lynne M. Walz,140
-Dodge,HW/LG ,15,State Legislature,,Lynne M. Walz,137
-Dodge,Elkhorn Township ,15,State Legislature,,Lynne M. Walz,83
-Dodge,CT/UN ,15,State Legislature,,Lynne M. Walz,148
-Dodge,New/Former Resident ,15,State Legislature,,Lynne M. Walz,NA
-Dodge,ABSENTEE ,15,State Legislature,,Lynne M. Walz,1441
-Dodge,TOTALS ,15,State Legislature,,Lynne M. Walz,7601
-Dodge,Fremont - 1A ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 1B ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 1C ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 1D ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 1E ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 2A ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 2B ,15,State Legislature,,Write-ins,2
-Dodge,Fremont - 2C ,15,State Legislature,,Write-ins,2
-Dodge,Fremont - 2D ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 2E ,15,State Legislature,,Write-ins,2
-Dodge,Fremont - 3A ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 3B ,15,State Legislature,,Write-ins,2
-Dodge,Fremont - 3C ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 3D ,15,State Legislature,,Write-ins,2
-Dodge,Fremont - 3E ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 4A ,15,State Legislature,,Write-ins,1
-Dodge,Fremont - 4B ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 4C ,15,State Legislature,,Write-ins,3
-Dodge,Fremont - 4D ,15,State Legislature,,Write-ins,0
-Dodge,Fremont - 4E ,15,State Legislature,,Write-ins,0
-Dodge,City of North Bend ,15,State Legislature,,Write-ins,1
-Dodge,City of Scribner ,15,State Legislature,,Write-ins,0
-Dodge,CU/EV ,15,State Legislature,,Write-ins,0
-Dodge,Webster Township ,15,State Legislature,,Write-ins,0
-Dodge,Pebble Township ,15,State Legislature,,Write-ins,0
-Dodge,Platte East ,15,State Legislature,,Write-ins,0
-Dodge,Platte West ,15,State Legislature,,Write-ins,2
-Dodge,Nickerson Township ,15,State Legislature,,Write-ins,0
-Dodge,City of Hooper ,15,State Legislature,,Write-ins,0
-Dodge,HW/LG ,15,State Legislature,,Write-ins,1
-Dodge,Elkhorn Township ,15,State Legislature,,Write-ins,0
-Dodge,CT/UN ,15,State Legislature,,Write-ins,1
-Dodge,New/Former Resident ,15,State Legislature,,Write-ins,NA
-Dodge,ABSENTEE ,15,State Legislature,,Write-ins,8
-Dodge,TOTALS ,15,State Legislature,,Write-ins,32
+Dodge,Fremont - 1A,,President,Republican,Donald J. Trump,359
+Dodge,Fremont - 1B,,President,Republican,Donald J. Trump,286
+Dodge,Fremont - 1C,,President,Republican,Donald J. Trump,457
+Dodge,Fremont - 1D,,President,Republican,Donald J. Trump,192
+Dodge,Fremont - 1E,,President,Republican,Donald J. Trump,326
+Dodge,Fremont - 2A,,President,Republican,Donald J. Trump,233
+Dodge,Fremont - 2B,,President,Republican,Donald J. Trump,210
+Dodge,Fremont - 2C,,President,Republican,Donald J. Trump,471
+Dodge,Fremont - 2D,,President,Republican,Donald J. Trump,166
+Dodge,Fremont - 2E,,President,Republican,Donald J. Trump,306
+Dodge,Fremont - 3A,,President,Republican,Donald J. Trump,156
+Dodge,Fremont - 3B,,President,Republican,Donald J. Trump,82
+Dodge,Fremont - 3C,,President,Republican,Donald J. Trump,171
+Dodge,Fremont - 3D,,President,Republican,Donald J. Trump,263
+Dodge,Fremont - 3E,,President,Republican,Donald J. Trump,227
+Dodge,Fremont - 4A,,President,Republican,Donald J. Trump,300
+Dodge,Fremont - 4B,,President,Republican,Donald J. Trump,196
+Dodge,Fremont - 4C,,President,Republican,Donald J. Trump,414
+Dodge,Fremont - 4D,,President,Republican,Donald J. Trump,455
+Dodge,Fremont - 4E,,President,Republican,Donald J. Trump,163
+Dodge,City of North Bend,,President,Republican,Donald J. Trump,327
+Dodge,City of Scribner,,President,Republican,Donald J. Trump,299
+Dodge,CU/EV,,President,Republican,Donald J. Trump,171
+Dodge,Webster Township,,President,Republican,Donald J. Trump,298
+Dodge,Pebble Township,,President,Republican,Donald J. Trump,166
+Dodge,Platte East,,President,Republican,Donald J. Trump,149
+Dodge,Platte West,,President,Republican,Donald J. Trump,371
+Dodge,Nickerson Township,,President,Republican,Donald J. Trump,292
+Dodge,City of Hooper,,President,Republican,Donald J. Trump,238
+Dodge,HW/LG,,President,Republican,Donald J. Trump,294
+Dodge,Elkhorn Township,,President,Republican,Donald J. Trump,124
+Dodge,CT/UN,,President,Republican,Donald J. Trump,360
+Dodge,New/Former Resident,,President,Republican,Donald J. Trump,0
+Dodge,ABSENTEE,,President,Republican,Donald J. Trump,1411
+Dodge,TOTALS,,President,Republican,Donald J. Trump,9933
+Dodge,Fremont - 1A,,President,Democratic,Hillary Clinton,167
+Dodge,Fremont - 1B,,President,Democratic,Hillary Clinton,156
+Dodge,Fremont - 1C,,President,Democratic,Hillary Clinton,181
+Dodge,Fremont - 1D,,President,Democratic,Hillary Clinton,75
+Dodge,Fremont - 1E,,President,Democratic,Hillary Clinton,182
+Dodge,Fremont - 2A,,President,Democratic,Hillary Clinton,121
+Dodge,Fremont - 2B,,President,Democratic,Hillary Clinton,98
+Dodge,Fremont - 2C,,President,Democratic,Hillary Clinton,180
+Dodge,Fremont - 2D,,President,Democratic,Hillary Clinton,63
+Dodge,Fremont - 2E,,President,Democratic,Hillary Clinton,115
+Dodge,Fremont - 3A,,President,Democratic,Hillary Clinton,87
+Dodge,Fremont - 3B,,President,Democratic,Hillary Clinton,59
+Dodge,Fremont - 3C,,President,Democratic,Hillary Clinton,99
+Dodge,Fremont - 3D,,President,Democratic,Hillary Clinton,154
+Dodge,Fremont - 3E,,President,Democratic,Hillary Clinton,113
+Dodge,Fremont - 4A,,President,Democratic,Hillary Clinton,127
+Dodge,Fremont - 4B,,President,Democratic,Hillary Clinton,93
+Dodge,Fremont - 4C,,President,Democratic,Hillary Clinton,201
+Dodge,Fremont - 4D,,President,Democratic,Hillary Clinton,192
+Dodge,Fremont - 4E,,President,Democratic,Hillary Clinton,75
+Dodge,City of North Bend,,President,Democratic,Hillary Clinton,108
+Dodge,City of Scribner,,President,Democratic,Hillary Clinton,58
+Dodge,CU/EV,,President,Democratic,Hillary Clinton,37
+Dodge,Webster Township,,President,Democratic,Hillary Clinton,64
+Dodge,Pebble Township,,President,Democratic,Hillary Clinton,23
+Dodge,Platte East,,President,Democratic,Hillary Clinton,59
+Dodge,Platte West,,President,Democratic,Hillary Clinton,100
+Dodge,Nickerson Township,,President,Democratic,Hillary Clinton,93
+Dodge,City of Hooper,,President,Democratic,Hillary Clinton,89
+Dodge,HW/LG,,President,Democratic,Hillary Clinton,55
+Dodge,Elkhorn Township,,President,Democratic,Hillary Clinton,36
+Dodge,CT/UN,,President,Democratic,Hillary Clinton,71
+Dodge,New/Former Resident,,President,Democratic,Hillary Clinton,0
+Dodge,ABSENTEE,,President,Democratic,Hillary Clinton,1213
+Dodge,TOTALS,,President,Democratic,Hillary Clinton,4544
+Dodge,Fremont - 1A,,President,Libertarian,Gary Johnson,26
+Dodge,Fremont - 1B,,President,Libertarian,Gary Johnson,32
+Dodge,Fremont - 1C,,President,Libertarian,Gary Johnson,18
+Dodge,Fremont - 1D,,President,Libertarian,Gary Johnson,8
+Dodge,Fremont - 1E,,President,Libertarian,Gary Johnson,10
+Dodge,Fremont - 2A,,President,Libertarian,Gary Johnson,14
+Dodge,Fremont - 2B,,President,Libertarian,Gary Johnson,17
+Dodge,Fremont - 2C,,President,Libertarian,Gary Johnson,38
+Dodge,Fremont - 2D,,President,Libertarian,Gary Johnson,12
+Dodge,Fremont - 2E,,President,Libertarian,Gary Johnson,18
+Dodge,Fremont - 3A,,President,Libertarian,Gary Johnson,18
+Dodge,Fremont - 3B,,President,Libertarian,Gary Johnson,7
+Dodge,Fremont - 3C,,President,Libertarian,Gary Johnson,15
+Dodge,Fremont - 3D,,President,Libertarian,Gary Johnson,15
+Dodge,Fremont - 3E,,President,Libertarian,Gary Johnson,17
+Dodge,Fremont - 4A,,President,Libertarian,Gary Johnson,30
+Dodge,Fremont - 4B,,President,Libertarian,Gary Johnson,15
+Dodge,Fremont - 4C,,President,Libertarian,Gary Johnson,30
+Dodge,Fremont - 4D,,President,Libertarian,Gary Johnson,27
+Dodge,Fremont - 4E,,President,Libertarian,Gary Johnson,14
+Dodge,City of North Bend,,President,Libertarian,Gary Johnson,24
+Dodge,City of Scribner,,President,Libertarian,Gary Johnson,16
+Dodge,CU/EV,,President,Libertarian,Gary Johnson,10
+Dodge,Webster Township,,President,Libertarian,Gary Johnson,6
+Dodge,Pebble Township,,President,Libertarian,Gary Johnson,12
+Dodge,Platte East,,President,Libertarian,Gary Johnson,6
+Dodge,Platte West,,President,Libertarian,Gary Johnson,12
+Dodge,Nickerson Township,,President,Libertarian,Gary Johnson,15
+Dodge,City of Hooper,,President,Libertarian,Gary Johnson,15
+Dodge,HW/LG,,President,Libertarian,Gary Johnson,19
+Dodge,Elkhorn Township,,President,Libertarian,Gary Johnson,7
+Dodge,CT/UN,,President,Libertarian,Gary Johnson,17
+Dodge,New/Former Resident,,President,Libertarian,Gary Johnson,0
+Dodge,ABSENTEE,,President,Libertarian,Gary Johnson,84
+Dodge,TOTALS,,President,Libertarian,Gary Johnson,624
+Dodge,Fremont - 1A,,President,,Jill Stein,7
+Dodge,Fremont - 1B,,President,,Jill Stein,2
+Dodge,Fremont - 1C,,President,,Jill Stein,3
+Dodge,Fremont - 1D,,President,,Jill Stein,6
+Dodge,Fremont - 1E,,President,,Jill Stein,5
+Dodge,Fremont - 2A,,President,,Jill Stein,11
+Dodge,Fremont - 2B,,President,,Jill Stein,2
+Dodge,Fremont - 2C,,President,,Jill Stein,5
+Dodge,Fremont - 2D,,President,,Jill Stein,3
+Dodge,Fremont - 2E,,President,,Jill Stein,5
+Dodge,Fremont - 3A,,President,,Jill Stein,2
+Dodge,Fremont - 3B,,President,,Jill Stein,3
+Dodge,Fremont - 3C,,President,,Jill Stein,7
+Dodge,Fremont - 3D,,President,,Jill Stein,6
+Dodge,Fremont - 3E,,President,,Jill Stein,8
+Dodge,Fremont - 4A,,President,,Jill Stein,6
+Dodge,Fremont - 4B,,President,,Jill Stein,7
+Dodge,Fremont - 4C,,President,,Jill Stein,4
+Dodge,Fremont - 4D,,President,,Jill Stein,3
+Dodge,Fremont - 4E,,President,,Jill Stein,3
+Dodge,City of North Bend,,President,,Jill Stein,4
+Dodge,City of Scribner,,President,,Jill Stein,3
+Dodge,CU/EV,,President,,Jill Stein,3
+Dodge,Webster Township,,President,,Jill Stein,0
+Dodge,Pebble Township,,President,,Jill Stein,2
+Dodge,Platte East,,President,,Jill Stein,1
+Dodge,Platte West,,President,,Jill Stein,4
+Dodge,Nickerson Township,,President,,Jill Stein,5
+Dodge,City of Hooper,,President,,Jill Stein,2
+Dodge,HW/LG,,President,,Jill Stein,6
+Dodge,Elkhorn Township,,President,,Jill Stein,0
+Dodge,CT/UN,,President,,Jill Stein,2
+Dodge,New/Former Resident,,President,,Jill Stein,0
+Dodge,ABSENTEE,,President,,Jill Stein,32
+Dodge,TOTALS,,President,,Jill Stein,162
+Dodge,Fremont - 1A,,President,,Write-ins,11
+Dodge,Fremont - 1B,,President,,Write-ins,9
+Dodge,Fremont - 1C,,President,,Write-ins,20
+Dodge,Fremont - 1D,,President,,Write-ins,5
+Dodge,Fremont - 1E,,President,,Write-ins,14
+Dodge,Fremont - 2A,,President,,Write-ins,5
+Dodge,Fremont - 2B,,President,,Write-ins,9
+Dodge,Fremont - 2C,,President,,Write-ins,7
+Dodge,Fremont - 2D,,President,,Write-ins,6
+Dodge,Fremont - 2E,,President,,Write-ins,7
+Dodge,Fremont - 3A,,President,,Write-ins,12
+Dodge,Fremont - 3B,,President,,Write-ins,1
+Dodge,Fremont - 3C,,President,,Write-ins,3
+Dodge,Fremont - 3D,,President,,Write-ins,6
+Dodge,Fremont - 3E,,President,,Write-ins,8
+Dodge,Fremont - 4A,,President,,Write-ins,5
+Dodge,Fremont - 4B,,President,,Write-ins,8
+Dodge,Fremont - 4C,,President,,Write-ins,13
+Dodge,Fremont - 4D,,President,,Write-ins,12
+Dodge,Fremont - 4E,,President,,Write-ins,6
+Dodge,City of North Bend,,President,,Write-ins,10
+Dodge,City of Scribner,,President,,Write-ins,6
+Dodge,CU/EV,,President,,Write-ins,2
+Dodge,Webster Township,,President,,Write-ins,2
+Dodge,Pebble Township,,President,,Write-ins,3
+Dodge,Platte East,,President,,Write-ins,4
+Dodge,Platte West,,President,,Write-ins,12
+Dodge,Nickerson Township,,President,,Write-ins,2
+Dodge,City of Hooper,,President,,Write-ins,2
+Dodge,HW/LG,,President,,Write-ins,3
+Dodge,Elkhorn Township,,President,,Write-ins,0
+Dodge,CT/UN,,President,,Write-ins,8
+Dodge,New/Former Resident,,President,,Write-ins,0
+Dodge,ABSENTEE,,President,,Write-ins,45
+Dodge,TOTALS,,President,,Write-ins,266
+Dodge,Fremont - 1A,1,U.S. House,Republican,Jeff Fortenberry,425
+Dodge,Fremont - 1B,1,U.S. House,Republican,Jeff Fortenberry,357
+Dodge,Fremont - 1C,1,U.S. House,Republican,Jeff Fortenberry,546
+Dodge,Fremont - 1D,1,U.S. House,Republican,Jeff Fortenberry,218
+Dodge,Fremont - 1E,1,U.S. House,Republican,Jeff Fortenberry,412
+Dodge,Fremont - 2A,1,U.S. House,Republican,Jeff Fortenberry,276
+Dodge,Fremont - 2B,1,U.S. House,Republican,Jeff Fortenberry,255
+Dodge,Fremont - 2C,1,U.S. House,Republican,Jeff Fortenberry,539
+Dodge,Fremont - 2D,1,U.S. House,Republican,Jeff Fortenberry,182
+Dodge,Fremont - 2E,1,U.S. House,Republican,Jeff Fortenberry,350
+Dodge,Fremont - 3A,1,U.S. House,Republican,Jeff Fortenberry,192
+Dodge,Fremont - 3B,1,U.S. House,Republican,Jeff Fortenberry,88
+Dodge,Fremont - 3C,1,U.S. House,Republican,Jeff Fortenberry,191
+Dodge,Fremont - 3D,1,U.S. House,Republican,Jeff Fortenberry,324
+Dodge,Fremont - 3E,1,U.S. House,Republican,Jeff Fortenberry,270
+Dodge,Fremont - 4A,1,U.S. House,Republican,Jeff Fortenberry,356
+Dodge,Fremont - 4B,1,U.S. House,Republican,Jeff Fortenberry,221
+Dodge,Fremont - 4C,1,U.S. House,Republican,Jeff Fortenberry,495
+Dodge,Fremont - 4D,1,U.S. House,Republican,Jeff Fortenberry,561
+Dodge,Fremont - 4E,1,U.S. House,Republican,Jeff Fortenberry,184
+Dodge,City of North Bend,1,U.S. House,Republican,Jeff Fortenberry,376
+Dodge,City of Scribner,1,U.S. House,Republican,Jeff Fortenberry,330
+Dodge,CU/EV,1,U.S. House,Republican,Jeff Fortenberry,186
+Dodge,Webster Township,1,U.S. House,Republican,Jeff Fortenberry,289
+Dodge,Pebble Township,1,U.S. House,Republican,Jeff Fortenberry,178
+Dodge,Platte East,1,U.S. House,Republican,Jeff Fortenberry,158
+Dodge,Platte West,1,U.S. House,Republican,Jeff Fortenberry,394
+Dodge,Nickerson Township,1,U.S. House,Republican,Jeff Fortenberry,314
+Dodge,City of Hooper,1,U.S. House,Republican,Jeff Fortenberry,271
+Dodge,HW/LG,1,U.S. House,Republican,Jeff Fortenberry,320
+Dodge,Elkhorn Township,1,U.S. House,Republican,Jeff Fortenberry,130
+Dodge,CT/UN,1,U.S. House,Republican,Jeff Fortenberry,380
+Dodge,New/Former Resident,1,U.S. House,Republican,Jeff Fortenberry,NA
+Dodge,ABSENTEE,1,U.S. House,Republican,Jeff Fortenberry,1713
+Dodge,TOTALS,1,U.S. House,Republican,Jeff Fortenberry,11481
+Dodge,Fremont - 1A,1,U.S. House,Democratic,Daniel M. Wik,115
+Dodge,Fremont - 1B,1,U.S. House,Democratic,Daniel M. Wik,112
+Dodge,Fremont - 1C,1,U.S. House,Democratic,Daniel M. Wik,117
+Dodge,Fremont - 1D,1,U.S. House,Democratic,Daniel M. Wik,52
+Dodge,Fremont - 1E,1,U.S. House,Democratic,Daniel M. Wik,114
+Dodge,Fremont - 2A,1,U.S. House,Democratic,Daniel M. Wik,99
+Dodge,Fremont - 2B,1,U.S. House,Democratic,Daniel M. Wik,76
+Dodge,Fremont - 2C,1,U.S. House,Democratic,Daniel M. Wik,134
+Dodge,Fremont - 2D,1,U.S. House,Democratic,Daniel M. Wik,52
+Dodge,Fremont - 2E,1,U.S. House,Democratic,Daniel M. Wik,89
+Dodge,Fremont - 3A,1,U.S. House,Democratic,Daniel M. Wik,69
+Dodge,Fremont - 3B,1,U.S. House,Democratic,Daniel M. Wik,59
+Dodge,Fremont - 3C,1,U.S. House,Democratic,Daniel M. Wik,94
+Dodge,Fremont - 3D,1,U.S. House,Democratic,Daniel M. Wik,111
+Dodge,Fremont - 3E,1,U.S. House,Democratic,Daniel M. Wik,93
+Dodge,Fremont - 4A,1,U.S. House,Democratic,Daniel M. Wik,100
+Dodge,Fremont - 4B,1,U.S. House,Democratic,Daniel M. Wik,81
+Dodge,Fremont - 4C,1,U.S. House,Democratic,Daniel M. Wik,139
+Dodge,Fremont - 4D,1,U.S. House,Democratic,Daniel M. Wik,111
+Dodge,Fremont - 4E,1,U.S. House,Democratic,Daniel M. Wik,64
+Dodge,City of North Bend,1,U.S. House,Democratic,Daniel M. Wik,78
+Dodge,City of Scribner,1,U.S. House,Democratic,Daniel M. Wik,43
+Dodge,CU/EV,1,U.S. House,Democratic,Daniel M. Wik,25
+Dodge,Webster Township,1,U.S. House,Democratic,Daniel M. Wik,60
+Dodge,Pebble Township,1,U.S. House,Democratic,Daniel M. Wik,20
+Dodge,Platte East,1,U.S. House,Democratic,Daniel M. Wik,50
+Dodge,Platte West,1,U.S. House,Democratic,Daniel M. Wik,87
+Dodge,Nickerson Township,1,U.S. House,Democratic,Daniel M. Wik,81
+Dodge,City of Hooper,1,U.S. House,Democratic,Daniel M. Wik,69
+Dodge,HW/LG,1,U.S. House,Democratic,Daniel M. Wik,42
+Dodge,Elkhorn Township,1,U.S. House,Democratic,Daniel M. Wik,30
+Dodge,CT/UN,1,U.S. House,Democratic,Daniel M. Wik,63
+Dodge,New/Former Resident,1,U.S. House,Democratic,Daniel M. Wik,NA
+Dodge,ABSENTEE,1,U.S. House,Democratic,Daniel M. Wik,959
+Dodge,TOTALS,1,U.S. House,Democratic,Daniel M. Wik,3488
+Dodge,Fremont - 1A,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 1B,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 1C,1,U.S. House,,Write-ins,2
+Dodge,Fremont - 1D,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 1E,1,U.S. House,,Write-ins,2
+Dodge,Fremont - 2A,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 2B,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 2C,1,U.S. House,,Write-ins,4
+Dodge,Fremont - 2D,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 2E,1,U.S. House,,Write-ins,3
+Dodge,Fremont - 3A,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 3B,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 3C,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 3D,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 3E,1,U.S. House,,Write-ins,0
+Dodge,Fremont - 4A,1,U.S. House,,Write-ins,3
+Dodge,Fremont - 4B,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 4C,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 4D,1,U.S. House,,Write-ins,1
+Dodge,Fremont - 4E,1,U.S. House,,Write-ins,0
+Dodge,City of North Bend,1,U.S. House,,Write-ins,0
+Dodge,City of Scribner,1,U.S. House,,Write-ins,0
+Dodge,CU/EV,1,U.S. House,,Write-ins,0
+Dodge,Webster Township,1,U.S. House,,Write-ins,1
+Dodge,Pebble Township,1,U.S. House,,Write-ins,1
+Dodge,Platte East,1,U.S. House,,Write-ins,0
+Dodge,Platte West,1,U.S. House,,Write-ins,3
+Dodge,Nickerson Township,1,U.S. House,,Write-ins,0
+Dodge,City of Hooper,1,U.S. House,,Write-ins,1
+Dodge,HW/LG,1,U.S. House,,Write-ins,1
+Dodge,Elkhorn Township,1,U.S. House,,Write-ins,0
+Dodge,CT/UN,1,U.S. House,,Write-ins,0
+Dodge,New/Former Resident,1,U.S. House,,Write-ins,NA
+Dodge,ABSENTEE,1,U.S. House,,Write-ins,6
+Dodge,TOTALS,1,U.S. House,,Write-ins,34
+Dodge,Fremont - 1A,15,State Legislature,,David A. Schnoor,269
+Dodge,Fremont - 1B,15,State Legislature,,David A. Schnoor,178
+Dodge,Fremont - 1C,15,State Legislature,,David A. Schnoor,347
+Dodge,Fremont - 1D,15,State Legislature,,David A. Schnoor,118
+Dodge,Fremont - 1E,15,State Legislature,,David A. Schnoor,249
+Dodge,Fremont - 2A,15,State Legislature,,David A. Schnoor,152
+Dodge,Fremont - 2B,15,State Legislature,,David A. Schnoor,115
+Dodge,Fremont - 2C,15,State Legislature,,David A. Schnoor,294
+Dodge,Fremont - 2D,15,State Legislature,,David A. Schnoor,123
+Dodge,Fremont - 2E,15,State Legislature,,David A. Schnoor,196
+Dodge,Fremont - 3A,15,State Legislature,,David A. Schnoor,115
+Dodge,Fremont - 3B,15,State Legislature,,David A. Schnoor,66
+Dodge,Fremont - 3C,15,State Legislature,,David A. Schnoor,120
+Dodge,Fremont - 3D,15,State Legislature,,David A. Schnoor,229
+Dodge,Fremont - 3E,15,State Legislature,,David A. Schnoor,169
+Dodge,Fremont - 4A,15,State Legislature,,David A. Schnoor,192
+Dodge,Fremont - 4B,15,State Legislature,,David A. Schnoor,134
+Dodge,Fremont - 4C,15,State Legislature,,David A. Schnoor,276
+Dodge,Fremont - 4D,15,State Legislature,,David A. Schnoor,278
+Dodge,Fremont - 4E,15,State Legislature,,David A. Schnoor,107
+Dodge,City of North Bend,15,State Legislature,,David A. Schnoor,258
+Dodge,City of Scribner,15,State Legislature,,David A. Schnoor,298
+Dodge,CU/EV,15,State Legislature,,David A. Schnoor,146
+Dodge,Webster Township,15,State Legislature,,David A. Schnoor,201
+Dodge,Pebble Township,15,State Legislature,,David A. Schnoor,124
+Dodge,Platte East,15,State Legislature,,David A. Schnoor,98
+Dodge,Platte West,15,State Legislature,,David A. Schnoor,237
+Dodge,Nickerson Township,15,State Legislature,,David A. Schnoor,193
+Dodge,City of Hooper,15,State Legislature,,David A. Schnoor,199
+Dodge,HW/LG,15,State Legislature,,David A. Schnoor,215
+Dodge,Elkhorn Township,15,State Legislature,,David A. Schnoor,73
+Dodge,CT/UN,15,State Legislature,,David A. Schnoor,283
+Dodge,New/Former Resident,15,State Legislature,,David A. Schnoor,NA
+Dodge,ABSENTEE,15,State Legislature,,David A. Schnoor,1137
+Dodge,TOTALS,15,State Legislature,,David A. Schnoor,7189
+Dodge,Fremont - 1A,15,State Legislature,,Lynne M. Walz,273
+Dodge,Fremont - 1B,15,State Legislature,,Lynne M. Walz,290
+Dodge,Fremont - 1C,15,State Legislature,,Lynne M. Walz,319
+Dodge,Fremont - 1D,15,State Legislature,,Lynne M. Walz,154
+Dodge,Fremont - 1E,15,State Legislature,,Lynne M. Walz,286
+Dodge,Fremont - 2A,15,State Legislature,,Lynne M. Walz,220
+Dodge,Fremont - 2B,15,State Legislature,,Lynne M. Walz,206
+Dodge,Fremont - 2C,15,State Legislature,,Lynne M. Walz,382
+Dodge,Fremont - 2D,15,State Legislature,,Lynne M. Walz,110
+Dodge,Fremont - 2E,15,State Legislature,,Lynne M. Walz,236
+Dodge,Fremont - 3A,15,State Legislature,,Lynne M. Walz,145
+Dodge,Fremont - 3B,15,State Legislature,,Lynne M. Walz,73
+Dodge,Fremont - 3C,15,State Legislature,,Lynne M. Walz,157
+Dodge,Fremont - 3D,15,State Legislature,,Lynne M. Walz,200
+Dodge,Fremont - 3E,15,State Legislature,,Lynne M. Walz,186
+Dodge,Fremont - 4A,15,State Legislature,,Lynne M. Walz,262
+Dodge,Fremont - 4B,15,State Legislature,,Lynne M. Walz,175
+Dodge,Fremont - 4C,15,State Legislature,,Lynne M. Walz,349
+Dodge,Fremont - 4D,15,State Legislature,,Lynne M. Walz,396
+Dodge,Fremont - 4E,15,State Legislature,,Lynne M. Walz,135
+Dodge,City of North Bend,15,State Legislature,,Lynne M. Walz,188
+Dodge,City of Scribner,15,State Legislature,,Lynne M. Walz,88
+Dodge,CU/EV,15,State Legislature,,Lynne M. Walz,69
+Dodge,Webster Township,15,State Legislature,,Lynne M. Walz,156
+Dodge,Pebble Township,15,State Legislature,,Lynne M. Walz,77
+Dodge,Platte East,15,State Legislature,,Lynne M. Walz,104
+Dodge,Platte West,15,State Legislature,,Lynne M. Walz,227
+Dodge,Nickerson Township,15,State Legislature,,Lynne M. Walz,189
+Dodge,City of Hooper,15,State Legislature,,Lynne M. Walz,140
+Dodge,HW/LG,15,State Legislature,,Lynne M. Walz,137
+Dodge,Elkhorn Township,15,State Legislature,,Lynne M. Walz,83
+Dodge,CT/UN,15,State Legislature,,Lynne M. Walz,148
+Dodge,New/Former Resident,15,State Legislature,,Lynne M. Walz,NA
+Dodge,ABSENTEE,15,State Legislature,,Lynne M. Walz,1441
+Dodge,TOTALS,15,State Legislature,,Lynne M. Walz,7601
+Dodge,Fremont - 1A,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 1B,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 1C,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 1D,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 1E,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 2A,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 2B,15,State Legislature,,Write-ins,2
+Dodge,Fremont - 2C,15,State Legislature,,Write-ins,2
+Dodge,Fremont - 2D,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 2E,15,State Legislature,,Write-ins,2
+Dodge,Fremont - 3A,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 3B,15,State Legislature,,Write-ins,2
+Dodge,Fremont - 3C,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 3D,15,State Legislature,,Write-ins,2
+Dodge,Fremont - 3E,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 4A,15,State Legislature,,Write-ins,1
+Dodge,Fremont - 4B,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 4C,15,State Legislature,,Write-ins,3
+Dodge,Fremont - 4D,15,State Legislature,,Write-ins,0
+Dodge,Fremont - 4E,15,State Legislature,,Write-ins,0
+Dodge,City of North Bend,15,State Legislature,,Write-ins,1
+Dodge,City of Scribner,15,State Legislature,,Write-ins,0
+Dodge,CU/EV,15,State Legislature,,Write-ins,0
+Dodge,Webster Township,15,State Legislature,,Write-ins,0
+Dodge,Pebble Township,15,State Legislature,,Write-ins,0
+Dodge,Platte East,15,State Legislature,,Write-ins,0
+Dodge,Platte West,15,State Legislature,,Write-ins,2
+Dodge,Nickerson Township,15,State Legislature,,Write-ins,0
+Dodge,City of Hooper,15,State Legislature,,Write-ins,0
+Dodge,HW/LG,15,State Legislature,,Write-ins,1
+Dodge,Elkhorn Township,15,State Legislature,,Write-ins,0
+Dodge,CT/UN,15,State Legislature,,Write-ins,1
+Dodge,New/Former Resident,15,State Legislature,,Write-ins,NA
+Dodge,ABSENTEE,15,State Legislature,,Write-ins,8
+Dodge,TOTALS,15,State Legislature,,Write-ins,32
 Douglas,1-Jan,,Ballots Cast,,,1277
 Douglas,2-Jan,,Ballots Cast,,,782
 Douglas,3-Jan,,Ballots Cast,,,1527
@@ -12958,24 +12958,24 @@ Richardson,Liberty,3,U.S. House,Republican,Adrian Smith,127
 Richardson,New/Former Resident,3,U.S. House,Republican,Adrian Smith,0
 Richardson,Salem,3,U.S. House,Republican,Adrian Smith,77
 Richardson,WMuddy/Porter,3,U.S. House,Republican,Adrian Smith,151
-Richardson,Absentee/Early Vote,1,State Legislature,,Dan Watermeier ,0
-Richardson,Arago/Barada,1,State Legislature,,Dan Watermeier ,161
-Richardson,Countywide,1,State Legislature,,Dan Watermeier ,0
-Richardson,East Muddy,1,State Legislature,,Dan Watermeier ,75
-Richardson,FC Ward 1,1,State Legislature,,Dan Watermeier ,471
-Richardson,FC Ward 2,1,State Legislature,,Dan Watermeier ,334
-Richardson,FC Ward 3,1,State Legislature,,Dan Watermeier ,355
-Richardson,FC Ward 4,1,State Legislature,,Dan Watermeier ,224
-Richardson,FCRural/Ohio,1,State Legislature,,Dan Watermeier ,231
-Richardson,Fran/Hrr/Spi,1,State Legislature,,Dan Watermeier ,183
-Richardson,Grant/Nemaha,1,State Legislature,,Dan Watermeier ,171
-Richardson,Humb. I,1,State Legislature,,Dan Watermeier ,176
-Richardson,Humb.II,1,State Legislature,,Dan Watermeier ,177
-Richardson,Jeff/Rulo,1,State Legislature,,Dan Watermeier ,169
-Richardson,Liberty,1,State Legislature,,Dan Watermeier ,122
-Richardson,New/Former Resident,1,State Legislature,,Dan Watermeier ,0
-Richardson,Salem,1,State Legislature,,Dan Watermeier ,69
-Richardson,WMuddy/Porter,1,State Legislature,,Dan Watermeier ,157
+Richardson,Absentee/Early Vote,1,State Legislature,,Dan Watermeier,0
+Richardson,Arago/Barada,1,State Legislature,,Dan Watermeier,161
+Richardson,Countywide,1,State Legislature,,Dan Watermeier,0
+Richardson,East Muddy,1,State Legislature,,Dan Watermeier,75
+Richardson,FC Ward 1,1,State Legislature,,Dan Watermeier,471
+Richardson,FC Ward 2,1,State Legislature,,Dan Watermeier,334
+Richardson,FC Ward 3,1,State Legislature,,Dan Watermeier,355
+Richardson,FC Ward 4,1,State Legislature,,Dan Watermeier,224
+Richardson,FCRural/Ohio,1,State Legislature,,Dan Watermeier,231
+Richardson,Fran/Hrr/Spi,1,State Legislature,,Dan Watermeier,183
+Richardson,Grant/Nemaha,1,State Legislature,,Dan Watermeier,171
+Richardson,Humb. I,1,State Legislature,,Dan Watermeier,176
+Richardson,Humb.II,1,State Legislature,,Dan Watermeier,177
+Richardson,Jeff/Rulo,1,State Legislature,,Dan Watermeier,169
+Richardson,Liberty,1,State Legislature,,Dan Watermeier,122
+Richardson,New/Former Resident,1,State Legislature,,Dan Watermeier,0
+Richardson,Salem,1,State Legislature,,Dan Watermeier,69
+Richardson,WMuddy/Porter,1,State Legislature,,Dan Watermeier,157
 Richardson,Arago/Barada,,President,,Write-ins,2
 Richardson,East Muddy,,President,,Write-ins,0
 Richardson,FC Ward 1,,President,,Write-ins,8
@@ -16588,7 +16588,7 @@ Sarpy,Precinct 59,,Referendum No. 426,,Repeal,825
 Sarpy,Precinct 60,,Referendum No. 426,,Repeal,723
 Sarpy,Precinct 61,,Referendum No. 426,,Repeal,1769
 Sarpy,Precinct 62,,Referendum No. 426,,Repeal,897
-Saunders,Early voters ,,President,REP,Trump/Pence,974
+Saunders,Early voters,,President,REP,Trump/Pence,974
 Saunders,Valparaiso 1,,President,REP,Trump/Pence,441
 Saunders,Weston 2,,President,REP,Trump/Pence,280
 Saunders,Prague 3,,President,REP,Trump/Pence,311
@@ -16606,8 +16606,8 @@ Saunders,Ashland ward 1 14,,President,REP,Trump/Pence,275
 Saunders,Ashland ward 2 15,,President,REP,Trump/Pence,305
 Saunders,Ashland rural 16,,President,REP,Trump/Pence,425
 Saunders,Yutan 17,,President,REP,Trump/Pence,740
-Saunders,Provisional ballots ,,President,REP,Trump/Pence,67
-Saunders,Early voters ,,President,DEM,Clinton/Kaine,493
+Saunders,Provisional ballots,,President,REP,Trump/Pence,67
+Saunders,Early voters,,President,DEM,Clinton/Kaine,493
 Saunders,Valparaiso 1,,President,DEM,Clinton/Kaine,144
 Saunders,Weston 2,,President,DEM,Clinton/Kaine,60
 Saunders,Prague 3,,President,DEM,Clinton/Kaine,67
@@ -16625,8 +16625,8 @@ Saunders,Ashland ward 1 14,,President,DEM,Clinton/Kaine,141
 Saunders,Ashland ward 2 15,,President,DEM,Clinton/Kaine,127
 Saunders,Ashland rural 16,,President,DEM,Clinton/Kaine,147
 Saunders,Yutan 17,,President,DEM,Clinton/Kaine,175
-Saunders,Provisional ballots ,,President,DEM,Clinton/Kaine,14
-Saunders,Early voters ,,President,LIB,Johnson/Weld,68
+Saunders,Provisional ballots,,President,DEM,Clinton/Kaine,14
+Saunders,Early voters,,President,LIB,Johnson/Weld,68
 Saunders,Valparaiso 1,,President,LIB,Johnson/Weld,16
 Saunders,Weston 2,,President,LIB,Johnson/Weld,20
 Saunders,Prague 3,,President,LIB,Johnson/Weld,17
@@ -16644,8 +16644,8 @@ Saunders,Ashland ward 1 14,,President,LIB,Johnson/Weld,34
 Saunders,Ashland ward 2 15,,President,LIB,Johnson/Weld,30
 Saunders,Ashland rural 16,,President,LIB,Johnson/Weld,29
 Saunders,Yutan 17,,President,LIB,Johnson/Weld,50
-Saunders,Provisional ballots ,,President,LIB,Johnson/Weld,7
-Saunders,Early voters ,,President,PET,Stein/Baraka,14
+Saunders,Provisional ballots,,President,LIB,Johnson/Weld,7
+Saunders,Early voters,,President,PET,Stein/Baraka,14
 Saunders,Valparaiso 1,,President,PET,Stein/Baraka,7
 Saunders,Weston 2,,President,PET,Stein/Baraka,3
 Saunders,Prague 3,,President,PET,Stein/Baraka,4
@@ -16663,8 +16663,8 @@ Saunders,Ashland ward 1 14,,President,PET,Stein/Baraka,3
 Saunders,Ashland ward 2 15,,President,PET,Stein/Baraka,6
 Saunders,Ashland rural 16,,President,PET,Stein/Baraka,6
 Saunders,Yutan 17,,President,PET,Stein/Baraka,10
-Saunders,Provisional ballots ,,President,PET,Stein/Baraka,2
-Saunders,Early voters ,,President,NON,Write-in,29
+Saunders,Provisional ballots,,President,PET,Stein/Baraka,2
+Saunders,Early voters,,President,NON,Write-in,29
 Saunders,Valparaiso 1,,President,NON,Write-in,6
 Saunders,Weston 2,,President,NON,Write-in,7
 Saunders,Prague 3,,President,NON,Write-in,7
@@ -16682,8 +16682,8 @@ Saunders,Ashland ward 1 14,,President,NON,Write-in,4
 Saunders,Ashland ward 2 15,,President,NON,Write-in,10
 Saunders,Ashland rural 16,,President,NON,Write-in,12
 Saunders,Yutan 17,,President,NON,Write-in,11
-Saunders,Provisional ballots ,,President,NON,Write-in,3
-Saunders,Early voters ,1,U.S. House,REP,Jeff Fortenberry,1090
+Saunders,Provisional ballots,,President,NON,Write-in,3
+Saunders,Early voters,1,U.S. House,REP,Jeff Fortenberry,1090
 Saunders,Valparaiso 1,1,U.S. House,REP,Jeff Fortenberry,465
 Saunders,Weston 2,1,U.S. House,REP,Jeff Fortenberry,293
 Saunders,Prague 3,1,U.S. House,REP,Jeff Fortenberry,330
@@ -16701,8 +16701,8 @@ Saunders,Ashland ward 1 14,1,U.S. House,REP,Jeff Fortenberry,311
 Saunders,Ashland ward 2 15,1,U.S. House,REP,Jeff Fortenberry,353
 Saunders,Ashland rural 16,1,U.S. House,REP,Jeff Fortenberry,476
 Saunders,Yutan 17,1,U.S. House,REP,Jeff Fortenberry,776
-Saunders,Provisional ballots ,1,U.S. House,REP,Jeff Fortenberry,71
-Saunders,Early voters ,1,U.S. House,DEM,Daniel M. Wik,429
+Saunders,Provisional ballots,1,U.S. House,REP,Jeff Fortenberry,71
+Saunders,Early voters,1,U.S. House,DEM,Daniel M. Wik,429
 Saunders,Valparaiso 1,1,U.S. House,DEM,Daniel M. Wik,141
 Saunders,Weston 2,1,U.S. House,DEM,Daniel M. Wik,70
 Saunders,Prague 3,1,U.S. House,DEM,Daniel M. Wik,66
@@ -16720,8 +16720,8 @@ Saunders,Ashland ward 1 14,1,U.S. House,DEM,Daniel M. Wik,121
 Saunders,Ashland ward 2 15,1,U.S. House,DEM,Daniel M. Wik,105
 Saunders,Ashland rural 16,1,U.S. House,DEM,Daniel M. Wik,128
 Saunders,Yutan 17,1,U.S. House,DEM,Daniel M. Wik,163
-Saunders,Provisional ballots ,1,U.S. House,DEM,Daniel M. Wik,15
-Saunders,Early voters ,1,U.S. House,NON,Write-in,3
+Saunders,Provisional ballots,1,U.S. House,DEM,Daniel M. Wik,15
+Saunders,Early voters,1,U.S. House,NON,Write-in,3
 Saunders,Valparaiso 1,1,U.S. House,NON,Write-in,1
 Saunders,Weston 2,1,U.S. House,NON,Write-in,2
 Saunders,Prague 3,1,U.S. House,NON,Write-in,0
@@ -16739,7 +16739,7 @@ Saunders,Ashland ward 1 14,1,U.S. House,NON,Write-in,3
 Saunders,Ashland ward 2 15,1,U.S. House,NON,Write-in,3
 Saunders,Ashland rural 16,1,U.S. House,NON,Write-in,1
 Saunders,Yutan 17,1,U.S. House,NON,Write-in,4
-Saunders,Provisional ballots ,1,U.S. House,NON,Write-in,0
+Saunders,Provisional ballots,1,U.S. House,NON,Write-in,0
 Scotts Bluff,Absentee/Early Vote,,President,Democratic,Hillary Clinton,956
 Scotts Bluff,Castle Rock A,,President,Democratic,Hillary Clinton,15
 Scotts Bluff,Castle Rock B,,President,Democratic,Hillary Clinton,12
@@ -18142,8 +18142,8 @@ Wheeler,Bartlett,,Ewing School Board,NON,Ed Nordby,16
 Wheeler,Ericson,,Ewing School Board,NON,Ed Nordby,0
 Wheeler,Bartlett,,Ewing School Board,NON,Write-in,0
 Wheeler,Ericson,,Ewing School Board,NON,Write-in,0
-Wheeler,Bartlett,4-year term,Chambers School Board,NON,Lenone F. Koenig ,1
-Wheeler,Ericson,4-year term,Chambers School Board,NON,Lenone F. Koenig ,0
+Wheeler,Bartlett,4-year term,Chambers School Board,NON,Lenone F. Koenig,1
+Wheeler,Ericson,4-year term,Chambers School Board,NON,Lenone F. Koenig,0
 Wheeler,Bartlett,4-year term,Chambers School Board,NON,Brian McManigal,1
 Wheeler,Ericson,4-year term,Chambers School Board,NON,Brian McManigal,0
 Wheeler,Bartlett,4-year term,Chambers School Board,NON,Write-in,0
@@ -18152,18 +18152,18 @@ Wheeler,Bartlett,2-year term,Chambers School Board,NON,Matt Ehlers,1
 Wheeler,Ericson,2-year term,Chambers School Board,NON,Matt Ehlers,0
 Wheeler,Bartlett,2-year term,Chambers School Board,NON,Write-in,0
 Wheeler,Ericson,2-year term,Chambers School Board,NON,Write-in,0
-Wheeler,Bartlett,,Bartlett Village Board,NON,Letti Nichols ,58
-Wheeler,Ericson,,Bartlett Village Board,NON,Letti Nichols ,0
-Wheeler,Bartlett,,Bartlett Village Board,NON,Paul Nordhues ,63
-Wheeler,Ericson,,Bartlett Village Board,NON,Paul Nordhues ,0
+Wheeler,Bartlett,,Bartlett Village Board,NON,Letti Nichols,58
+Wheeler,Ericson,,Bartlett Village Board,NON,Letti Nichols,0
+Wheeler,Bartlett,,Bartlett Village Board,NON,Paul Nordhues,63
+Wheeler,Ericson,,Bartlett Village Board,NON,Paul Nordhues,0
 Wheeler,Bartlett,,Bartlett Village Board,NON,Write-in,0
 Wheeler,Ericson,,Bartlett Village Board,NON,Write-in,0
-Wheeler,Bartlett,,Ericson Village Board,NON,Duane Waddle ,0
-Wheeler,Ericson,,Ericson Village Board,NON,Duane Waddle ,31
-Wheeler,Bartlett,,Ericson Village Board,NON,Jerry B. Horwart ,0
-Wheeler,Ericson,,Ericson Village Board,NON,Jerry B. Horwart ,30
-Wheeler,Bartlett,,Ericson Village Board,NON,William Curry ,0
-Wheeler,Ericson,,Ericson Village Board,NON,William Curry ,49
+Wheeler,Bartlett,,Ericson Village Board,NON,Duane Waddle,0
+Wheeler,Ericson,,Ericson Village Board,NON,Duane Waddle,31
+Wheeler,Bartlett,,Ericson Village Board,NON,Jerry B. Horwart,0
+Wheeler,Ericson,,Ericson Village Board,NON,Jerry B. Horwart,30
+Wheeler,Bartlett,,Ericson Village Board,NON,William Curry,0
+Wheeler,Ericson,,Ericson Village Board,NON,William Curry,49
 Wheeler,Bartlett,,Ericson Village Board,NON,Write-in,0
 Wheeler,Ericson,,Ericson Village Board,NON,Write-in,5
 York,Absentee/Early Vote,,President,Democratic,Hillary Clinton,333

--- a/2016/counties/20161108__ne__general__dodge__precinct.csv
+++ b/2016/counties/20161108__ne__general__dodge__precinct.csv
@@ -1,386 +1,386 @@
-"","county","precinct","district","office","party","candidate","votes"
-"1","Dodge","Fremont - 1A ",NA,"President","REP","Donald J. Trump",359
-"2","Dodge","Fremont - 1B ",NA,"President","REP","Donald J. Trump",286
-"3","Dodge","Fremont - 1C ",NA,"President","REP","Donald J. Trump",457
-"4","Dodge","Fremont - 1D ",NA,"President","REP","Donald J. Trump",192
-"5","Dodge","Fremont - 1E ",NA,"President","REP","Donald J. Trump",326
-"6","Dodge","Fremont - 2A ",NA,"President","REP","Donald J. Trump",233
-"7","Dodge","Fremont - 2B ",NA,"President","REP","Donald J. Trump",210
-"8","Dodge","Fremont - 2C ",NA,"President","REP","Donald J. Trump",471
-"9","Dodge","Fremont - 2D ",NA,"President","REP","Donald J. Trump",166
-"10","Dodge","Fremont - 2E ",NA,"President","REP","Donald J. Trump",306
-"11","Dodge","Fremont - 3A ",NA,"President","REP","Donald J. Trump",156
-"12","Dodge","Fremont - 3B ",NA,"President","REP","Donald J. Trump",82
-"13","Dodge","Fremont - 3C ",NA,"President","REP","Donald J. Trump",171
-"14","Dodge","Fremont - 3D ",NA,"President","REP","Donald J. Trump",263
-"15","Dodge","Fremont - 3E ",NA,"President","REP","Donald J. Trump",227
-"16","Dodge","Fremont - 4A ",NA,"President","REP","Donald J. Trump",300
-"17","Dodge","Fremont - 4B ",NA,"President","REP","Donald J. Trump",196
-"18","Dodge","Fremont - 4C ",NA,"President","REP","Donald J. Trump",414
-"19","Dodge","Fremont - 4D ",NA,"President","REP","Donald J. Trump",455
-"20","Dodge","Fremont - 4E ",NA,"President","REP","Donald J. Trump",163
-"21","Dodge","City of North Bend ",NA,"President","REP","Donald J. Trump",327
-"22","Dodge","City of Scribner ",NA,"President","REP","Donald J. Trump",299
-"23","Dodge","CU/EV ",NA,"President","REP","Donald J. Trump",171
-"24","Dodge","Webster Township ",NA,"President","REP","Donald J. Trump",298
-"25","Dodge","Pebble Township ",NA,"President","REP","Donald J. Trump",166
-"26","Dodge","Platte East ",NA,"President","REP","Donald J. Trump",149
-"27","Dodge","Platte West ",NA,"President","REP","Donald J. Trump",371
-"28","Dodge","Nickerson Township ",NA,"President","REP","Donald J. Trump",292
-"29","Dodge","City of Hooper ",NA,"President","REP","Donald J. Trump",238
-"30","Dodge","HW/LG ",NA,"President","REP","Donald J. Trump",294
-"31","Dodge","Elkhorn Township ",NA,"President","REP","Donald J. Trump",124
-"32","Dodge","CT/UN ",NA,"President","REP","Donald J. Trump",360
-"33","Dodge","New/Former Resident ",NA,"President","REP","Donald J. Trump",0
-"34","Dodge","ABSENTEE ",NA,"President","REP","Donald J. Trump",1411
-"35","Dodge","TOTALS ",NA,"President","REP","Donald J. Trump",9933
-"36","Dodge","Fremont - 1A ",NA,"President","DEM","Hillary Clinton",167
-"37","Dodge","Fremont - 1B ",NA,"President","DEM","Hillary Clinton",156
-"38","Dodge","Fremont - 1C ",NA,"President","DEM","Hillary Clinton",181
-"39","Dodge","Fremont - 1D ",NA,"President","DEM","Hillary Clinton",75
-"40","Dodge","Fremont - 1E ",NA,"President","DEM","Hillary Clinton",182
-"41","Dodge","Fremont - 2A ",NA,"President","DEM","Hillary Clinton",121
-"42","Dodge","Fremont - 2B ",NA,"President","DEM","Hillary Clinton",98
-"43","Dodge","Fremont - 2C ",NA,"President","DEM","Hillary Clinton",180
-"44","Dodge","Fremont - 2D ",NA,"President","DEM","Hillary Clinton",63
-"45","Dodge","Fremont - 2E ",NA,"President","DEM","Hillary Clinton",115
-"46","Dodge","Fremont - 3A ",NA,"President","DEM","Hillary Clinton",87
-"47","Dodge","Fremont - 3B ",NA,"President","DEM","Hillary Clinton",59
-"48","Dodge","Fremont - 3C ",NA,"President","DEM","Hillary Clinton",99
-"49","Dodge","Fremont - 3D ",NA,"President","DEM","Hillary Clinton",154
-"50","Dodge","Fremont - 3E ",NA,"President","DEM","Hillary Clinton",113
-"51","Dodge","Fremont - 4A ",NA,"President","DEM","Hillary Clinton",127
-"52","Dodge","Fremont - 4B ",NA,"President","DEM","Hillary Clinton",93
-"53","Dodge","Fremont - 4C ",NA,"President","DEM","Hillary Clinton",201
-"54","Dodge","Fremont - 4D ",NA,"President","DEM","Hillary Clinton",192
-"55","Dodge","Fremont - 4E ",NA,"President","DEM","Hillary Clinton",75
-"56","Dodge","City of North Bend ",NA,"President","DEM","Hillary Clinton",108
-"57","Dodge","City of Scribner ",NA,"President","DEM","Hillary Clinton",58
-"58","Dodge","CU/EV ",NA,"President","DEM","Hillary Clinton",37
-"59","Dodge","Webster Township ",NA,"President","DEM","Hillary Clinton",64
-"60","Dodge","Pebble Township ",NA,"President","DEM","Hillary Clinton",23
-"61","Dodge","Platte East ",NA,"President","DEM","Hillary Clinton",59
-"62","Dodge","Platte West ",NA,"President","DEM","Hillary Clinton",100
-"63","Dodge","Nickerson Township ",NA,"President","DEM","Hillary Clinton",93
-"64","Dodge","City of Hooper ",NA,"President","DEM","Hillary Clinton",89
-"65","Dodge","HW/LG ",NA,"President","DEM","Hillary Clinton",55
-"66","Dodge","Elkhorn Township ",NA,"President","DEM","Hillary Clinton",36
-"67","Dodge","CT/UN ",NA,"President","DEM","Hillary Clinton",71
-"68","Dodge","New/Former Resident ",NA,"President","DEM","Hillary Clinton",0
-"69","Dodge","ABSENTEE ",NA,"President","DEM","Hillary Clinton",1213
-"70","Dodge","TOTALS ",NA,"President","DEM","Hillary Clinton",4544
-"71","Dodge","Fremont - 1A ",NA,"President","LIB","Gary Johnson",26
-"72","Dodge","Fremont - 1B ",NA,"President","LIB","Gary Johnson",32
-"73","Dodge","Fremont - 1C ",NA,"President","LIB","Gary Johnson",18
-"74","Dodge","Fremont - 1D ",NA,"President","LIB","Gary Johnson",8
-"75","Dodge","Fremont - 1E ",NA,"President","LIB","Gary Johnson",10
-"76","Dodge","Fremont - 2A ",NA,"President","LIB","Gary Johnson",14
-"77","Dodge","Fremont - 2B ",NA,"President","LIB","Gary Johnson",17
-"78","Dodge","Fremont - 2C ",NA,"President","LIB","Gary Johnson",38
-"79","Dodge","Fremont - 2D ",NA,"President","LIB","Gary Johnson",12
-"80","Dodge","Fremont - 2E ",NA,"President","LIB","Gary Johnson",18
-"81","Dodge","Fremont - 3A ",NA,"President","LIB","Gary Johnson",18
-"82","Dodge","Fremont - 3B ",NA,"President","LIB","Gary Johnson",7
-"83","Dodge","Fremont - 3C ",NA,"President","LIB","Gary Johnson",15
-"84","Dodge","Fremont - 3D ",NA,"President","LIB","Gary Johnson",15
-"85","Dodge","Fremont - 3E ",NA,"President","LIB","Gary Johnson",17
-"86","Dodge","Fremont - 4A ",NA,"President","LIB","Gary Johnson",30
-"87","Dodge","Fremont - 4B ",NA,"President","LIB","Gary Johnson",15
-"88","Dodge","Fremont - 4C ",NA,"President","LIB","Gary Johnson",30
-"89","Dodge","Fremont - 4D ",NA,"President","LIB","Gary Johnson",27
-"90","Dodge","Fremont - 4E ",NA,"President","LIB","Gary Johnson",14
-"91","Dodge","City of North Bend ",NA,"President","LIB","Gary Johnson",24
-"92","Dodge","City of Scribner ",NA,"President","LIB","Gary Johnson",16
-"93","Dodge","CU/EV ",NA,"President","LIB","Gary Johnson",10
-"94","Dodge","Webster Township ",NA,"President","LIB","Gary Johnson",6
-"95","Dodge","Pebble Township ",NA,"President","LIB","Gary Johnson",12
-"96","Dodge","Platte East ",NA,"President","LIB","Gary Johnson",6
-"97","Dodge","Platte West ",NA,"President","LIB","Gary Johnson",12
-"98","Dodge","Nickerson Township ",NA,"President","LIB","Gary Johnson",15
-"99","Dodge","City of Hooper ",NA,"President","LIB","Gary Johnson",15
-"100","Dodge","HW/LG ",NA,"President","LIB","Gary Johnson",19
-"101","Dodge","Elkhorn Township ",NA,"President","LIB","Gary Johnson",7
-"102","Dodge","CT/UN ",NA,"President","LIB","Gary Johnson",17
-"103","Dodge","New/Former Resident ",NA,"President","LIB","Gary Johnson",0
-"104","Dodge","ABSENTEE ",NA,"President","LIB","Gary Johnson",84
-"105","Dodge","TOTALS ",NA,"President","LIB","Gary Johnson",624
-"106","Dodge","Fremont - 1A ",NA,"President","","Jill Stein",7
-"107","Dodge","Fremont - 1B ",NA,"President","","Jill Stein",2
-"108","Dodge","Fremont - 1C ",NA,"President","","Jill Stein",3
-"109","Dodge","Fremont - 1D ",NA,"President","","Jill Stein",6
-"110","Dodge","Fremont - 1E ",NA,"President","","Jill Stein",5
-"111","Dodge","Fremont - 2A ",NA,"President","","Jill Stein",11
-"112","Dodge","Fremont - 2B ",NA,"President","","Jill Stein",2
-"113","Dodge","Fremont - 2C ",NA,"President","","Jill Stein",5
-"114","Dodge","Fremont - 2D ",NA,"President","","Jill Stein",3
-"115","Dodge","Fremont - 2E ",NA,"President","","Jill Stein",5
-"116","Dodge","Fremont - 3A ",NA,"President","","Jill Stein",2
-"117","Dodge","Fremont - 3B ",NA,"President","","Jill Stein",3
-"118","Dodge","Fremont - 3C ",NA,"President","","Jill Stein",7
-"119","Dodge","Fremont - 3D ",NA,"President","","Jill Stein",6
-"120","Dodge","Fremont - 3E ",NA,"President","","Jill Stein",8
-"121","Dodge","Fremont - 4A ",NA,"President","","Jill Stein",6
-"122","Dodge","Fremont - 4B ",NA,"President","","Jill Stein",7
-"123","Dodge","Fremont - 4C ",NA,"President","","Jill Stein",4
-"124","Dodge","Fremont - 4D ",NA,"President","","Jill Stein",3
-"125","Dodge","Fremont - 4E ",NA,"President","","Jill Stein",3
-"126","Dodge","City of North Bend ",NA,"President","","Jill Stein",4
-"127","Dodge","City of Scribner ",NA,"President","","Jill Stein",3
-"128","Dodge","CU/EV ",NA,"President","","Jill Stein",3
-"129","Dodge","Webster Township ",NA,"President","","Jill Stein",0
-"130","Dodge","Pebble Township ",NA,"President","","Jill Stein",2
-"131","Dodge","Platte East ",NA,"President","","Jill Stein",1
-"132","Dodge","Platte West ",NA,"President","","Jill Stein",4
-"133","Dodge","Nickerson Township ",NA,"President","","Jill Stein",5
-"134","Dodge","City of Hooper ",NA,"President","","Jill Stein",2
-"135","Dodge","HW/LG ",NA,"President","","Jill Stein",6
-"136","Dodge","Elkhorn Township ",NA,"President","","Jill Stein",0
-"137","Dodge","CT/UN ",NA,"President","","Jill Stein",2
-"138","Dodge","New/Former Resident ",NA,"President","","Jill Stein",0
-"139","Dodge","ABSENTEE ",NA,"President","","Jill Stein",32
-"140","Dodge","TOTALS ",NA,"President","","Jill Stein",162
-"141","Dodge","Fremont - 1A ",NA,"President","","Write-ins",11
-"142","Dodge","Fremont - 1B ",NA,"President","","Write-ins",9
-"143","Dodge","Fremont - 1C ",NA,"President","","Write-ins",20
-"144","Dodge","Fremont - 1D ",NA,"President","","Write-ins",5
-"145","Dodge","Fremont - 1E ",NA,"President","","Write-ins",14
-"146","Dodge","Fremont - 2A ",NA,"President","","Write-ins",5
-"147","Dodge","Fremont - 2B ",NA,"President","","Write-ins",9
-"148","Dodge","Fremont - 2C ",NA,"President","","Write-ins",7
-"149","Dodge","Fremont - 2D ",NA,"President","","Write-ins",6
-"150","Dodge","Fremont - 2E ",NA,"President","","Write-ins",7
-"151","Dodge","Fremont - 3A ",NA,"President","","Write-ins",12
-"152","Dodge","Fremont - 3B ",NA,"President","","Write-ins",1
-"153","Dodge","Fremont - 3C ",NA,"President","","Write-ins",3
-"154","Dodge","Fremont - 3D ",NA,"President","","Write-ins",6
-"155","Dodge","Fremont - 3E ",NA,"President","","Write-ins",8
-"156","Dodge","Fremont - 4A ",NA,"President","","Write-ins",5
-"157","Dodge","Fremont - 4B ",NA,"President","","Write-ins",8
-"158","Dodge","Fremont - 4C ",NA,"President","","Write-ins",13
-"159","Dodge","Fremont - 4D ",NA,"President","","Write-ins",12
-"160","Dodge","Fremont - 4E ",NA,"President","","Write-ins",6
-"161","Dodge","City of North Bend ",NA,"President","","Write-ins",10
-"162","Dodge","City of Scribner ",NA,"President","","Write-ins",6
-"163","Dodge","CU/EV ",NA,"President","","Write-ins",2
-"164","Dodge","Webster Township ",NA,"President","","Write-ins",2
-"165","Dodge","Pebble Township ",NA,"President","","Write-ins",3
-"166","Dodge","Platte East ",NA,"President","","Write-ins",4
-"167","Dodge","Platte West ",NA,"President","","Write-ins",12
-"168","Dodge","Nickerson Township ",NA,"President","","Write-ins",2
-"169","Dodge","City of Hooper ",NA,"President","","Write-ins",2
-"170","Dodge","HW/LG ",NA,"President","","Write-ins",3
-"171","Dodge","Elkhorn Township ",NA,"President","","Write-ins",0
-"172","Dodge","CT/UN ",NA,"President","","Write-ins",8
-"173","Dodge","New/Former Resident ",NA,"President","","Write-ins",0
-"174","Dodge","ABSENTEE ",NA,"President","","Write-ins",45
-"175","Dodge","TOTALS ",NA,"President","","Write-ins",266
-"176","Dodge","Fremont - 1A ",1,"U.S. House","REP","Jeff Fortenberry",425
-"177","Dodge","Fremont - 1B ",1,"U.S. House","REP","Jeff Fortenberry",357
-"178","Dodge","Fremont - 1C ",1,"U.S. House","REP","Jeff Fortenberry",546
-"179","Dodge","Fremont - 1D ",1,"U.S. House","REP","Jeff Fortenberry",218
-"180","Dodge","Fremont - 1E ",1,"U.S. House","REP","Jeff Fortenberry",412
-"181","Dodge","Fremont - 2A ",1,"U.S. House","REP","Jeff Fortenberry",276
-"182","Dodge","Fremont - 2B ",1,"U.S. House","REP","Jeff Fortenberry",255
-"183","Dodge","Fremont - 2C ",1,"U.S. House","REP","Jeff Fortenberry",539
-"184","Dodge","Fremont - 2D ",1,"U.S. House","REP","Jeff Fortenberry",182
-"185","Dodge","Fremont - 2E ",1,"U.S. House","REP","Jeff Fortenberry",350
-"186","Dodge","Fremont - 3A ",1,"U.S. House","REP","Jeff Fortenberry",192
-"187","Dodge","Fremont - 3B ",1,"U.S. House","REP","Jeff Fortenberry",88
-"188","Dodge","Fremont - 3C ",1,"U.S. House","REP","Jeff Fortenberry",191
-"189","Dodge","Fremont - 3D ",1,"U.S. House","REP","Jeff Fortenberry",324
-"190","Dodge","Fremont - 3E ",1,"U.S. House","REP","Jeff Fortenberry",270
-"191","Dodge","Fremont - 4A ",1,"U.S. House","REP","Jeff Fortenberry",356
-"192","Dodge","Fremont - 4B ",1,"U.S. House","REP","Jeff Fortenberry",221
-"193","Dodge","Fremont - 4C ",1,"U.S. House","REP","Jeff Fortenberry",495
-"194","Dodge","Fremont - 4D ",1,"U.S. House","REP","Jeff Fortenberry",561
-"195","Dodge","Fremont - 4E ",1,"U.S. House","REP","Jeff Fortenberry",184
-"196","Dodge","City of North Bend ",1,"U.S. House","REP","Jeff Fortenberry",376
-"197","Dodge","City of Scribner ",1,"U.S. House","REP","Jeff Fortenberry",330
-"198","Dodge","CU/EV ",1,"U.S. House","REP","Jeff Fortenberry",186
-"199","Dodge","Webster Township ",1,"U.S. House","REP","Jeff Fortenberry",289
-"200","Dodge","Pebble Township ",1,"U.S. House","REP","Jeff Fortenberry",178
-"201","Dodge","Platte East ",1,"U.S. House","REP","Jeff Fortenberry",158
-"202","Dodge","Platte West ",1,"U.S. House","REP","Jeff Fortenberry",394
-"203","Dodge","Nickerson Township ",1,"U.S. House","REP","Jeff Fortenberry",314
-"204","Dodge","City of Hooper ",1,"U.S. House","REP","Jeff Fortenberry",271
-"205","Dodge","HW/LG ",1,"U.S. House","REP","Jeff Fortenberry",320
-"206","Dodge","Elkhorn Township ",1,"U.S. House","REP","Jeff Fortenberry",130
-"207","Dodge","CT/UN ",1,"U.S. House","REP","Jeff Fortenberry",380
-"208","Dodge","New/Former Resident ",1,"U.S. House","REP","Jeff Fortenberry",NA
-"209","Dodge","ABSENTEE ",1,"U.S. House","REP","Jeff Fortenberry",1713
-"210","Dodge","TOTALS ",1,"U.S. House","REP","Jeff Fortenberry",11481
-"211","Dodge","Fremont - 1A ",1,"U.S. House","DEM","Daniel M. Wik",115
-"212","Dodge","Fremont - 1B ",1,"U.S. House","DEM","Daniel M. Wik",112
-"213","Dodge","Fremont - 1C ",1,"U.S. House","DEM","Daniel M. Wik",117
-"214","Dodge","Fremont - 1D ",1,"U.S. House","DEM","Daniel M. Wik",52
-"215","Dodge","Fremont - 1E ",1,"U.S. House","DEM","Daniel M. Wik",114
-"216","Dodge","Fremont - 2A ",1,"U.S. House","DEM","Daniel M. Wik",99
-"217","Dodge","Fremont - 2B ",1,"U.S. House","DEM","Daniel M. Wik",76
-"218","Dodge","Fremont - 2C ",1,"U.S. House","DEM","Daniel M. Wik",134
-"219","Dodge","Fremont - 2D ",1,"U.S. House","DEM","Daniel M. Wik",52
-"220","Dodge","Fremont - 2E ",1,"U.S. House","DEM","Daniel M. Wik",89
-"221","Dodge","Fremont - 3A ",1,"U.S. House","DEM","Daniel M. Wik",69
-"222","Dodge","Fremont - 3B ",1,"U.S. House","DEM","Daniel M. Wik",59
-"223","Dodge","Fremont - 3C ",1,"U.S. House","DEM","Daniel M. Wik",94
-"224","Dodge","Fremont - 3D ",1,"U.S. House","DEM","Daniel M. Wik",111
-"225","Dodge","Fremont - 3E ",1,"U.S. House","DEM","Daniel M. Wik",93
-"226","Dodge","Fremont - 4A ",1,"U.S. House","DEM","Daniel M. Wik",100
-"227","Dodge","Fremont - 4B ",1,"U.S. House","DEM","Daniel M. Wik",81
-"228","Dodge","Fremont - 4C ",1,"U.S. House","DEM","Daniel M. Wik",139
-"229","Dodge","Fremont - 4D ",1,"U.S. House","DEM","Daniel M. Wik",111
-"230","Dodge","Fremont - 4E ",1,"U.S. House","DEM","Daniel M. Wik",64
-"231","Dodge","City of North Bend ",1,"U.S. House","DEM","Daniel M. Wik",78
-"232","Dodge","City of Scribner ",1,"U.S. House","DEM","Daniel M. Wik",43
-"233","Dodge","CU/EV ",1,"U.S. House","DEM","Daniel M. Wik",25
-"234","Dodge","Webster Township ",1,"U.S. House","DEM","Daniel M. Wik",60
-"235","Dodge","Pebble Township ",1,"U.S. House","DEM","Daniel M. Wik",20
-"236","Dodge","Platte East ",1,"U.S. House","DEM","Daniel M. Wik",50
-"237","Dodge","Platte West ",1,"U.S. House","DEM","Daniel M. Wik",87
-"238","Dodge","Nickerson Township ",1,"U.S. House","DEM","Daniel M. Wik",81
-"239","Dodge","City of Hooper ",1,"U.S. House","DEM","Daniel M. Wik",69
-"240","Dodge","HW/LG ",1,"U.S. House","DEM","Daniel M. Wik",42
-"241","Dodge","Elkhorn Township ",1,"U.S. House","DEM","Daniel M. Wik",30
-"242","Dodge","CT/UN ",1,"U.S. House","DEM","Daniel M. Wik",63
-"243","Dodge","New/Former Resident ",1,"U.S. House","DEM","Daniel M. Wik",NA
-"244","Dodge","ABSENTEE ",1,"U.S. House","DEM","Daniel M. Wik",959
-"245","Dodge","TOTALS ",1,"U.S. House","DEM","Daniel M. Wik",3488
-"246","Dodge","Fremont - 1A ",1,"U.S. House","","Write-ins",0
-"247","Dodge","Fremont - 1B ",1,"U.S. House","","Write-ins",0
-"248","Dodge","Fremont - 1C ",1,"U.S. House","","Write-ins",2
-"249","Dodge","Fremont - 1D ",1,"U.S. House","","Write-ins",1
-"250","Dodge","Fremont - 1E ",1,"U.S. House","","Write-ins",2
-"251","Dodge","Fremont - 2A ",1,"U.S. House","","Write-ins",0
-"252","Dodge","Fremont - 2B ",1,"U.S. House","","Write-ins",0
-"253","Dodge","Fremont - 2C ",1,"U.S. House","","Write-ins",4
-"254","Dodge","Fremont - 2D ",1,"U.S. House","","Write-ins",1
-"255","Dodge","Fremont - 2E ",1,"U.S. House","","Write-ins",3
-"256","Dodge","Fremont - 3A ",1,"U.S. House","","Write-ins",0
-"257","Dodge","Fremont - 3B ",1,"U.S. House","","Write-ins",1
-"258","Dodge","Fremont - 3C ",1,"U.S. House","","Write-ins",0
-"259","Dodge","Fremont - 3D ",1,"U.S. House","","Write-ins",1
-"260","Dodge","Fremont - 3E ",1,"U.S. House","","Write-ins",0
-"261","Dodge","Fremont - 4A ",1,"U.S. House","","Write-ins",3
-"262","Dodge","Fremont - 4B ",1,"U.S. House","","Write-ins",1
-"263","Dodge","Fremont - 4C ",1,"U.S. House","","Write-ins",1
-"264","Dodge","Fremont - 4D ",1,"U.S. House","","Write-ins",1
-"265","Dodge","Fremont - 4E ",1,"U.S. House","","Write-ins",0
-"266","Dodge","City of North Bend ",1,"U.S. House","","Write-ins",0
-"267","Dodge","City of Scribner ",1,"U.S. House","","Write-ins",0
-"268","Dodge","CU/EV ",1,"U.S. House","","Write-ins",0
-"269","Dodge","Webster Township ",1,"U.S. House","","Write-ins",1
-"270","Dodge","Pebble Township ",1,"U.S. House","","Write-ins",1
-"271","Dodge","Platte East ",1,"U.S. House","","Write-ins",0
-"272","Dodge","Platte West ",1,"U.S. House","","Write-ins",3
-"273","Dodge","Nickerson Township ",1,"U.S. House","","Write-ins",0
-"274","Dodge","City of Hooper ",1,"U.S. House","","Write-ins",1
-"275","Dodge","HW/LG ",1,"U.S. House","","Write-ins",1
-"276","Dodge","Elkhorn Township ",1,"U.S. House","","Write-ins",0
-"277","Dodge","CT/UN ",1,"U.S. House","","Write-ins",0
-"278","Dodge","New/Former Resident ",1,"U.S. House","","Write-ins",NA
-"279","Dodge","ABSENTEE ",1,"U.S. House","","Write-ins",6
-"280","Dodge","TOTALS ",1,"U.S. House","","Write-ins",34
-"281","Dodge","Fremont - 1A ",15,"State Legislature","","David A. Schnoor",269
-"282","Dodge","Fremont - 1B ",15,"State Legislature","","David A. Schnoor",178
-"283","Dodge","Fremont - 1C ",15,"State Legislature","","David A. Schnoor",347
-"284","Dodge","Fremont - 1D ",15,"State Legislature","","David A. Schnoor",118
-"285","Dodge","Fremont - 1E ",15,"State Legislature","","David A. Schnoor",249
-"286","Dodge","Fremont - 2A ",15,"State Legislature","","David A. Schnoor",152
-"287","Dodge","Fremont - 2B ",15,"State Legislature","","David A. Schnoor",115
-"288","Dodge","Fremont - 2C ",15,"State Legislature","","David A. Schnoor",294
-"289","Dodge","Fremont - 2D ",15,"State Legislature","","David A. Schnoor",123
-"290","Dodge","Fremont - 2E ",15,"State Legislature","","David A. Schnoor",196
-"291","Dodge","Fremont - 3A ",15,"State Legislature","","David A. Schnoor",115
-"292","Dodge","Fremont - 3B ",15,"State Legislature","","David A. Schnoor",66
-"293","Dodge","Fremont - 3C ",15,"State Legislature","","David A. Schnoor",120
-"294","Dodge","Fremont - 3D ",15,"State Legislature","","David A. Schnoor",229
-"295","Dodge","Fremont - 3E ",15,"State Legislature","","David A. Schnoor",169
-"296","Dodge","Fremont - 4A ",15,"State Legislature","","David A. Schnoor",192
-"297","Dodge","Fremont - 4B ",15,"State Legislature","","David A. Schnoor",134
-"298","Dodge","Fremont - 4C ",15,"State Legislature","","David A. Schnoor",276
-"299","Dodge","Fremont - 4D ",15,"State Legislature","","David A. Schnoor",278
-"300","Dodge","Fremont - 4E ",15,"State Legislature","","David A. Schnoor",107
-"301","Dodge","City of North Bend ",15,"State Legislature","","David A. Schnoor",258
-"302","Dodge","City of Scribner ",15,"State Legislature","","David A. Schnoor",298
-"303","Dodge","CU/EV ",15,"State Legislature","","David A. Schnoor",146
-"304","Dodge","Webster Township ",15,"State Legislature","","David A. Schnoor",201
-"305","Dodge","Pebble Township ",15,"State Legislature","","David A. Schnoor",124
-"306","Dodge","Platte East ",15,"State Legislature","","David A. Schnoor",98
-"307","Dodge","Platte West ",15,"State Legislature","","David A. Schnoor",237
-"308","Dodge","Nickerson Township ",15,"State Legislature","","David A. Schnoor",193
-"309","Dodge","City of Hooper ",15,"State Legislature","","David A. Schnoor",199
-"310","Dodge","HW/LG ",15,"State Legislature","","David A. Schnoor",215
-"311","Dodge","Elkhorn Township ",15,"State Legislature","","David A. Schnoor",73
-"312","Dodge","CT/UN ",15,"State Legislature","","David A. Schnoor",283
-"313","Dodge","New/Former Resident ",15,"State Legislature","","David A. Schnoor",NA
-"314","Dodge","ABSENTEE ",15,"State Legislature","","David A. Schnoor",1137
-"315","Dodge","TOTALS ",15,"State Legislature","","David A. Schnoor",7189
-"316","Dodge","Fremont - 1A ",15,"State Legislature","","Lynne M. Walz",273
-"317","Dodge","Fremont - 1B ",15,"State Legislature","","Lynne M. Walz",290
-"318","Dodge","Fremont - 1C ",15,"State Legislature","","Lynne M. Walz",319
-"319","Dodge","Fremont - 1D ",15,"State Legislature","","Lynne M. Walz",154
-"320","Dodge","Fremont - 1E ",15,"State Legislature","","Lynne M. Walz",286
-"321","Dodge","Fremont - 2A ",15,"State Legislature","","Lynne M. Walz",220
-"322","Dodge","Fremont - 2B ",15,"State Legislature","","Lynne M. Walz",206
-"323","Dodge","Fremont - 2C ",15,"State Legislature","","Lynne M. Walz",382
-"324","Dodge","Fremont - 2D ",15,"State Legislature","","Lynne M. Walz",110
-"325","Dodge","Fremont - 2E ",15,"State Legislature","","Lynne M. Walz",236
-"326","Dodge","Fremont - 3A ",15,"State Legislature","","Lynne M. Walz",145
-"327","Dodge","Fremont - 3B ",15,"State Legislature","","Lynne M. Walz",73
-"328","Dodge","Fremont - 3C ",15,"State Legislature","","Lynne M. Walz",157
-"329","Dodge","Fremont - 3D ",15,"State Legislature","","Lynne M. Walz",200
-"330","Dodge","Fremont - 3E ",15,"State Legislature","","Lynne M. Walz",186
-"331","Dodge","Fremont - 4A ",15,"State Legislature","","Lynne M. Walz",262
-"332","Dodge","Fremont - 4B ",15,"State Legislature","","Lynne M. Walz",175
-"333","Dodge","Fremont - 4C ",15,"State Legislature","","Lynne M. Walz",349
-"334","Dodge","Fremont - 4D ",15,"State Legislature","","Lynne M. Walz",396
-"335","Dodge","Fremont - 4E ",15,"State Legislature","","Lynne M. Walz",135
-"336","Dodge","City of North Bend ",15,"State Legislature","","Lynne M. Walz",188
-"337","Dodge","City of Scribner ",15,"State Legislature","","Lynne M. Walz",88
-"338","Dodge","CU/EV ",15,"State Legislature","","Lynne M. Walz",69
-"339","Dodge","Webster Township ",15,"State Legislature","","Lynne M. Walz",156
-"340","Dodge","Pebble Township ",15,"State Legislature","","Lynne M. Walz",77
-"341","Dodge","Platte East ",15,"State Legislature","","Lynne M. Walz",104
-"342","Dodge","Platte West ",15,"State Legislature","","Lynne M. Walz",227
-"343","Dodge","Nickerson Township ",15,"State Legislature","","Lynne M. Walz",189
-"344","Dodge","City of Hooper ",15,"State Legislature","","Lynne M. Walz",140
-"345","Dodge","HW/LG ",15,"State Legislature","","Lynne M. Walz",137
-"346","Dodge","Elkhorn Township ",15,"State Legislature","","Lynne M. Walz",83
-"347","Dodge","CT/UN ",15,"State Legislature","","Lynne M. Walz",148
-"348","Dodge","New/Former Resident ",15,"State Legislature","","Lynne M. Walz",NA
-"349","Dodge","ABSENTEE ",15,"State Legislature","","Lynne M. Walz",1441
-"350","Dodge","TOTALS ",15,"State Legislature","","Lynne M. Walz",7601
-"351","Dodge","Fremont - 1A ",15,"State Legislature","","Write-ins",0
-"352","Dodge","Fremont - 1B ",15,"State Legislature","","Write-ins",1
-"353","Dodge","Fremont - 1C ",15,"State Legislature","","Write-ins",1
-"354","Dodge","Fremont - 1D ",15,"State Legislature","","Write-ins",0
-"355","Dodge","Fremont - 1E ",15,"State Legislature","","Write-ins",1
-"356","Dodge","Fremont - 2A ",15,"State Legislature","","Write-ins",0
-"357","Dodge","Fremont - 2B ",15,"State Legislature","","Write-ins",2
-"358","Dodge","Fremont - 2C ",15,"State Legislature","","Write-ins",2
-"359","Dodge","Fremont - 2D ",15,"State Legislature","","Write-ins",1
-"360","Dodge","Fremont - 2E ",15,"State Legislature","","Write-ins",2
-"361","Dodge","Fremont - 3A ",15,"State Legislature","","Write-ins",1
-"362","Dodge","Fremont - 3B ",15,"State Legislature","","Write-ins",2
-"363","Dodge","Fremont - 3C ",15,"State Legislature","","Write-ins",0
-"364","Dodge","Fremont - 3D ",15,"State Legislature","","Write-ins",2
-"365","Dodge","Fremont - 3E ",15,"State Legislature","","Write-ins",0
-"366","Dodge","Fremont - 4A ",15,"State Legislature","","Write-ins",1
-"367","Dodge","Fremont - 4B ",15,"State Legislature","","Write-ins",0
-"368","Dodge","Fremont - 4C ",15,"State Legislature","","Write-ins",3
-"369","Dodge","Fremont - 4D ",15,"State Legislature","","Write-ins",0
-"370","Dodge","Fremont - 4E ",15,"State Legislature","","Write-ins",0
-"371","Dodge","City of North Bend ",15,"State Legislature","","Write-ins",1
-"372","Dodge","City of Scribner ",15,"State Legislature","","Write-ins",0
-"373","Dodge","CU/EV ",15,"State Legislature","","Write-ins",0
-"374","Dodge","Webster Township ",15,"State Legislature","","Write-ins",0
-"375","Dodge","Pebble Township ",15,"State Legislature","","Write-ins",0
-"376","Dodge","Platte East ",15,"State Legislature","","Write-ins",0
-"377","Dodge","Platte West ",15,"State Legislature","","Write-ins",2
-"378","Dodge","Nickerson Township ",15,"State Legislature","","Write-ins",0
-"379","Dodge","City of Hooper ",15,"State Legislature","","Write-ins",0
-"380","Dodge","HW/LG ",15,"State Legislature","","Write-ins",1
-"381","Dodge","Elkhorn Township ",15,"State Legislature","","Write-ins",0
-"382","Dodge","CT/UN ",15,"State Legislature","","Write-ins",1
-"383","Dodge","New/Former Resident ",15,"State Legislature","","Write-ins",NA
-"384","Dodge","ABSENTEE ",15,"State Legislature","","Write-ins",8
-"385","Dodge","TOTALS ",15,"State Legislature","","Write-ins",32
+,county,precinct,district,office,party,candidate,votes
+1,Dodge,Fremont - 1A,NA,President,REP,Donald J. Trump,359
+2,Dodge,Fremont - 1B,NA,President,REP,Donald J. Trump,286
+3,Dodge,Fremont - 1C,NA,President,REP,Donald J. Trump,457
+4,Dodge,Fremont - 1D,NA,President,REP,Donald J. Trump,192
+5,Dodge,Fremont - 1E,NA,President,REP,Donald J. Trump,326
+6,Dodge,Fremont - 2A,NA,President,REP,Donald J. Trump,233
+7,Dodge,Fremont - 2B,NA,President,REP,Donald J. Trump,210
+8,Dodge,Fremont - 2C,NA,President,REP,Donald J. Trump,471
+9,Dodge,Fremont - 2D,NA,President,REP,Donald J. Trump,166
+10,Dodge,Fremont - 2E,NA,President,REP,Donald J. Trump,306
+11,Dodge,Fremont - 3A,NA,President,REP,Donald J. Trump,156
+12,Dodge,Fremont - 3B,NA,President,REP,Donald J. Trump,82
+13,Dodge,Fremont - 3C,NA,President,REP,Donald J. Trump,171
+14,Dodge,Fremont - 3D,NA,President,REP,Donald J. Trump,263
+15,Dodge,Fremont - 3E,NA,President,REP,Donald J. Trump,227
+16,Dodge,Fremont - 4A,NA,President,REP,Donald J. Trump,300
+17,Dodge,Fremont - 4B,NA,President,REP,Donald J. Trump,196
+18,Dodge,Fremont - 4C,NA,President,REP,Donald J. Trump,414
+19,Dodge,Fremont - 4D,NA,President,REP,Donald J. Trump,455
+20,Dodge,Fremont - 4E,NA,President,REP,Donald J. Trump,163
+21,Dodge,City of North Bend,NA,President,REP,Donald J. Trump,327
+22,Dodge,City of Scribner,NA,President,REP,Donald J. Trump,299
+23,Dodge,CU/EV,NA,President,REP,Donald J. Trump,171
+24,Dodge,Webster Township,NA,President,REP,Donald J. Trump,298
+25,Dodge,Pebble Township,NA,President,REP,Donald J. Trump,166
+26,Dodge,Platte East,NA,President,REP,Donald J. Trump,149
+27,Dodge,Platte West,NA,President,REP,Donald J. Trump,371
+28,Dodge,Nickerson Township,NA,President,REP,Donald J. Trump,292
+29,Dodge,City of Hooper,NA,President,REP,Donald J. Trump,238
+30,Dodge,HW/LG,NA,President,REP,Donald J. Trump,294
+31,Dodge,Elkhorn Township,NA,President,REP,Donald J. Trump,124
+32,Dodge,CT/UN,NA,President,REP,Donald J. Trump,360
+33,Dodge,New/Former Resident,NA,President,REP,Donald J. Trump,0
+34,Dodge,ABSENTEE,NA,President,REP,Donald J. Trump,1411
+35,Dodge,TOTALS,NA,President,REP,Donald J. Trump,9933
+36,Dodge,Fremont - 1A,NA,President,DEM,Hillary Clinton,167
+37,Dodge,Fremont - 1B,NA,President,DEM,Hillary Clinton,156
+38,Dodge,Fremont - 1C,NA,President,DEM,Hillary Clinton,181
+39,Dodge,Fremont - 1D,NA,President,DEM,Hillary Clinton,75
+40,Dodge,Fremont - 1E,NA,President,DEM,Hillary Clinton,182
+41,Dodge,Fremont - 2A,NA,President,DEM,Hillary Clinton,121
+42,Dodge,Fremont - 2B,NA,President,DEM,Hillary Clinton,98
+43,Dodge,Fremont - 2C,NA,President,DEM,Hillary Clinton,180
+44,Dodge,Fremont - 2D,NA,President,DEM,Hillary Clinton,63
+45,Dodge,Fremont - 2E,NA,President,DEM,Hillary Clinton,115
+46,Dodge,Fremont - 3A,NA,President,DEM,Hillary Clinton,87
+47,Dodge,Fremont - 3B,NA,President,DEM,Hillary Clinton,59
+48,Dodge,Fremont - 3C,NA,President,DEM,Hillary Clinton,99
+49,Dodge,Fremont - 3D,NA,President,DEM,Hillary Clinton,154
+50,Dodge,Fremont - 3E,NA,President,DEM,Hillary Clinton,113
+51,Dodge,Fremont - 4A,NA,President,DEM,Hillary Clinton,127
+52,Dodge,Fremont - 4B,NA,President,DEM,Hillary Clinton,93
+53,Dodge,Fremont - 4C,NA,President,DEM,Hillary Clinton,201
+54,Dodge,Fremont - 4D,NA,President,DEM,Hillary Clinton,192
+55,Dodge,Fremont - 4E,NA,President,DEM,Hillary Clinton,75
+56,Dodge,City of North Bend,NA,President,DEM,Hillary Clinton,108
+57,Dodge,City of Scribner,NA,President,DEM,Hillary Clinton,58
+58,Dodge,CU/EV,NA,President,DEM,Hillary Clinton,37
+59,Dodge,Webster Township,NA,President,DEM,Hillary Clinton,64
+60,Dodge,Pebble Township,NA,President,DEM,Hillary Clinton,23
+61,Dodge,Platte East,NA,President,DEM,Hillary Clinton,59
+62,Dodge,Platte West,NA,President,DEM,Hillary Clinton,100
+63,Dodge,Nickerson Township,NA,President,DEM,Hillary Clinton,93
+64,Dodge,City of Hooper,NA,President,DEM,Hillary Clinton,89
+65,Dodge,HW/LG,NA,President,DEM,Hillary Clinton,55
+66,Dodge,Elkhorn Township,NA,President,DEM,Hillary Clinton,36
+67,Dodge,CT/UN,NA,President,DEM,Hillary Clinton,71
+68,Dodge,New/Former Resident,NA,President,DEM,Hillary Clinton,0
+69,Dodge,ABSENTEE,NA,President,DEM,Hillary Clinton,1213
+70,Dodge,TOTALS,NA,President,DEM,Hillary Clinton,4544
+71,Dodge,Fremont - 1A,NA,President,LIB,Gary Johnson,26
+72,Dodge,Fremont - 1B,NA,President,LIB,Gary Johnson,32
+73,Dodge,Fremont - 1C,NA,President,LIB,Gary Johnson,18
+74,Dodge,Fremont - 1D,NA,President,LIB,Gary Johnson,8
+75,Dodge,Fremont - 1E,NA,President,LIB,Gary Johnson,10
+76,Dodge,Fremont - 2A,NA,President,LIB,Gary Johnson,14
+77,Dodge,Fremont - 2B,NA,President,LIB,Gary Johnson,17
+78,Dodge,Fremont - 2C,NA,President,LIB,Gary Johnson,38
+79,Dodge,Fremont - 2D,NA,President,LIB,Gary Johnson,12
+80,Dodge,Fremont - 2E,NA,President,LIB,Gary Johnson,18
+81,Dodge,Fremont - 3A,NA,President,LIB,Gary Johnson,18
+82,Dodge,Fremont - 3B,NA,President,LIB,Gary Johnson,7
+83,Dodge,Fremont - 3C,NA,President,LIB,Gary Johnson,15
+84,Dodge,Fremont - 3D,NA,President,LIB,Gary Johnson,15
+85,Dodge,Fremont - 3E,NA,President,LIB,Gary Johnson,17
+86,Dodge,Fremont - 4A,NA,President,LIB,Gary Johnson,30
+87,Dodge,Fremont - 4B,NA,President,LIB,Gary Johnson,15
+88,Dodge,Fremont - 4C,NA,President,LIB,Gary Johnson,30
+89,Dodge,Fremont - 4D,NA,President,LIB,Gary Johnson,27
+90,Dodge,Fremont - 4E,NA,President,LIB,Gary Johnson,14
+91,Dodge,City of North Bend,NA,President,LIB,Gary Johnson,24
+92,Dodge,City of Scribner,NA,President,LIB,Gary Johnson,16
+93,Dodge,CU/EV,NA,President,LIB,Gary Johnson,10
+94,Dodge,Webster Township,NA,President,LIB,Gary Johnson,6
+95,Dodge,Pebble Township,NA,President,LIB,Gary Johnson,12
+96,Dodge,Platte East,NA,President,LIB,Gary Johnson,6
+97,Dodge,Platte West,NA,President,LIB,Gary Johnson,12
+98,Dodge,Nickerson Township,NA,President,LIB,Gary Johnson,15
+99,Dodge,City of Hooper,NA,President,LIB,Gary Johnson,15
+100,Dodge,HW/LG,NA,President,LIB,Gary Johnson,19
+101,Dodge,Elkhorn Township,NA,President,LIB,Gary Johnson,7
+102,Dodge,CT/UN,NA,President,LIB,Gary Johnson,17
+103,Dodge,New/Former Resident,NA,President,LIB,Gary Johnson,0
+104,Dodge,ABSENTEE,NA,President,LIB,Gary Johnson,84
+105,Dodge,TOTALS,NA,President,LIB,Gary Johnson,624
+106,Dodge,Fremont - 1A,NA,President,,Jill Stein,7
+107,Dodge,Fremont - 1B,NA,President,,Jill Stein,2
+108,Dodge,Fremont - 1C,NA,President,,Jill Stein,3
+109,Dodge,Fremont - 1D,NA,President,,Jill Stein,6
+110,Dodge,Fremont - 1E,NA,President,,Jill Stein,5
+111,Dodge,Fremont - 2A,NA,President,,Jill Stein,11
+112,Dodge,Fremont - 2B,NA,President,,Jill Stein,2
+113,Dodge,Fremont - 2C,NA,President,,Jill Stein,5
+114,Dodge,Fremont - 2D,NA,President,,Jill Stein,3
+115,Dodge,Fremont - 2E,NA,President,,Jill Stein,5
+116,Dodge,Fremont - 3A,NA,President,,Jill Stein,2
+117,Dodge,Fremont - 3B,NA,President,,Jill Stein,3
+118,Dodge,Fremont - 3C,NA,President,,Jill Stein,7
+119,Dodge,Fremont - 3D,NA,President,,Jill Stein,6
+120,Dodge,Fremont - 3E,NA,President,,Jill Stein,8
+121,Dodge,Fremont - 4A,NA,President,,Jill Stein,6
+122,Dodge,Fremont - 4B,NA,President,,Jill Stein,7
+123,Dodge,Fremont - 4C,NA,President,,Jill Stein,4
+124,Dodge,Fremont - 4D,NA,President,,Jill Stein,3
+125,Dodge,Fremont - 4E,NA,President,,Jill Stein,3
+126,Dodge,City of North Bend,NA,President,,Jill Stein,4
+127,Dodge,City of Scribner,NA,President,,Jill Stein,3
+128,Dodge,CU/EV,NA,President,,Jill Stein,3
+129,Dodge,Webster Township,NA,President,,Jill Stein,0
+130,Dodge,Pebble Township,NA,President,,Jill Stein,2
+131,Dodge,Platte East,NA,President,,Jill Stein,1
+132,Dodge,Platte West,NA,President,,Jill Stein,4
+133,Dodge,Nickerson Township,NA,President,,Jill Stein,5
+134,Dodge,City of Hooper,NA,President,,Jill Stein,2
+135,Dodge,HW/LG,NA,President,,Jill Stein,6
+136,Dodge,Elkhorn Township,NA,President,,Jill Stein,0
+137,Dodge,CT/UN,NA,President,,Jill Stein,2
+138,Dodge,New/Former Resident,NA,President,,Jill Stein,0
+139,Dodge,ABSENTEE,NA,President,,Jill Stein,32
+140,Dodge,TOTALS,NA,President,,Jill Stein,162
+141,Dodge,Fremont - 1A,NA,President,,Write-ins,11
+142,Dodge,Fremont - 1B,NA,President,,Write-ins,9
+143,Dodge,Fremont - 1C,NA,President,,Write-ins,20
+144,Dodge,Fremont - 1D,NA,President,,Write-ins,5
+145,Dodge,Fremont - 1E,NA,President,,Write-ins,14
+146,Dodge,Fremont - 2A,NA,President,,Write-ins,5
+147,Dodge,Fremont - 2B,NA,President,,Write-ins,9
+148,Dodge,Fremont - 2C,NA,President,,Write-ins,7
+149,Dodge,Fremont - 2D,NA,President,,Write-ins,6
+150,Dodge,Fremont - 2E,NA,President,,Write-ins,7
+151,Dodge,Fremont - 3A,NA,President,,Write-ins,12
+152,Dodge,Fremont - 3B,NA,President,,Write-ins,1
+153,Dodge,Fremont - 3C,NA,President,,Write-ins,3
+154,Dodge,Fremont - 3D,NA,President,,Write-ins,6
+155,Dodge,Fremont - 3E,NA,President,,Write-ins,8
+156,Dodge,Fremont - 4A,NA,President,,Write-ins,5
+157,Dodge,Fremont - 4B,NA,President,,Write-ins,8
+158,Dodge,Fremont - 4C,NA,President,,Write-ins,13
+159,Dodge,Fremont - 4D,NA,President,,Write-ins,12
+160,Dodge,Fremont - 4E,NA,President,,Write-ins,6
+161,Dodge,City of North Bend,NA,President,,Write-ins,10
+162,Dodge,City of Scribner,NA,President,,Write-ins,6
+163,Dodge,CU/EV,NA,President,,Write-ins,2
+164,Dodge,Webster Township,NA,President,,Write-ins,2
+165,Dodge,Pebble Township,NA,President,,Write-ins,3
+166,Dodge,Platte East,NA,President,,Write-ins,4
+167,Dodge,Platte West,NA,President,,Write-ins,12
+168,Dodge,Nickerson Township,NA,President,,Write-ins,2
+169,Dodge,City of Hooper,NA,President,,Write-ins,2
+170,Dodge,HW/LG,NA,President,,Write-ins,3
+171,Dodge,Elkhorn Township,NA,President,,Write-ins,0
+172,Dodge,CT/UN,NA,President,,Write-ins,8
+173,Dodge,New/Former Resident,NA,President,,Write-ins,0
+174,Dodge,ABSENTEE,NA,President,,Write-ins,45
+175,Dodge,TOTALS,NA,President,,Write-ins,266
+176,Dodge,Fremont - 1A,1,U.S. House,REP,Jeff Fortenberry,425
+177,Dodge,Fremont - 1B,1,U.S. House,REP,Jeff Fortenberry,357
+178,Dodge,Fremont - 1C,1,U.S. House,REP,Jeff Fortenberry,546
+179,Dodge,Fremont - 1D,1,U.S. House,REP,Jeff Fortenberry,218
+180,Dodge,Fremont - 1E,1,U.S. House,REP,Jeff Fortenberry,412
+181,Dodge,Fremont - 2A,1,U.S. House,REP,Jeff Fortenberry,276
+182,Dodge,Fremont - 2B,1,U.S. House,REP,Jeff Fortenberry,255
+183,Dodge,Fremont - 2C,1,U.S. House,REP,Jeff Fortenberry,539
+184,Dodge,Fremont - 2D,1,U.S. House,REP,Jeff Fortenberry,182
+185,Dodge,Fremont - 2E,1,U.S. House,REP,Jeff Fortenberry,350
+186,Dodge,Fremont - 3A,1,U.S. House,REP,Jeff Fortenberry,192
+187,Dodge,Fremont - 3B,1,U.S. House,REP,Jeff Fortenberry,88
+188,Dodge,Fremont - 3C,1,U.S. House,REP,Jeff Fortenberry,191
+189,Dodge,Fremont - 3D,1,U.S. House,REP,Jeff Fortenberry,324
+190,Dodge,Fremont - 3E,1,U.S. House,REP,Jeff Fortenberry,270
+191,Dodge,Fremont - 4A,1,U.S. House,REP,Jeff Fortenberry,356
+192,Dodge,Fremont - 4B,1,U.S. House,REP,Jeff Fortenberry,221
+193,Dodge,Fremont - 4C,1,U.S. House,REP,Jeff Fortenberry,495
+194,Dodge,Fremont - 4D,1,U.S. House,REP,Jeff Fortenberry,561
+195,Dodge,Fremont - 4E,1,U.S. House,REP,Jeff Fortenberry,184
+196,Dodge,City of North Bend,1,U.S. House,REP,Jeff Fortenberry,376
+197,Dodge,City of Scribner,1,U.S. House,REP,Jeff Fortenberry,330
+198,Dodge,CU/EV,1,U.S. House,REP,Jeff Fortenberry,186
+199,Dodge,Webster Township,1,U.S. House,REP,Jeff Fortenberry,289
+200,Dodge,Pebble Township,1,U.S. House,REP,Jeff Fortenberry,178
+201,Dodge,Platte East,1,U.S. House,REP,Jeff Fortenberry,158
+202,Dodge,Platte West,1,U.S. House,REP,Jeff Fortenberry,394
+203,Dodge,Nickerson Township,1,U.S. House,REP,Jeff Fortenberry,314
+204,Dodge,City of Hooper,1,U.S. House,REP,Jeff Fortenberry,271
+205,Dodge,HW/LG,1,U.S. House,REP,Jeff Fortenberry,320
+206,Dodge,Elkhorn Township,1,U.S. House,REP,Jeff Fortenberry,130
+207,Dodge,CT/UN,1,U.S. House,REP,Jeff Fortenberry,380
+208,Dodge,New/Former Resident,1,U.S. House,REP,Jeff Fortenberry,NA
+209,Dodge,ABSENTEE,1,U.S. House,REP,Jeff Fortenberry,1713
+210,Dodge,TOTALS,1,U.S. House,REP,Jeff Fortenberry,11481
+211,Dodge,Fremont - 1A,1,U.S. House,DEM,Daniel M. Wik,115
+212,Dodge,Fremont - 1B,1,U.S. House,DEM,Daniel M. Wik,112
+213,Dodge,Fremont - 1C,1,U.S. House,DEM,Daniel M. Wik,117
+214,Dodge,Fremont - 1D,1,U.S. House,DEM,Daniel M. Wik,52
+215,Dodge,Fremont - 1E,1,U.S. House,DEM,Daniel M. Wik,114
+216,Dodge,Fremont - 2A,1,U.S. House,DEM,Daniel M. Wik,99
+217,Dodge,Fremont - 2B,1,U.S. House,DEM,Daniel M. Wik,76
+218,Dodge,Fremont - 2C,1,U.S. House,DEM,Daniel M. Wik,134
+219,Dodge,Fremont - 2D,1,U.S. House,DEM,Daniel M. Wik,52
+220,Dodge,Fremont - 2E,1,U.S. House,DEM,Daniel M. Wik,89
+221,Dodge,Fremont - 3A,1,U.S. House,DEM,Daniel M. Wik,69
+222,Dodge,Fremont - 3B,1,U.S. House,DEM,Daniel M. Wik,59
+223,Dodge,Fremont - 3C,1,U.S. House,DEM,Daniel M. Wik,94
+224,Dodge,Fremont - 3D,1,U.S. House,DEM,Daniel M. Wik,111
+225,Dodge,Fremont - 3E,1,U.S. House,DEM,Daniel M. Wik,93
+226,Dodge,Fremont - 4A,1,U.S. House,DEM,Daniel M. Wik,100
+227,Dodge,Fremont - 4B,1,U.S. House,DEM,Daniel M. Wik,81
+228,Dodge,Fremont - 4C,1,U.S. House,DEM,Daniel M. Wik,139
+229,Dodge,Fremont - 4D,1,U.S. House,DEM,Daniel M. Wik,111
+230,Dodge,Fremont - 4E,1,U.S. House,DEM,Daniel M. Wik,64
+231,Dodge,City of North Bend,1,U.S. House,DEM,Daniel M. Wik,78
+232,Dodge,City of Scribner,1,U.S. House,DEM,Daniel M. Wik,43
+233,Dodge,CU/EV,1,U.S. House,DEM,Daniel M. Wik,25
+234,Dodge,Webster Township,1,U.S. House,DEM,Daniel M. Wik,60
+235,Dodge,Pebble Township,1,U.S. House,DEM,Daniel M. Wik,20
+236,Dodge,Platte East,1,U.S. House,DEM,Daniel M. Wik,50
+237,Dodge,Platte West,1,U.S. House,DEM,Daniel M. Wik,87
+238,Dodge,Nickerson Township,1,U.S. House,DEM,Daniel M. Wik,81
+239,Dodge,City of Hooper,1,U.S. House,DEM,Daniel M. Wik,69
+240,Dodge,HW/LG,1,U.S. House,DEM,Daniel M. Wik,42
+241,Dodge,Elkhorn Township,1,U.S. House,DEM,Daniel M. Wik,30
+242,Dodge,CT/UN,1,U.S. House,DEM,Daniel M. Wik,63
+243,Dodge,New/Former Resident,1,U.S. House,DEM,Daniel M. Wik,NA
+244,Dodge,ABSENTEE,1,U.S. House,DEM,Daniel M. Wik,959
+245,Dodge,TOTALS,1,U.S. House,DEM,Daniel M. Wik,3488
+246,Dodge,Fremont - 1A,1,U.S. House,,Write-ins,0
+247,Dodge,Fremont - 1B,1,U.S. House,,Write-ins,0
+248,Dodge,Fremont - 1C,1,U.S. House,,Write-ins,2
+249,Dodge,Fremont - 1D,1,U.S. House,,Write-ins,1
+250,Dodge,Fremont - 1E,1,U.S. House,,Write-ins,2
+251,Dodge,Fremont - 2A,1,U.S. House,,Write-ins,0
+252,Dodge,Fremont - 2B,1,U.S. House,,Write-ins,0
+253,Dodge,Fremont - 2C,1,U.S. House,,Write-ins,4
+254,Dodge,Fremont - 2D,1,U.S. House,,Write-ins,1
+255,Dodge,Fremont - 2E,1,U.S. House,,Write-ins,3
+256,Dodge,Fremont - 3A,1,U.S. House,,Write-ins,0
+257,Dodge,Fremont - 3B,1,U.S. House,,Write-ins,1
+258,Dodge,Fremont - 3C,1,U.S. House,,Write-ins,0
+259,Dodge,Fremont - 3D,1,U.S. House,,Write-ins,1
+260,Dodge,Fremont - 3E,1,U.S. House,,Write-ins,0
+261,Dodge,Fremont - 4A,1,U.S. House,,Write-ins,3
+262,Dodge,Fremont - 4B,1,U.S. House,,Write-ins,1
+263,Dodge,Fremont - 4C,1,U.S. House,,Write-ins,1
+264,Dodge,Fremont - 4D,1,U.S. House,,Write-ins,1
+265,Dodge,Fremont - 4E,1,U.S. House,,Write-ins,0
+266,Dodge,City of North Bend,1,U.S. House,,Write-ins,0
+267,Dodge,City of Scribner,1,U.S. House,,Write-ins,0
+268,Dodge,CU/EV,1,U.S. House,,Write-ins,0
+269,Dodge,Webster Township,1,U.S. House,,Write-ins,1
+270,Dodge,Pebble Township,1,U.S. House,,Write-ins,1
+271,Dodge,Platte East,1,U.S. House,,Write-ins,0
+272,Dodge,Platte West,1,U.S. House,,Write-ins,3
+273,Dodge,Nickerson Township,1,U.S. House,,Write-ins,0
+274,Dodge,City of Hooper,1,U.S. House,,Write-ins,1
+275,Dodge,HW/LG,1,U.S. House,,Write-ins,1
+276,Dodge,Elkhorn Township,1,U.S. House,,Write-ins,0
+277,Dodge,CT/UN,1,U.S. House,,Write-ins,0
+278,Dodge,New/Former Resident,1,U.S. House,,Write-ins,NA
+279,Dodge,ABSENTEE,1,U.S. House,,Write-ins,6
+280,Dodge,TOTALS,1,U.S. House,,Write-ins,34
+281,Dodge,Fremont - 1A,15,State Legislature,,David A. Schnoor,269
+282,Dodge,Fremont - 1B,15,State Legislature,,David A. Schnoor,178
+283,Dodge,Fremont - 1C,15,State Legislature,,David A. Schnoor,347
+284,Dodge,Fremont - 1D,15,State Legislature,,David A. Schnoor,118
+285,Dodge,Fremont - 1E,15,State Legislature,,David A. Schnoor,249
+286,Dodge,Fremont - 2A,15,State Legislature,,David A. Schnoor,152
+287,Dodge,Fremont - 2B,15,State Legislature,,David A. Schnoor,115
+288,Dodge,Fremont - 2C,15,State Legislature,,David A. Schnoor,294
+289,Dodge,Fremont - 2D,15,State Legislature,,David A. Schnoor,123
+290,Dodge,Fremont - 2E,15,State Legislature,,David A. Schnoor,196
+291,Dodge,Fremont - 3A,15,State Legislature,,David A. Schnoor,115
+292,Dodge,Fremont - 3B,15,State Legislature,,David A. Schnoor,66
+293,Dodge,Fremont - 3C,15,State Legislature,,David A. Schnoor,120
+294,Dodge,Fremont - 3D,15,State Legislature,,David A. Schnoor,229
+295,Dodge,Fremont - 3E,15,State Legislature,,David A. Schnoor,169
+296,Dodge,Fremont - 4A,15,State Legislature,,David A. Schnoor,192
+297,Dodge,Fremont - 4B,15,State Legislature,,David A. Schnoor,134
+298,Dodge,Fremont - 4C,15,State Legislature,,David A. Schnoor,276
+299,Dodge,Fremont - 4D,15,State Legislature,,David A. Schnoor,278
+300,Dodge,Fremont - 4E,15,State Legislature,,David A. Schnoor,107
+301,Dodge,City of North Bend,15,State Legislature,,David A. Schnoor,258
+302,Dodge,City of Scribner,15,State Legislature,,David A. Schnoor,298
+303,Dodge,CU/EV,15,State Legislature,,David A. Schnoor,146
+304,Dodge,Webster Township,15,State Legislature,,David A. Schnoor,201
+305,Dodge,Pebble Township,15,State Legislature,,David A. Schnoor,124
+306,Dodge,Platte East,15,State Legislature,,David A. Schnoor,98
+307,Dodge,Platte West,15,State Legislature,,David A. Schnoor,237
+308,Dodge,Nickerson Township,15,State Legislature,,David A. Schnoor,193
+309,Dodge,City of Hooper,15,State Legislature,,David A. Schnoor,199
+310,Dodge,HW/LG,15,State Legislature,,David A. Schnoor,215
+311,Dodge,Elkhorn Township,15,State Legislature,,David A. Schnoor,73
+312,Dodge,CT/UN,15,State Legislature,,David A. Schnoor,283
+313,Dodge,New/Former Resident,15,State Legislature,,David A. Schnoor,NA
+314,Dodge,ABSENTEE,15,State Legislature,,David A. Schnoor,1137
+315,Dodge,TOTALS,15,State Legislature,,David A. Schnoor,7189
+316,Dodge,Fremont - 1A,15,State Legislature,,Lynne M. Walz,273
+317,Dodge,Fremont - 1B,15,State Legislature,,Lynne M. Walz,290
+318,Dodge,Fremont - 1C,15,State Legislature,,Lynne M. Walz,319
+319,Dodge,Fremont - 1D,15,State Legislature,,Lynne M. Walz,154
+320,Dodge,Fremont - 1E,15,State Legislature,,Lynne M. Walz,286
+321,Dodge,Fremont - 2A,15,State Legislature,,Lynne M. Walz,220
+322,Dodge,Fremont - 2B,15,State Legislature,,Lynne M. Walz,206
+323,Dodge,Fremont - 2C,15,State Legislature,,Lynne M. Walz,382
+324,Dodge,Fremont - 2D,15,State Legislature,,Lynne M. Walz,110
+325,Dodge,Fremont - 2E,15,State Legislature,,Lynne M. Walz,236
+326,Dodge,Fremont - 3A,15,State Legislature,,Lynne M. Walz,145
+327,Dodge,Fremont - 3B,15,State Legislature,,Lynne M. Walz,73
+328,Dodge,Fremont - 3C,15,State Legislature,,Lynne M. Walz,157
+329,Dodge,Fremont - 3D,15,State Legislature,,Lynne M. Walz,200
+330,Dodge,Fremont - 3E,15,State Legislature,,Lynne M. Walz,186
+331,Dodge,Fremont - 4A,15,State Legislature,,Lynne M. Walz,262
+332,Dodge,Fremont - 4B,15,State Legislature,,Lynne M. Walz,175
+333,Dodge,Fremont - 4C,15,State Legislature,,Lynne M. Walz,349
+334,Dodge,Fremont - 4D,15,State Legislature,,Lynne M. Walz,396
+335,Dodge,Fremont - 4E,15,State Legislature,,Lynne M. Walz,135
+336,Dodge,City of North Bend,15,State Legislature,,Lynne M. Walz,188
+337,Dodge,City of Scribner,15,State Legislature,,Lynne M. Walz,88
+338,Dodge,CU/EV,15,State Legislature,,Lynne M. Walz,69
+339,Dodge,Webster Township,15,State Legislature,,Lynne M. Walz,156
+340,Dodge,Pebble Township,15,State Legislature,,Lynne M. Walz,77
+341,Dodge,Platte East,15,State Legislature,,Lynne M. Walz,104
+342,Dodge,Platte West,15,State Legislature,,Lynne M. Walz,227
+343,Dodge,Nickerson Township,15,State Legislature,,Lynne M. Walz,189
+344,Dodge,City of Hooper,15,State Legislature,,Lynne M. Walz,140
+345,Dodge,HW/LG,15,State Legislature,,Lynne M. Walz,137
+346,Dodge,Elkhorn Township,15,State Legislature,,Lynne M. Walz,83
+347,Dodge,CT/UN,15,State Legislature,,Lynne M. Walz,148
+348,Dodge,New/Former Resident,15,State Legislature,,Lynne M. Walz,NA
+349,Dodge,ABSENTEE,15,State Legislature,,Lynne M. Walz,1441
+350,Dodge,TOTALS,15,State Legislature,,Lynne M. Walz,7601
+351,Dodge,Fremont - 1A,15,State Legislature,,Write-ins,0
+352,Dodge,Fremont - 1B,15,State Legislature,,Write-ins,1
+353,Dodge,Fremont - 1C,15,State Legislature,,Write-ins,1
+354,Dodge,Fremont - 1D,15,State Legislature,,Write-ins,0
+355,Dodge,Fremont - 1E,15,State Legislature,,Write-ins,1
+356,Dodge,Fremont - 2A,15,State Legislature,,Write-ins,0
+357,Dodge,Fremont - 2B,15,State Legislature,,Write-ins,2
+358,Dodge,Fremont - 2C,15,State Legislature,,Write-ins,2
+359,Dodge,Fremont - 2D,15,State Legislature,,Write-ins,1
+360,Dodge,Fremont - 2E,15,State Legislature,,Write-ins,2
+361,Dodge,Fremont - 3A,15,State Legislature,,Write-ins,1
+362,Dodge,Fremont - 3B,15,State Legislature,,Write-ins,2
+363,Dodge,Fremont - 3C,15,State Legislature,,Write-ins,0
+364,Dodge,Fremont - 3D,15,State Legislature,,Write-ins,2
+365,Dodge,Fremont - 3E,15,State Legislature,,Write-ins,0
+366,Dodge,Fremont - 4A,15,State Legislature,,Write-ins,1
+367,Dodge,Fremont - 4B,15,State Legislature,,Write-ins,0
+368,Dodge,Fremont - 4C,15,State Legislature,,Write-ins,3
+369,Dodge,Fremont - 4D,15,State Legislature,,Write-ins,0
+370,Dodge,Fremont - 4E,15,State Legislature,,Write-ins,0
+371,Dodge,City of North Bend,15,State Legislature,,Write-ins,1
+372,Dodge,City of Scribner,15,State Legislature,,Write-ins,0
+373,Dodge,CU/EV,15,State Legislature,,Write-ins,0
+374,Dodge,Webster Township,15,State Legislature,,Write-ins,0
+375,Dodge,Pebble Township,15,State Legislature,,Write-ins,0
+376,Dodge,Platte East,15,State Legislature,,Write-ins,0
+377,Dodge,Platte West,15,State Legislature,,Write-ins,2
+378,Dodge,Nickerson Township,15,State Legislature,,Write-ins,0
+379,Dodge,City of Hooper,15,State Legislature,,Write-ins,0
+380,Dodge,HW/LG,15,State Legislature,,Write-ins,1
+381,Dodge,Elkhorn Township,15,State Legislature,,Write-ins,0
+382,Dodge,CT/UN,15,State Legislature,,Write-ins,1
+383,Dodge,New/Former Resident,15,State Legislature,,Write-ins,NA
+384,Dodge,ABSENTEE,15,State Legislature,,Write-ins,8
+385,Dodge,TOTALS,15,State Legislature,,Write-ins,32

--- a/2016/counties/20161108__ne__general__richardson__precinct.csv
+++ b/2016/counties/20161108__ne__general__richardson__precinct.csv
@@ -1,171 +1,171 @@
-"","county","precinct","district","office","party","candidate","votes"
-"1","Richardson","Absentee/Early Vote",NA,"President","DEM","Hillary Clinton",0
-"2","Richardson","Arago/Barada",NA,"President","DEM","Hillary Clinton",40
-"3","Richardson","Countywide",NA,"President","DEM","Hillary Clinton",0
-"4","Richardson","East Muddy",NA,"President","DEM","Hillary Clinton",22
-"5","Richardson","FC Ward 1",NA,"President","DEM","Hillary Clinton",135
-"6","Richardson","FC Ward 2",NA,"President","DEM","Hillary Clinton",92
-"7","Richardson","FC Ward 3",NA,"President","DEM","Hillary Clinton",108
-"8","Richardson","FC Ward 4",NA,"President","DEM","Hillary Clinton",105
-"9","Richardson","FCRural/Ohio",NA,"President","DEM","Hillary Clinton",26
-"10","Richardson","Fran/Hrr/Spi",NA,"President","DEM","Hillary Clinton",34
-"11","Richardson","Grant/Nemaha",NA,"President","DEM","Hillary Clinton",34
-"12","Richardson","Humb. I",NA,"President","DEM","Hillary Clinton",46
-"13","Richardson","Humb.II",NA,"President","DEM","Hillary Clinton",45
-"14","Richardson","Jeff/Rulo",NA,"President","DEM","Hillary Clinton",56
-"15","Richardson","Liberty",NA,"President","DEM","Hillary Clinton",20
-"16","Richardson","New/Former Resident",NA,"President","DEM","Hillary Clinton",1
-"17","Richardson","Salem",NA,"President","DEM","Hillary Clinton",11
-"18","Richardson","WMuddy/Porter",NA,"President","DEM","Hillary Clinton",43
-"19","Richardson","Absentee/Early Vote",NA,"President","LIB","Gary Johnson",0
-"20","Richardson","Arago/Barada",NA,"President","LIB","Gary Johnson",8
-"21","Richardson","Countywide",NA,"President","LIB","Gary Johnson",0
-"22","Richardson","East Muddy",NA,"President","LIB","Gary Johnson",7
-"23","Richardson","FC Ward 1",NA,"President","LIB","Gary Johnson",21
-"24","Richardson","FC Ward 2",NA,"President","LIB","Gary Johnson",21
-"25","Richardson","FC Ward 3",NA,"President","LIB","Gary Johnson",16
-"26","Richardson","FC Ward 4",NA,"President","LIB","Gary Johnson",12
-"27","Richardson","FCRural/Ohio",NA,"President","LIB","Gary Johnson",9
-"28","Richardson","Fran/Hrr/Spi",NA,"President","LIB","Gary Johnson",7
-"29","Richardson","Grant/Nemaha",NA,"President","LIB","Gary Johnson",11
-"30","Richardson","Humb. I",NA,"President","LIB","Gary Johnson",8
-"31","Richardson","Humb.II",NA,"President","LIB","Gary Johnson",6
-"32","Richardson","Jeff/Rulo",NA,"President","LIB","Gary Johnson",8
-"33","Richardson","Liberty",NA,"President","LIB","Gary Johnson",10
-"34","Richardson","New/Former Resident",NA,"President","LIB","Gary Johnson",0
-"35","Richardson","Salem",NA,"President","LIB","Gary Johnson",7
-"36","Richardson","WMuddy/Porter",NA,"President","LIB","Gary Johnson",8
-"37","Richardson","Absentee/Early Vote",NA,"President","","Jill Stein",0
-"38","Richardson","Arago/Barada",NA,"President","","Jill Stein",1
-"39","Richardson","Countywide",NA,"President","","Jill Stein",0
-"40","Richardson","East Muddy",NA,"President","","Jill Stein",2
-"41","Richardson","FC Ward 1",NA,"President","","Jill Stein",3
-"42","Richardson","FC Ward 2",NA,"President","","Jill Stein",3
-"43","Richardson","FC Ward 3",NA,"President","","Jill Stein",4
-"44","Richardson","FC Ward 4",NA,"President","","Jill Stein",3
-"45","Richardson","FCRural/Ohio",NA,"President","","Jill Stein",1
-"46","Richardson","Fran/Hrr/Spi",NA,"President","","Jill Stein",2
-"47","Richardson","Grant/Nemaha",NA,"President","","Jill Stein",3
-"48","Richardson","Humb. I",NA,"President","","Jill Stein",2
-"49","Richardson","Humb.II",NA,"President","","Jill Stein",2
-"50","Richardson","Jeff/Rulo",NA,"President","","Jill Stein",0
-"51","Richardson","Liberty",NA,"President","","Jill Stein",0
-"52","Richardson","New/Former Resident",NA,"President","","Jill Stein",0
-"53","Richardson","Salem",NA,"President","","Jill Stein",0
-"54","Richardson","WMuddy/Porter",NA,"President","","Jill Stein",1
-"55","Richardson","Absentee/Early Vote",NA,"President","REP","Donald J. Trump",0
-"56","Richardson","Arago/Barada",NA,"President","REP","Donald J. Trump",164
-"57","Richardson","Countywide",NA,"President","REP","Donald J. Trump",0
-"58","Richardson","East Muddy",NA,"President","REP","Donald J. Trump",80
-"59","Richardson","FC Ward 1",NA,"President","REP","Donald J. Trump",401
-"60","Richardson","FC Ward 2",NA,"President","REP","Donald J. Trump",298
-"61","Richardson","FC Ward 3",NA,"President","REP","Donald J. Trump",292
-"62","Richardson","FC Ward 4",NA,"President","REP","Donald J. Trump",190
-"63","Richardson","FCRural/Ohio",NA,"President","REP","Donald J. Trump",240
-"64","Richardson","Fran/Hrr/Spi",NA,"President","REP","Donald J. Trump",165
-"65","Richardson","Grant/Nemaha",NA,"President","REP","Donald J. Trump",147
-"66","Richardson","Humb. I",NA,"President","REP","Donald J. Trump",146
-"67","Richardson","Humb.II",NA,"President","REP","Donald J. Trump",141
-"68","Richardson","Jeff/Rulo",NA,"President","REP","Donald J. Trump",164
-"69","Richardson","Liberty",NA,"President","REP","Donald J. Trump",128
-"70","Richardson","New/Former Resident",NA,"President","REP","Donald J. Trump",4
-"71","Richardson","Salem",NA,"President","REP","Donald J. Trump",75
-"72","Richardson","WMuddy/Porter",NA,"President","REP","Donald J. Trump",134
-"73","Richardson","Absentee/Early Vote",3,"U.S. House","REP","Adrian Smith",0
-"74","Richardson","Arago/Barada",3,"U.S. House","REP","Adrian Smith",157
-"75","Richardson","Countywide",3,"U.S. House","REP","Adrian Smith",0
-"76","Richardson","East Muddy",3,"U.S. House","REP","Adrian Smith",72
-"77","Richardson","FC Ward 1",3,"U.S. House","REP","Adrian Smith",453
-"78","Richardson","FC Ward 2",3,"U.S. House","REP","Adrian Smith",337
-"79","Richardson","FC Ward 3",3,"U.S. House","REP","Adrian Smith",343
-"80","Richardson","FC Ward 4",3,"U.S. House","REP","Adrian Smith",218
-"81","Richardson","FCRural/Ohio",3,"U.S. House","REP","Adrian Smith",220
-"82","Richardson","Fran/Hrr/Spi",3,"U.S. House","REP","Adrian Smith",177
-"83","Richardson","Grant/Nemaha",3,"U.S. House","REP","Adrian Smith",161
-"84","Richardson","Humb. I",3,"U.S. House","REP","Adrian Smith",167
-"85","Richardson","Humb.II",3,"U.S. House","REP","Adrian Smith",176
-"86","Richardson","Jeff/Rulo",3,"U.S. House","REP","Adrian Smith",159
-"87","Richardson","Liberty",3,"U.S. House","REP","Adrian Smith",127
-"88","Richardson","New/Former Resident",3,"U.S. House","REP","Adrian Smith",0
-"89","Richardson","Salem",3,"U.S. House","REP","Adrian Smith",77
-"90","Richardson","WMuddy/Porter",3,"U.S. House","REP","Adrian Smith",151
-"91","Richardson","Absentee/Early Vote",1,"State Legislature","","Dan Watermeier ",0
-"92","Richardson","Arago/Barada",1,"State Legislature","","Dan Watermeier ",161
-"93","Richardson","Countywide",1,"State Legislature","","Dan Watermeier ",0
-"94","Richardson","East Muddy",1,"State Legislature","","Dan Watermeier ",75
-"95","Richardson","FC Ward 1",1,"State Legislature","","Dan Watermeier ",471
-"96","Richardson","FC Ward 2",1,"State Legislature","","Dan Watermeier ",334
-"97","Richardson","FC Ward 3",1,"State Legislature","","Dan Watermeier ",355
-"98","Richardson","FC Ward 4",1,"State Legislature","","Dan Watermeier ",224
-"99","Richardson","FCRural/Ohio",1,"State Legislature","","Dan Watermeier ",231
-"100","Richardson","Fran/Hrr/Spi",1,"State Legislature","","Dan Watermeier ",183
-"101","Richardson","Grant/Nemaha",1,"State Legislature","","Dan Watermeier ",171
-"102","Richardson","Humb. I",1,"State Legislature","","Dan Watermeier ",176
-"103","Richardson","Humb.II",1,"State Legislature","","Dan Watermeier ",177
-"104","Richardson","Jeff/Rulo",1,"State Legislature","","Dan Watermeier ",169
-"105","Richardson","Liberty",1,"State Legislature","","Dan Watermeier ",122
-"106","Richardson","New/Former Resident",1,"State Legislature","","Dan Watermeier ",0
-"107","Richardson","Salem",1,"State Legislature","","Dan Watermeier ",69
-"108","Richardson","WMuddy/Porter",1,"State Legislature","","Dan Watermeier ",157
-"109","Richardson","Arago/Barada",NA,"President","","Write-ins",2
-"110","Richardson","East Muddy",NA,"President","","Write-ins",0
-"111","Richardson","FC Ward 1",NA,"President","","Write-ins",8
-"112","Richardson","FC Ward 2",NA,"President","","Write-ins",4
-"113","Richardson","FC Ward 3",NA,"President","","Write-ins",1
-"114","Richardson","FC Ward 4",NA,"President","","Write-ins",3
-"115","Richardson","FCRural/Ohio",NA,"President","","Write-ins",2
-"116","Richardson","Fran/Hrr/Spi",NA,"President","","Write-ins",0
-"117","Richardson","Grant/Nemaha",NA,"President","","Write-ins",3
-"118","Richardson","Humb. I",NA,"President","","Write-ins",1
-"119","Richardson","Humb.II",NA,"President","","Write-ins",0
-"120","Richardson","Jeff/Rulo",NA,"President","","Write-ins",4
-"121","Richardson","Liberty",NA,"President","","Write-ins",1
-"122","Richardson","New/Former Resident",NA,"President","","Write-ins",0
-"123","Richardson","Salem",NA,"President","","Write-ins",1
-"124","Richardson","WMuddy/Porter",NA,"President","","Write-ins",2
-"125","Richardson","Arago/Barada",NA,"","","Registered Voters",259
-"126","Richardson","East Muddy",NA,"","","Registered Voters",170
-"127","Richardson","FC Ward 1",NA,"","","Registered Voters",816
-"128","Richardson","FC Ward 2",NA,"","","Registered Voters",693
-"129","Richardson","FC Ward 3",NA,"","","Registered Voters",692
-"130","Richardson","FC Ward 4",NA,"","","Registered Voters",627
-"131","Richardson","FCRural/Ohio",NA,"","","Registered Voters",357
-"132","Richardson","Fran/Hrr/Spi",NA,"","","Registered Voters",289
-"133","Richardson","Grant/Nemaha",NA,"","","Registered Voters",276
-"134","Richardson","Humb. I",NA,"","","Registered Voters",291
-"135","Richardson","Humb.II",NA,"","","Registered Voters",289
-"136","Richardson","Jeff/Rulo",NA,"","","Registered Voters",344
-"137","Richardson","Liberty",NA,"","","Registered Voters",219
-"138","Richardson","Salem",NA,"","","Registered Voters",147
-"139","Richardson","WMuddy/Porter",NA,"","","Registered Voters",243
-"140","Richardson","Arago/Barada",NA,"","","Ballots Cast",219
-"141","Richardson","East Muddy",NA,"","","Ballots Cast",112
-"142","Richardson","FC Ward 1",NA,"","","Ballots Cast",573
-"143","Richardson","FC Ward 2",NA,"","","Ballots Cast",423
-"144","Richardson","FC Ward 3",NA,"","","Ballots Cast",428
-"145","Richardson","FC Ward 4",NA,"","","Ballots Cast",315
-"146","Richardson","FCRural/Ohio",NA,"","","Ballots Cast",280
-"147","Richardson","Fran/Hrr/Spi",NA,"","","Ballots Cast",212
-"148","Richardson","Grant/Nemaha",NA,"","","Ballots Cast",200
-"149","Richardson","Humb. I",NA,"","","Ballots Cast",208
-"150","Richardson","Humb.II",NA,"","","Ballots Cast",195
-"151","Richardson","Jeff/Rulo",NA,"","","Ballots Cast",236
-"152","Richardson","Liberty",NA,"","","Ballots Cast",159
-"153","Richardson","New/Former Resident",NA,"","","Ballots Cast",5
-"154","Richardson","Salem",NA,"","","Ballots Cast",96
-"155","Richardson","WMuddy/Porter",NA,"","","Ballots Cast",190
-"156","Richardson","Arago/Barada",3,"U.S. House","","Write-ins",0
-"157","Richardson","East Muddy",3,"U.S. House","","Write-ins",2
-"158","Richardson","FC Ward 1",3,"U.S. House","","Write-ins",9
-"159","Richardson","FC Ward 2",3,"U.S. House","","Write-ins",6
-"160","Richardson","FC Ward 3",3,"U.S. House","","Write-ins",7
-"161","Richardson","FC Ward 4",3,"U.S. House","","Write-ins",8
-"162","Richardson","FCRural/Ohio",3,"U.S. House","","Write-ins",2
-"163","Richardson","Fran/Hrr/Spi",3,"U.S. House","","Write-ins",1
-"164","Richardson","Grant/Nemaha",3,"U.S. House","","Write-ins",5
-"165","Richardson","Humb. I",3,"U.S. House","","Write-ins",2
-"166","Richardson","Humb.II",3,"U.S. House","","Write-ins",1
-"167","Richardson","Jeff/Rulo",3,"U.S. House","","Write-ins",5
-"168","Richardson","Liberty",3,"U.S. House","","Write-ins",1
-"169","Richardson","Salem",3,"U.S. House","","Write-ins",1
-"170","Richardson","WMuddy/Porter",3,"U.S. House","","Write-ins",0
+,county,precinct,district,office,party,candidate,votes
+1,Richardson,Absentee/Early Vote,NA,President,DEM,Hillary Clinton,0
+2,Richardson,Arago/Barada,NA,President,DEM,Hillary Clinton,40
+3,Richardson,Countywide,NA,President,DEM,Hillary Clinton,0
+4,Richardson,East Muddy,NA,President,DEM,Hillary Clinton,22
+5,Richardson,FC Ward 1,NA,President,DEM,Hillary Clinton,135
+6,Richardson,FC Ward 2,NA,President,DEM,Hillary Clinton,92
+7,Richardson,FC Ward 3,NA,President,DEM,Hillary Clinton,108
+8,Richardson,FC Ward 4,NA,President,DEM,Hillary Clinton,105
+9,Richardson,FCRural/Ohio,NA,President,DEM,Hillary Clinton,26
+10,Richardson,Fran/Hrr/Spi,NA,President,DEM,Hillary Clinton,34
+11,Richardson,Grant/Nemaha,NA,President,DEM,Hillary Clinton,34
+12,Richardson,Humb. I,NA,President,DEM,Hillary Clinton,46
+13,Richardson,Humb.II,NA,President,DEM,Hillary Clinton,45
+14,Richardson,Jeff/Rulo,NA,President,DEM,Hillary Clinton,56
+15,Richardson,Liberty,NA,President,DEM,Hillary Clinton,20
+16,Richardson,New/Former Resident,NA,President,DEM,Hillary Clinton,1
+17,Richardson,Salem,NA,President,DEM,Hillary Clinton,11
+18,Richardson,WMuddy/Porter,NA,President,DEM,Hillary Clinton,43
+19,Richardson,Absentee/Early Vote,NA,President,LIB,Gary Johnson,0
+20,Richardson,Arago/Barada,NA,President,LIB,Gary Johnson,8
+21,Richardson,Countywide,NA,President,LIB,Gary Johnson,0
+22,Richardson,East Muddy,NA,President,LIB,Gary Johnson,7
+23,Richardson,FC Ward 1,NA,President,LIB,Gary Johnson,21
+24,Richardson,FC Ward 2,NA,President,LIB,Gary Johnson,21
+25,Richardson,FC Ward 3,NA,President,LIB,Gary Johnson,16
+26,Richardson,FC Ward 4,NA,President,LIB,Gary Johnson,12
+27,Richardson,FCRural/Ohio,NA,President,LIB,Gary Johnson,9
+28,Richardson,Fran/Hrr/Spi,NA,President,LIB,Gary Johnson,7
+29,Richardson,Grant/Nemaha,NA,President,LIB,Gary Johnson,11
+30,Richardson,Humb. I,NA,President,LIB,Gary Johnson,8
+31,Richardson,Humb.II,NA,President,LIB,Gary Johnson,6
+32,Richardson,Jeff/Rulo,NA,President,LIB,Gary Johnson,8
+33,Richardson,Liberty,NA,President,LIB,Gary Johnson,10
+34,Richardson,New/Former Resident,NA,President,LIB,Gary Johnson,0
+35,Richardson,Salem,NA,President,LIB,Gary Johnson,7
+36,Richardson,WMuddy/Porter,NA,President,LIB,Gary Johnson,8
+37,Richardson,Absentee/Early Vote,NA,President,,Jill Stein,0
+38,Richardson,Arago/Barada,NA,President,,Jill Stein,1
+39,Richardson,Countywide,NA,President,,Jill Stein,0
+40,Richardson,East Muddy,NA,President,,Jill Stein,2
+41,Richardson,FC Ward 1,NA,President,,Jill Stein,3
+42,Richardson,FC Ward 2,NA,President,,Jill Stein,3
+43,Richardson,FC Ward 3,NA,President,,Jill Stein,4
+44,Richardson,FC Ward 4,NA,President,,Jill Stein,3
+45,Richardson,FCRural/Ohio,NA,President,,Jill Stein,1
+46,Richardson,Fran/Hrr/Spi,NA,President,,Jill Stein,2
+47,Richardson,Grant/Nemaha,NA,President,,Jill Stein,3
+48,Richardson,Humb. I,NA,President,,Jill Stein,2
+49,Richardson,Humb.II,NA,President,,Jill Stein,2
+50,Richardson,Jeff/Rulo,NA,President,,Jill Stein,0
+51,Richardson,Liberty,NA,President,,Jill Stein,0
+52,Richardson,New/Former Resident,NA,President,,Jill Stein,0
+53,Richardson,Salem,NA,President,,Jill Stein,0
+54,Richardson,WMuddy/Porter,NA,President,,Jill Stein,1
+55,Richardson,Absentee/Early Vote,NA,President,REP,Donald J. Trump,0
+56,Richardson,Arago/Barada,NA,President,REP,Donald J. Trump,164
+57,Richardson,Countywide,NA,President,REP,Donald J. Trump,0
+58,Richardson,East Muddy,NA,President,REP,Donald J. Trump,80
+59,Richardson,FC Ward 1,NA,President,REP,Donald J. Trump,401
+60,Richardson,FC Ward 2,NA,President,REP,Donald J. Trump,298
+61,Richardson,FC Ward 3,NA,President,REP,Donald J. Trump,292
+62,Richardson,FC Ward 4,NA,President,REP,Donald J. Trump,190
+63,Richardson,FCRural/Ohio,NA,President,REP,Donald J. Trump,240
+64,Richardson,Fran/Hrr/Spi,NA,President,REP,Donald J. Trump,165
+65,Richardson,Grant/Nemaha,NA,President,REP,Donald J. Trump,147
+66,Richardson,Humb. I,NA,President,REP,Donald J. Trump,146
+67,Richardson,Humb.II,NA,President,REP,Donald J. Trump,141
+68,Richardson,Jeff/Rulo,NA,President,REP,Donald J. Trump,164
+69,Richardson,Liberty,NA,President,REP,Donald J. Trump,128
+70,Richardson,New/Former Resident,NA,President,REP,Donald J. Trump,4
+71,Richardson,Salem,NA,President,REP,Donald J. Trump,75
+72,Richardson,WMuddy/Porter,NA,President,REP,Donald J. Trump,134
+73,Richardson,Absentee/Early Vote,3,U.S. House,REP,Adrian Smith,0
+74,Richardson,Arago/Barada,3,U.S. House,REP,Adrian Smith,157
+75,Richardson,Countywide,3,U.S. House,REP,Adrian Smith,0
+76,Richardson,East Muddy,3,U.S. House,REP,Adrian Smith,72
+77,Richardson,FC Ward 1,3,U.S. House,REP,Adrian Smith,453
+78,Richardson,FC Ward 2,3,U.S. House,REP,Adrian Smith,337
+79,Richardson,FC Ward 3,3,U.S. House,REP,Adrian Smith,343
+80,Richardson,FC Ward 4,3,U.S. House,REP,Adrian Smith,218
+81,Richardson,FCRural/Ohio,3,U.S. House,REP,Adrian Smith,220
+82,Richardson,Fran/Hrr/Spi,3,U.S. House,REP,Adrian Smith,177
+83,Richardson,Grant/Nemaha,3,U.S. House,REP,Adrian Smith,161
+84,Richardson,Humb. I,3,U.S. House,REP,Adrian Smith,167
+85,Richardson,Humb.II,3,U.S. House,REP,Adrian Smith,176
+86,Richardson,Jeff/Rulo,3,U.S. House,REP,Adrian Smith,159
+87,Richardson,Liberty,3,U.S. House,REP,Adrian Smith,127
+88,Richardson,New/Former Resident,3,U.S. House,REP,Adrian Smith,0
+89,Richardson,Salem,3,U.S. House,REP,Adrian Smith,77
+90,Richardson,WMuddy/Porter,3,U.S. House,REP,Adrian Smith,151
+91,Richardson,Absentee/Early Vote,1,State Legislature,,Dan Watermeier,0
+92,Richardson,Arago/Barada,1,State Legislature,,Dan Watermeier,161
+93,Richardson,Countywide,1,State Legislature,,Dan Watermeier,0
+94,Richardson,East Muddy,1,State Legislature,,Dan Watermeier,75
+95,Richardson,FC Ward 1,1,State Legislature,,Dan Watermeier,471
+96,Richardson,FC Ward 2,1,State Legislature,,Dan Watermeier,334
+97,Richardson,FC Ward 3,1,State Legislature,,Dan Watermeier,355
+98,Richardson,FC Ward 4,1,State Legislature,,Dan Watermeier,224
+99,Richardson,FCRural/Ohio,1,State Legislature,,Dan Watermeier,231
+100,Richardson,Fran/Hrr/Spi,1,State Legislature,,Dan Watermeier,183
+101,Richardson,Grant/Nemaha,1,State Legislature,,Dan Watermeier,171
+102,Richardson,Humb. I,1,State Legislature,,Dan Watermeier,176
+103,Richardson,Humb.II,1,State Legislature,,Dan Watermeier,177
+104,Richardson,Jeff/Rulo,1,State Legislature,,Dan Watermeier,169
+105,Richardson,Liberty,1,State Legislature,,Dan Watermeier,122
+106,Richardson,New/Former Resident,1,State Legislature,,Dan Watermeier,0
+107,Richardson,Salem,1,State Legislature,,Dan Watermeier,69
+108,Richardson,WMuddy/Porter,1,State Legislature,,Dan Watermeier,157
+109,Richardson,Arago/Barada,NA,President,,Write-ins,2
+110,Richardson,East Muddy,NA,President,,Write-ins,0
+111,Richardson,FC Ward 1,NA,President,,Write-ins,8
+112,Richardson,FC Ward 2,NA,President,,Write-ins,4
+113,Richardson,FC Ward 3,NA,President,,Write-ins,1
+114,Richardson,FC Ward 4,NA,President,,Write-ins,3
+115,Richardson,FCRural/Ohio,NA,President,,Write-ins,2
+116,Richardson,Fran/Hrr/Spi,NA,President,,Write-ins,0
+117,Richardson,Grant/Nemaha,NA,President,,Write-ins,3
+118,Richardson,Humb. I,NA,President,,Write-ins,1
+119,Richardson,Humb.II,NA,President,,Write-ins,0
+120,Richardson,Jeff/Rulo,NA,President,,Write-ins,4
+121,Richardson,Liberty,NA,President,,Write-ins,1
+122,Richardson,New/Former Resident,NA,President,,Write-ins,0
+123,Richardson,Salem,NA,President,,Write-ins,1
+124,Richardson,WMuddy/Porter,NA,President,,Write-ins,2
+125,Richardson,Arago/Barada,NA,,,Registered Voters,259
+126,Richardson,East Muddy,NA,,,Registered Voters,170
+127,Richardson,FC Ward 1,NA,,,Registered Voters,816
+128,Richardson,FC Ward 2,NA,,,Registered Voters,693
+129,Richardson,FC Ward 3,NA,,,Registered Voters,692
+130,Richardson,FC Ward 4,NA,,,Registered Voters,627
+131,Richardson,FCRural/Ohio,NA,,,Registered Voters,357
+132,Richardson,Fran/Hrr/Spi,NA,,,Registered Voters,289
+133,Richardson,Grant/Nemaha,NA,,,Registered Voters,276
+134,Richardson,Humb. I,NA,,,Registered Voters,291
+135,Richardson,Humb.II,NA,,,Registered Voters,289
+136,Richardson,Jeff/Rulo,NA,,,Registered Voters,344
+137,Richardson,Liberty,NA,,,Registered Voters,219
+138,Richardson,Salem,NA,,,Registered Voters,147
+139,Richardson,WMuddy/Porter,NA,,,Registered Voters,243
+140,Richardson,Arago/Barada,NA,,,Ballots Cast,219
+141,Richardson,East Muddy,NA,,,Ballots Cast,112
+142,Richardson,FC Ward 1,NA,,,Ballots Cast,573
+143,Richardson,FC Ward 2,NA,,,Ballots Cast,423
+144,Richardson,FC Ward 3,NA,,,Ballots Cast,428
+145,Richardson,FC Ward 4,NA,,,Ballots Cast,315
+146,Richardson,FCRural/Ohio,NA,,,Ballots Cast,280
+147,Richardson,Fran/Hrr/Spi,NA,,,Ballots Cast,212
+148,Richardson,Grant/Nemaha,NA,,,Ballots Cast,200
+149,Richardson,Humb. I,NA,,,Ballots Cast,208
+150,Richardson,Humb.II,NA,,,Ballots Cast,195
+151,Richardson,Jeff/Rulo,NA,,,Ballots Cast,236
+152,Richardson,Liberty,NA,,,Ballots Cast,159
+153,Richardson,New/Former Resident,NA,,,Ballots Cast,5
+154,Richardson,Salem,NA,,,Ballots Cast,96
+155,Richardson,WMuddy/Porter,NA,,,Ballots Cast,190
+156,Richardson,Arago/Barada,3,U.S. House,,Write-ins,0
+157,Richardson,East Muddy,3,U.S. House,,Write-ins,2
+158,Richardson,FC Ward 1,3,U.S. House,,Write-ins,9
+159,Richardson,FC Ward 2,3,U.S. House,,Write-ins,6
+160,Richardson,FC Ward 3,3,U.S. House,,Write-ins,7
+161,Richardson,FC Ward 4,3,U.S. House,,Write-ins,8
+162,Richardson,FCRural/Ohio,3,U.S. House,,Write-ins,2
+163,Richardson,Fran/Hrr/Spi,3,U.S. House,,Write-ins,1
+164,Richardson,Grant/Nemaha,3,U.S. House,,Write-ins,5
+165,Richardson,Humb. I,3,U.S. House,,Write-ins,2
+166,Richardson,Humb.II,3,U.S. House,,Write-ins,1
+167,Richardson,Jeff/Rulo,3,U.S. House,,Write-ins,5
+168,Richardson,Liberty,3,U.S. House,,Write-ins,1
+169,Richardson,Salem,3,U.S. House,,Write-ins,1
+170,Richardson,WMuddy/Porter,3,U.S. House,,Write-ins,0

--- a/2016/counties/20161108__ne__general__saunders__precinct.csv
+++ b/2016/counties/20161108__ne__general__saunders__precinct.csv
@@ -1,153 +1,153 @@
-"","county","precinct","district","office","party","candidate","votes"
-"1","Saunders","Early voters ",NA,"President","REP","Donald J. Trump",974
-"2","Saunders","Valparaiso 1",NA,"President","REP","Donald J. Trump",441
-"3","Saunders","Weston 2",NA,"President","REP","Donald J. Trump",280
-"4","Saunders","Prague 3",NA,"President","REP","Donald J. Trump",311
-"5","Saunders","Malmo 4",NA,"President","REP","Donald J. Trump",200
-"6","Saunders","Ceresco 5",NA,"President","REP","Donald J. Trump",507
-"7","Saunders","Wahoo rural 6",NA,"President","REP","Donald J. Trump",304
-"8","Saunders","Wahoo ward 1 7",NA,"President","REP","Donald J. Trump",430
-"9","Saunders","Wahoo ward 2 8",NA,"President","REP","Donald J. Trump",369
-"10","Saunders","Wahoo ward 3 9",NA,"President","REP","Donald J. Trump",365
-"11","Saunders","Center 10",NA,"President","REP","Donald J. Trump",205
-"12","Saunders","Cedar Bluffs 11",NA,"President","REP","Donald J. Trump",439
-"13","Saunders","Marietta 12",NA,"President","REP","Donald J. Trump",264
-"14","Saunders","District 4 13",NA,"President","REP","Donald J. Trump",654
-"15","Saunders","Ashland ward 1 14",NA,"President","REP","Donald J. Trump",275
-"16","Saunders","Ashland ward 2 15",NA,"President","REP","Donald J. Trump",305
-"17","Saunders","Ashland rural 16",NA,"President","REP","Donald J. Trump",425
-"18","Saunders","Yutan 17",NA,"President","REP","Donald J. Trump",740
-"19","Saunders","Provisional ballots ",NA,"President","REP","Donald J. Trump",67
-"20","Saunders","Early voters ",NA,"President","DEM","Hillary Clinton",493
-"21","Saunders","Valparaiso 1",NA,"President","DEM","Hillary Clinton",144
-"22","Saunders","Weston 2",NA,"President","DEM","Hillary Clinton",60
-"23","Saunders","Prague 3",NA,"President","DEM","Hillary Clinton",67
-"24","Saunders","Malmo 4",NA,"President","DEM","Hillary Clinton",48
-"25","Saunders","Ceresco 5",NA,"President","DEM","Hillary Clinton",181
-"26","Saunders","Wahoo rural 6",NA,"President","DEM","Hillary Clinton",49
-"27","Saunders","Wahoo ward 1 7",NA,"President","DEM","Hillary Clinton",180
-"28","Saunders","Wahoo ward 2 8",NA,"President","DEM","Hillary Clinton",106
-"29","Saunders","Wahoo ward 3 9",NA,"President","DEM","Hillary Clinton",135
-"30","Saunders","Center 10",NA,"President","DEM","Hillary Clinton",51
-"31","Saunders","Cedar Bluffs 11",NA,"President","DEM","Hillary Clinton",130
-"32","Saunders","Marietta 12",NA,"President","DEM","Hillary Clinton",74
-"33","Saunders","District 4 13",NA,"President","DEM","Hillary Clinton",201
-"34","Saunders","Ashland ward 1 14",NA,"President","DEM","Hillary Clinton",141
-"35","Saunders","Ashland ward 2 15",NA,"President","DEM","Hillary Clinton",127
-"36","Saunders","Ashland rural 16",NA,"President","DEM","Hillary Clinton",147
-"37","Saunders","Yutan 17",NA,"President","DEM","Hillary Clinton",175
-"38","Saunders","Provisional ballots ",NA,"President","DEM","Hillary Clinton",14
-"39","Saunders","Early voters ",NA,"President","LIB","Johnson/Weld",68
-"40","Saunders","Valparaiso 1",NA,"President","LIB","Johnson/Weld",16
-"41","Saunders","Weston 2",NA,"President","LIB","Johnson/Weld",20
-"42","Saunders","Prague 3",NA,"President","LIB","Johnson/Weld",17
-"43","Saunders","Malmo 4",NA,"President","LIB","Johnson/Weld",14
-"44","Saunders","Ceresco 5",NA,"President","LIB","Johnson/Weld",41
-"45","Saunders","Wahoo rural 6",NA,"President","LIB","Johnson/Weld",23
-"46","Saunders","Wahoo ward 1 7",NA,"President","LIB","Johnson/Weld",32
-"47","Saunders","Wahoo ward 2 8",NA,"President","LIB","Johnson/Weld",24
-"48","Saunders","Wahoo ward 3 9",NA,"President","LIB","Johnson/Weld",23
-"49","Saunders","Center 10",NA,"President","LIB","Johnson/Weld",21
-"50","Saunders","Cedar Bluffs 11",NA,"President","LIB","Johnson/Weld",29
-"51","Saunders","Marietta 12",NA,"President","LIB","Johnson/Weld",18
-"52","Saunders","District 4 13",NA,"President","LIB","Johnson/Weld",19
-"53","Saunders","Ashland ward 1 14",NA,"President","LIB","Johnson/Weld",34
-"54","Saunders","Ashland ward 2 15",NA,"President","LIB","Johnson/Weld",30
-"55","Saunders","Ashland rural 16",NA,"President","LIB","Johnson/Weld",29
-"56","Saunders","Yutan 17",NA,"President","LIB","Johnson/Weld",50
-"57","Saunders","Provisional ballots ",NA,"President","LIB","Johnson/Weld",7
-"58","Saunders","Early voters ",NA,"President","PET","Jill Stein",14
-"59","Saunders","Valparaiso 1",NA,"President","PET","Jill Stein",7
-"60","Saunders","Weston 2",NA,"President","PET","Jill Stein",3
-"61","Saunders","Prague 3",NA,"President","PET","Jill Stein",4
-"62","Saunders","Malmo 4",NA,"President","PET","Jill Stein",0
-"63","Saunders","Ceresco 5",NA,"President","PET","Jill Stein",8
-"64","Saunders","Wahoo rural 6",NA,"President","PET","Jill Stein",4
-"65","Saunders","Wahoo ward 1 7",NA,"President","PET","Jill Stein",9
-"66","Saunders","Wahoo ward 2 8",NA,"President","PET","Jill Stein",2
-"67","Saunders","Wahoo ward 3 9",NA,"President","PET","Jill Stein",4
-"68","Saunders","Center 10",NA,"President","PET","Jill Stein",2
-"69","Saunders","Cedar Bluffs 11",NA,"President","PET","Jill Stein",9
-"70","Saunders","Marietta 12",NA,"President","PET","Jill Stein",3
-"71","Saunders","District 4 13",NA,"President","PET","Jill Stein",1
-"72","Saunders","Ashland ward 1 14",NA,"President","PET","Jill Stein",3
-"73","Saunders","Ashland ward 2 15",NA,"President","PET","Jill Stein",6
-"74","Saunders","Ashland rural 16",NA,"President","PET","Jill Stein",6
-"75","Saunders","Yutan 17",NA,"President","PET","Jill Stein",10
-"76","Saunders","Provisional ballots ",NA,"President","PET","Jill Stein",2
-"77","Saunders","Early voters ",NA,"President","NON","Write-ins",29
-"78","Saunders","Valparaiso 1",NA,"President","NON","Write-ins",6
-"79","Saunders","Weston 2",NA,"President","NON","Write-ins",7
-"80","Saunders","Prague 3",NA,"President","NON","Write-ins",7
-"81","Saunders","Malmo 4",NA,"President","NON","Write-ins",4
-"82","Saunders","Ceresco 5",NA,"President","NON","Write-ins",12
-"83","Saunders","Wahoo rural 6",NA,"President","NON","Write-ins",5
-"84","Saunders","Wahoo ward 1 7",NA,"President","NON","Write-ins",10
-"85","Saunders","Wahoo ward 2 8",NA,"President","NON","Write-ins",11
-"86","Saunders","Wahoo ward 3 9",NA,"President","NON","Write-ins",17
-"87","Saunders","Center 10",NA,"President","NON","Write-ins",5
-"88","Saunders","Cedar Bluffs 11",NA,"President","NON","Write-ins",6
-"89","Saunders","Marietta 12",NA,"President","NON","Write-ins",2
-"90","Saunders","District 4 13",NA,"President","NON","Write-ins",12
-"91","Saunders","Ashland ward 1 14",NA,"President","NON","Write-ins",4
-"92","Saunders","Ashland ward 2 15",NA,"President","NON","Write-ins",10
-"93","Saunders","Ashland rural 16",NA,"President","NON","Write-ins",12
-"94","Saunders","Yutan 17",NA,"President","NON","Write-ins",11
-"95","Saunders","Provisional ballots ",NA,"President","NON","Write-ins",3
-"96","Saunders","Early voters ",1,"U.S. House","REP","Jeff Fortenberry",1090
-"97","Saunders","Valparaiso 1",1,"U.S. House","REP","Jeff Fortenberry",465
-"98","Saunders","Weston 2",1,"U.S. House","REP","Jeff Fortenberry",293
-"99","Saunders","Prague 3",1,"U.S. House","REP","Jeff Fortenberry",330
-"100","Saunders","Malmo 4",1,"U.S. House","REP","Jeff Fortenberry",219
-"101","Saunders","Ceresco 5",1,"U.S. House","REP","Jeff Fortenberry",572
-"102","Saunders","Wahoo rural 6",1,"U.S. House","REP","Jeff Fortenberry",321
-"103","Saunders","Wahoo ward 1 7",1,"U.S. House","REP","Jeff Fortenberry",505
-"104","Saunders","Wahoo ward 2 8",1,"U.S. House","REP","Jeff Fortenberry",407
-"105","Saunders","Wahoo ward 3 9",1,"U.S. House","REP","Jeff Fortenberry",406
-"106","Saunders","Center 10",1,"U.S. House","REP","Jeff Fortenberry",223
-"107","Saunders","Cedar Bluffs 11",1,"U.S. House","REP","Jeff Fortenberry",471
-"108","Saunders","Marietta 12",1,"U.S. House","REP","Jeff Fortenberry",289
-"109","Saunders","District 4 13",1,"U.S. House","REP","Jeff Fortenberry",709
-"110","Saunders","Ashland ward 1 14",1,"U.S. House","REP","Jeff Fortenberry",311
-"111","Saunders","Ashland ward 2 15",1,"U.S. House","REP","Jeff Fortenberry",353
-"112","Saunders","Ashland rural 16",1,"U.S. House","REP","Jeff Fortenberry",476
-"113","Saunders","Yutan 17",1,"U.S. House","REP","Jeff Fortenberry",776
-"114","Saunders","Provisional ballots ",1,"U.S. House","REP","Jeff Fortenberry",71
-"115","Saunders","Early voters ",1,"U.S. House","DEM","Daniel M. Wik",429
-"116","Saunders","Valparaiso 1",1,"U.S. House","DEM","Daniel M. Wik",141
-"117","Saunders","Weston 2",1,"U.S. House","DEM","Daniel M. Wik",70
-"118","Saunders","Prague 3",1,"U.S. House","DEM","Daniel M. Wik",66
-"119","Saunders","Malmo 4",1,"U.S. House","DEM","Daniel M. Wik",41
-"120","Saunders","Ceresco 5",1,"U.S. House","DEM","Daniel M. Wik",156
-"121","Saunders","Wahoo rural 6",1,"U.S. House","DEM","Daniel M. Wik",46
-"122","Saunders","Wahoo ward 1 7",1,"U.S. House","DEM","Daniel M. Wik",146
-"123","Saunders","Wahoo ward 2 8",1,"U.S. House","DEM","Daniel M. Wik",94
-"124","Saunders","Wahoo ward 3 9",1,"U.S. House","DEM","Daniel M. Wik",114
-"125","Saunders","Center 10",1,"U.S. House","DEM","Daniel M. Wik",47
-"126","Saunders","Cedar Bluffs 11",1,"U.S. House","DEM","Daniel M. Wik",119
-"127","Saunders","Marietta 12",1,"U.S. House","DEM","Daniel M. Wik",59
-"128","Saunders","District 4 13",1,"U.S. House","DEM","Daniel M. Wik",143
-"129","Saunders","Ashland ward 1 14",1,"U.S. House","DEM","Daniel M. Wik",121
-"130","Saunders","Ashland ward 2 15",1,"U.S. House","DEM","Daniel M. Wik",105
-"131","Saunders","Ashland rural 16",1,"U.S. House","DEM","Daniel M. Wik",128
-"132","Saunders","Yutan 17",1,"U.S. House","DEM","Daniel M. Wik",163
-"133","Saunders","Provisional ballots ",1,"U.S. House","DEM","Daniel M. Wik",15
-"134","Saunders","Early voters ",1,"U.S. House","NON","Write-ins",3
-"135","Saunders","Valparaiso 1",1,"U.S. House","NON","Write-ins",1
-"136","Saunders","Weston 2",1,"U.S. House","NON","Write-ins",2
-"137","Saunders","Prague 3",1,"U.S. House","NON","Write-ins",0
-"138","Saunders","Malmo 4",1,"U.S. House","NON","Write-ins",1
-"139","Saunders","Ceresco 5",1,"U.S. House","NON","Write-ins",1
-"140","Saunders","Wahoo rural 6",1,"U.S. House","NON","Write-ins",2
-"141","Saunders","Wahoo ward 1 7",1,"U.S. House","NON","Write-ins",0
-"142","Saunders","Wahoo ward 2 8",1,"U.S. House","NON","Write-ins",0
-"143","Saunders","Wahoo ward 3 9",1,"U.S. House","NON","Write-ins",2
-"144","Saunders","Center 10",1,"U.S. House","NON","Write-ins",2
-"145","Saunders","Cedar Bluffs 11",1,"U.S. House","NON","Write-ins",0
-"146","Saunders","Marietta 12",1,"U.S. House","NON","Write-ins",0
-"147","Saunders","District 4 13",1,"U.S. House","NON","Write-ins",3
-"148","Saunders","Ashland ward 1 14",1,"U.S. House","NON","Write-ins",3
-"149","Saunders","Ashland ward 2 15",1,"U.S. House","NON","Write-ins",3
-"150","Saunders","Ashland rural 16",1,"U.S. House","NON","Write-ins",1
-"151","Saunders","Yutan 17",1,"U.S. House","NON","Write-ins",4
-"152","Saunders","Provisional ballots ",1,"U.S. House","NON","Write-ins",0
+,county,precinct,district,office,party,candidate,votes
+1,Saunders,Early voters,NA,President,REP,Donald J. Trump,974
+2,Saunders,Valparaiso 1,NA,President,REP,Donald J. Trump,441
+3,Saunders,Weston 2,NA,President,REP,Donald J. Trump,280
+4,Saunders,Prague 3,NA,President,REP,Donald J. Trump,311
+5,Saunders,Malmo 4,NA,President,REP,Donald J. Trump,200
+6,Saunders,Ceresco 5,NA,President,REP,Donald J. Trump,507
+7,Saunders,Wahoo rural 6,NA,President,REP,Donald J. Trump,304
+8,Saunders,Wahoo ward 1 7,NA,President,REP,Donald J. Trump,430
+9,Saunders,Wahoo ward 2 8,NA,President,REP,Donald J. Trump,369
+10,Saunders,Wahoo ward 3 9,NA,President,REP,Donald J. Trump,365
+11,Saunders,Center 10,NA,President,REP,Donald J. Trump,205
+12,Saunders,Cedar Bluffs 11,NA,President,REP,Donald J. Trump,439
+13,Saunders,Marietta 12,NA,President,REP,Donald J. Trump,264
+14,Saunders,District 4 13,NA,President,REP,Donald J. Trump,654
+15,Saunders,Ashland ward 1 14,NA,President,REP,Donald J. Trump,275
+16,Saunders,Ashland ward 2 15,NA,President,REP,Donald J. Trump,305
+17,Saunders,Ashland rural 16,NA,President,REP,Donald J. Trump,425
+18,Saunders,Yutan 17,NA,President,REP,Donald J. Trump,740
+19,Saunders,Provisional ballots,NA,President,REP,Donald J. Trump,67
+20,Saunders,Early voters,NA,President,DEM,Hillary Clinton,493
+21,Saunders,Valparaiso 1,NA,President,DEM,Hillary Clinton,144
+22,Saunders,Weston 2,NA,President,DEM,Hillary Clinton,60
+23,Saunders,Prague 3,NA,President,DEM,Hillary Clinton,67
+24,Saunders,Malmo 4,NA,President,DEM,Hillary Clinton,48
+25,Saunders,Ceresco 5,NA,President,DEM,Hillary Clinton,181
+26,Saunders,Wahoo rural 6,NA,President,DEM,Hillary Clinton,49
+27,Saunders,Wahoo ward 1 7,NA,President,DEM,Hillary Clinton,180
+28,Saunders,Wahoo ward 2 8,NA,President,DEM,Hillary Clinton,106
+29,Saunders,Wahoo ward 3 9,NA,President,DEM,Hillary Clinton,135
+30,Saunders,Center 10,NA,President,DEM,Hillary Clinton,51
+31,Saunders,Cedar Bluffs 11,NA,President,DEM,Hillary Clinton,130
+32,Saunders,Marietta 12,NA,President,DEM,Hillary Clinton,74
+33,Saunders,District 4 13,NA,President,DEM,Hillary Clinton,201
+34,Saunders,Ashland ward 1 14,NA,President,DEM,Hillary Clinton,141
+35,Saunders,Ashland ward 2 15,NA,President,DEM,Hillary Clinton,127
+36,Saunders,Ashland rural 16,NA,President,DEM,Hillary Clinton,147
+37,Saunders,Yutan 17,NA,President,DEM,Hillary Clinton,175
+38,Saunders,Provisional ballots,NA,President,DEM,Hillary Clinton,14
+39,Saunders,Early voters,NA,President,LIB,Johnson/Weld,68
+40,Saunders,Valparaiso 1,NA,President,LIB,Johnson/Weld,16
+41,Saunders,Weston 2,NA,President,LIB,Johnson/Weld,20
+42,Saunders,Prague 3,NA,President,LIB,Johnson/Weld,17
+43,Saunders,Malmo 4,NA,President,LIB,Johnson/Weld,14
+44,Saunders,Ceresco 5,NA,President,LIB,Johnson/Weld,41
+45,Saunders,Wahoo rural 6,NA,President,LIB,Johnson/Weld,23
+46,Saunders,Wahoo ward 1 7,NA,President,LIB,Johnson/Weld,32
+47,Saunders,Wahoo ward 2 8,NA,President,LIB,Johnson/Weld,24
+48,Saunders,Wahoo ward 3 9,NA,President,LIB,Johnson/Weld,23
+49,Saunders,Center 10,NA,President,LIB,Johnson/Weld,21
+50,Saunders,Cedar Bluffs 11,NA,President,LIB,Johnson/Weld,29
+51,Saunders,Marietta 12,NA,President,LIB,Johnson/Weld,18
+52,Saunders,District 4 13,NA,President,LIB,Johnson/Weld,19
+53,Saunders,Ashland ward 1 14,NA,President,LIB,Johnson/Weld,34
+54,Saunders,Ashland ward 2 15,NA,President,LIB,Johnson/Weld,30
+55,Saunders,Ashland rural 16,NA,President,LIB,Johnson/Weld,29
+56,Saunders,Yutan 17,NA,President,LIB,Johnson/Weld,50
+57,Saunders,Provisional ballots,NA,President,LIB,Johnson/Weld,7
+58,Saunders,Early voters,NA,President,PET,Jill Stein,14
+59,Saunders,Valparaiso 1,NA,President,PET,Jill Stein,7
+60,Saunders,Weston 2,NA,President,PET,Jill Stein,3
+61,Saunders,Prague 3,NA,President,PET,Jill Stein,4
+62,Saunders,Malmo 4,NA,President,PET,Jill Stein,0
+63,Saunders,Ceresco 5,NA,President,PET,Jill Stein,8
+64,Saunders,Wahoo rural 6,NA,President,PET,Jill Stein,4
+65,Saunders,Wahoo ward 1 7,NA,President,PET,Jill Stein,9
+66,Saunders,Wahoo ward 2 8,NA,President,PET,Jill Stein,2
+67,Saunders,Wahoo ward 3 9,NA,President,PET,Jill Stein,4
+68,Saunders,Center 10,NA,President,PET,Jill Stein,2
+69,Saunders,Cedar Bluffs 11,NA,President,PET,Jill Stein,9
+70,Saunders,Marietta 12,NA,President,PET,Jill Stein,3
+71,Saunders,District 4 13,NA,President,PET,Jill Stein,1
+72,Saunders,Ashland ward 1 14,NA,President,PET,Jill Stein,3
+73,Saunders,Ashland ward 2 15,NA,President,PET,Jill Stein,6
+74,Saunders,Ashland rural 16,NA,President,PET,Jill Stein,6
+75,Saunders,Yutan 17,NA,President,PET,Jill Stein,10
+76,Saunders,Provisional ballots,NA,President,PET,Jill Stein,2
+77,Saunders,Early voters,NA,President,NON,Write-ins,29
+78,Saunders,Valparaiso 1,NA,President,NON,Write-ins,6
+79,Saunders,Weston 2,NA,President,NON,Write-ins,7
+80,Saunders,Prague 3,NA,President,NON,Write-ins,7
+81,Saunders,Malmo 4,NA,President,NON,Write-ins,4
+82,Saunders,Ceresco 5,NA,President,NON,Write-ins,12
+83,Saunders,Wahoo rural 6,NA,President,NON,Write-ins,5
+84,Saunders,Wahoo ward 1 7,NA,President,NON,Write-ins,10
+85,Saunders,Wahoo ward 2 8,NA,President,NON,Write-ins,11
+86,Saunders,Wahoo ward 3 9,NA,President,NON,Write-ins,17
+87,Saunders,Center 10,NA,President,NON,Write-ins,5
+88,Saunders,Cedar Bluffs 11,NA,President,NON,Write-ins,6
+89,Saunders,Marietta 12,NA,President,NON,Write-ins,2
+90,Saunders,District 4 13,NA,President,NON,Write-ins,12
+91,Saunders,Ashland ward 1 14,NA,President,NON,Write-ins,4
+92,Saunders,Ashland ward 2 15,NA,President,NON,Write-ins,10
+93,Saunders,Ashland rural 16,NA,President,NON,Write-ins,12
+94,Saunders,Yutan 17,NA,President,NON,Write-ins,11
+95,Saunders,Provisional ballots,NA,President,NON,Write-ins,3
+96,Saunders,Early voters,1,U.S. House,REP,Jeff Fortenberry,1090
+97,Saunders,Valparaiso 1,1,U.S. House,REP,Jeff Fortenberry,465
+98,Saunders,Weston 2,1,U.S. House,REP,Jeff Fortenberry,293
+99,Saunders,Prague 3,1,U.S. House,REP,Jeff Fortenberry,330
+100,Saunders,Malmo 4,1,U.S. House,REP,Jeff Fortenberry,219
+101,Saunders,Ceresco 5,1,U.S. House,REP,Jeff Fortenberry,572
+102,Saunders,Wahoo rural 6,1,U.S. House,REP,Jeff Fortenberry,321
+103,Saunders,Wahoo ward 1 7,1,U.S. House,REP,Jeff Fortenberry,505
+104,Saunders,Wahoo ward 2 8,1,U.S. House,REP,Jeff Fortenberry,407
+105,Saunders,Wahoo ward 3 9,1,U.S. House,REP,Jeff Fortenberry,406
+106,Saunders,Center 10,1,U.S. House,REP,Jeff Fortenberry,223
+107,Saunders,Cedar Bluffs 11,1,U.S. House,REP,Jeff Fortenberry,471
+108,Saunders,Marietta 12,1,U.S. House,REP,Jeff Fortenberry,289
+109,Saunders,District 4 13,1,U.S. House,REP,Jeff Fortenberry,709
+110,Saunders,Ashland ward 1 14,1,U.S. House,REP,Jeff Fortenberry,311
+111,Saunders,Ashland ward 2 15,1,U.S. House,REP,Jeff Fortenberry,353
+112,Saunders,Ashland rural 16,1,U.S. House,REP,Jeff Fortenberry,476
+113,Saunders,Yutan 17,1,U.S. House,REP,Jeff Fortenberry,776
+114,Saunders,Provisional ballots,1,U.S. House,REP,Jeff Fortenberry,71
+115,Saunders,Early voters,1,U.S. House,DEM,Daniel M. Wik,429
+116,Saunders,Valparaiso 1,1,U.S. House,DEM,Daniel M. Wik,141
+117,Saunders,Weston 2,1,U.S. House,DEM,Daniel M. Wik,70
+118,Saunders,Prague 3,1,U.S. House,DEM,Daniel M. Wik,66
+119,Saunders,Malmo 4,1,U.S. House,DEM,Daniel M. Wik,41
+120,Saunders,Ceresco 5,1,U.S. House,DEM,Daniel M. Wik,156
+121,Saunders,Wahoo rural 6,1,U.S. House,DEM,Daniel M. Wik,46
+122,Saunders,Wahoo ward 1 7,1,U.S. House,DEM,Daniel M. Wik,146
+123,Saunders,Wahoo ward 2 8,1,U.S. House,DEM,Daniel M. Wik,94
+124,Saunders,Wahoo ward 3 9,1,U.S. House,DEM,Daniel M. Wik,114
+125,Saunders,Center 10,1,U.S. House,DEM,Daniel M. Wik,47
+126,Saunders,Cedar Bluffs 11,1,U.S. House,DEM,Daniel M. Wik,119
+127,Saunders,Marietta 12,1,U.S. House,DEM,Daniel M. Wik,59
+128,Saunders,District 4 13,1,U.S. House,DEM,Daniel M. Wik,143
+129,Saunders,Ashland ward 1 14,1,U.S. House,DEM,Daniel M. Wik,121
+130,Saunders,Ashland ward 2 15,1,U.S. House,DEM,Daniel M. Wik,105
+131,Saunders,Ashland rural 16,1,U.S. House,DEM,Daniel M. Wik,128
+132,Saunders,Yutan 17,1,U.S. House,DEM,Daniel M. Wik,163
+133,Saunders,Provisional ballots,1,U.S. House,DEM,Daniel M. Wik,15
+134,Saunders,Early voters,1,U.S. House,NON,Write-ins,3
+135,Saunders,Valparaiso 1,1,U.S. House,NON,Write-ins,1
+136,Saunders,Weston 2,1,U.S. House,NON,Write-ins,2
+137,Saunders,Prague 3,1,U.S. House,NON,Write-ins,0
+138,Saunders,Malmo 4,1,U.S. House,NON,Write-ins,1
+139,Saunders,Ceresco 5,1,U.S. House,NON,Write-ins,1
+140,Saunders,Wahoo rural 6,1,U.S. House,NON,Write-ins,2
+141,Saunders,Wahoo ward 1 7,1,U.S. House,NON,Write-ins,0
+142,Saunders,Wahoo ward 2 8,1,U.S. House,NON,Write-ins,0
+143,Saunders,Wahoo ward 3 9,1,U.S. House,NON,Write-ins,2
+144,Saunders,Center 10,1,U.S. House,NON,Write-ins,2
+145,Saunders,Cedar Bluffs 11,1,U.S. House,NON,Write-ins,0
+146,Saunders,Marietta 12,1,U.S. House,NON,Write-ins,0
+147,Saunders,District 4 13,1,U.S. House,NON,Write-ins,3
+148,Saunders,Ashland ward 1 14,1,U.S. House,NON,Write-ins,3
+149,Saunders,Ashland ward 2 15,1,U.S. House,NON,Write-ins,3
+150,Saunders,Ashland rural 16,1,U.S. House,NON,Write-ins,1
+151,Saunders,Yutan 17,1,U.S. House,NON,Write-ins,4
+152,Saunders,Provisional ballots,1,U.S. House,NON,Write-ins,0

--- a/2016/counties/20161108__ne__general__wheeler__precinct.csv
+++ b/2016/counties/20161108__ne__general__wheeler__precinct.csv
@@ -1,221 +1,221 @@
-"","county","precinct","district","office","party","candidate","votes"
-"1","Wheeler","Bartlett","","President","REP","Donald J. Trump",271
-"2","Wheeler","Ericson","","President","REP","Donald J. Trump",106
-"3","Wheeler","Bartlett","","President","DEM","Hillary Clinton",36
-"4","Wheeler","Ericson","","President","DEM","Hillary Clinton",26
-"5","Wheeler","Bartlett","","President","LIB","Johnson/Weld",13
-"6","Wheeler","Ericson","","President","LIB","Johnson/Weld",4
-"7","Wheeler","Bartlett","","President","PET","Jill Stein",4
-"8","Wheeler","Ericson","","President","PET","Jill Stein",0
-"9","Wheeler","Bartlett","","President","NON","Write-ins",4
-"10","Wheeler","Ericson","","President","NON","Write-ins",1
-"11","Wheeler","Bartlett","3","U.S. House","REP","Adrian Smith",292
-"12","Wheeler","Ericson","3","U.S. House","REP","Adrian Smith",114
-"13","Wheeler","Bartlett","3","U.S. House","NON","Write-ins",2
-"14","Wheeler","Ericson","3","U.S. House","NON","Write-ins",1
-"15","Wheeler","Bartlett","","Public Service Commissioner","NON","Rod Johnson",241
-"16","Wheeler","Ericson","","Public Service Commissioner","NON","Rod Johnson",105
-"17","Wheeler","Bartlett","","Public Service Commissioner","NON","Write-ins",0
-"18","Wheeler","Ericson","","Public Service Commissioner","NON","Write-ins",0
-"19","Wheeler","Bartlett","","County Commissioner","NON","Jesse Plugge",149
-"20","Wheeler","Ericson","","County Commissioner","NON","Jesse Plugge",73
-"21","Wheeler","Bartlett","","County Commissioner","NON","Jim Hoerle",168
-"22","Wheeler","Ericson","","County Commissioner","NON","Jim Hoerle",60
-"23","Wheeler","Bartlett","","County Commissioner","NON","Write-ins",0
-"24","Wheeler","Ericson","","County Commissioner","NON","Write-ins",0
-"25","Wheeler","Bartlett","41","Legislature","NON","Tom Briese",236
-"26","Wheeler","Ericson","41","Legislature","NON","Tom Briese",92
-"27","Wheeler","Bartlett","41","Legislature","NON","Write-ins",0
-"28","Wheeler","Ericson","41","Legislature","NON","Write-ins",0
-"29","Wheeler","Bartlett","6","University of Nebraska Board of Regents","NON","Marsha E. Fangmeyer",73
-"30","Wheeler","Ericson","6","University of Nebraska Board of Regents","NON","Marsha E. Fangmeyer",22
-"31","Wheeler","Bartlett","6","University of Nebraska Board of Regents","NON","Paul Kenney",139
-"32","Wheeler","Ericson","6","University of Nebraska Board of Regents","NON","Paul Kenney",65
-"33","Wheeler","Bartlett","6","University of Nebraska Board of Regents","NON","Write-ins",1
-"34","Wheeler","Ericson","6","University of Nebraska Board of Regents","NON","Write-ins",0
-"35","Wheeler","Bartlett","","Retain Chief Justice of the Supreme Court Michael Heavican","NON","Yes",156
-"36","Wheeler","Ericson","","Retain Chief Justice of the Supreme Court Michael Heavican","NON","Yes",59
-"37","Wheeler","Bartlett","","Retain Chief Justice of the Supreme Court Michael Heavican","NON","No",65
-"38","Wheeler","Ericson","","Retain Chief Justice of the Supreme Court Michael Heavican","NON","No",38
-"39","Wheeler","Bartlett","","Retain William B. Cassel","NON","Yes",158
-"40","Wheeler","Ericson","","Retain William B. Cassel","NON","Yes",61
-"41","Wheeler","Bartlett","","Retain William B. Cassel","NON","No",57
-"42","Wheeler","Ericson","","Retain William B. Cassel","NON","No",31
-"43","Wheeler","Bartlett","","Retain Francie Riedmann Weis","NON","Yes",137
-"44","Wheeler","Ericson","","Retain Francie Riedmann Weis","NON","Yes",52
-"45","Wheeler","Bartlett","","Retain Francie Riedmann Weis","NON","No",64
-"46","Wheeler","Ericson","","Retain Francie Riedmann Weis","NON","No",38
-"47","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich","NON","Yes",144
-"48","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich","NON","Yes",53
-"49","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich","NON","No",59
-"50","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich","NON","No",36
-"51","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge John R. Hoffert","NON","Yes",151
-"52","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge John R. Hoffert","NON","Yes",56
-"53","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge John R. Hoffert","NON","No",54
-"54","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge John R. Hoffert","NON","No",28
-"55","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge James R. Coe","NON","Yes",147
-"56","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge James R. Coe","NON","Yes",55
-"57","Wheeler","Bartlett","","Retain Nebraska Workers' Compensation Court Judge James R. Coe","NON","No",55
-"58","Wheeler","Ericson","","Retain Nebraska Workers' Compensation Court Judge James R. Coe","NON","No",27
-"59","Wheeler","Bartlett","","Retain Karin Noakes","NON","Yes",143
-"60","Wheeler","Ericson","","Retain Karin Noakes","NON","Yes",54
-"61","Wheeler","Bartlett","","Retain Karin Noakes","NON","No",63
-"62","Wheeler","Ericson","","Retain Karin Noakes","NON","No",34
-"63","Wheeler","Bartlett","","Retain Tami K. Schendt","NON","Yes",143
-"64","Wheeler","Ericson","","Retain Tami K. Schendt","NON","Yes",55
-"65","Wheeler","Bartlett","","Retain Tami K. Schendt","NON","No",59
-"66","Wheeler","Ericson","","Retain Tami K. Schendt","NON","No",31
-"67","Wheeler","Bartlett","1","Northeast Community College Board","NON","Shirley J. Petsche",203
-"68","Wheeler","Ericson","1","Northeast Community College Board","NON","Shirley J. Petsche",83
-"69","Wheeler","Bartlett","1","Northeast Community College Board","NON","Write-ins",1
-"70","Wheeler","Ericson","1","Northeast Community College Board","NON","Write-ins",0
-"71","Wheeler","Bartlett","At-large","Northeast Community College Board","NON","Ted Hillman",97
-"72","Wheeler","Ericson","At-large","Northeast Community College Board","NON","Ted Hillman",40
-"73","Wheeler","Bartlett","At-large","Northeast Community College Board","NON","Jeffrey M. Scherer",89
-"74","Wheeler","Ericson","At-large","Northeast Community College Board","NON","Jeffrey M. Scherer",39
-"75","Wheeler","Bartlett","At-large","Northeast Community College Board","NON","Write-ins",0
-"76","Wheeler","Ericson","At-large","Northeast Community College Board","NON","Write-ins",0
-"77","Wheeler","Bartlett","2","Lower Loup Natural Resources District","NON","Alan D. Petersen",166
-"78","Wheeler","Ericson","2","Lower Loup Natural Resources District","NON","Alan D. Petersen",89
-"79","Wheeler","Bartlett","2","Lower Loup Natural Resources District","NON","Write-ins",6
-"80","Wheeler","Ericson","2","Lower Loup Natural Resources District","NON","Write-ins",7
-"81","Wheeler","Bartlett","6","Lower Loup Natural Resources District","NON","Write-ins",54
-"82","Wheeler","Ericson","6","Lower Loup Natural Resources District","NON","Write-ins",29
-"83","Wheeler","Bartlett","1","Upper Elkhorn Natural Resources District","NON","Roy Stewart",48
-"84","Wheeler","Ericson","1","Upper Elkhorn Natural Resources District","NON","Roy Stewart",0
-"85","Wheeler","Bartlett","1","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"86","Wheeler","Ericson","1","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"87","Wheeler","Bartlett","2","Upper Elkhorn Natural Resources District","NON","Curtis Gotschall",51
-"88","Wheeler","Ericson","2","Upper Elkhorn Natural Resources District","NON","Curtis Gotschall",0
-"89","Wheeler","Bartlett","2","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"90","Wheeler","Ericson","2","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"91","Wheeler","Bartlett","3","Upper Elkhorn Natural Resources District","NON","Gene Kelly",53
-"92","Wheeler","Ericson","3","Upper Elkhorn Natural Resources District","NON","Gene Kelly",0
-"93","Wheeler","Bartlett","3","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"94","Wheeler","Ericson","3","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"95","Wheeler","Bartlett","4","Upper Elkhorn Natural Resources District","NON","Gary L. Bartak",58
-"96","Wheeler","Ericson","4","Upper Elkhorn Natural Resources District","NON","Gary L. Bartak",0
-"97","Wheeler","Bartlett","4","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"98","Wheeler","Ericson","4","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"99","Wheeler","Bartlett","5","Upper Elkhorn Natural Resources District","NON","Mark Carpenter",17
-"100","Wheeler","Ericson","5","Upper Elkhorn Natural Resources District","NON","Mark Carpenter",0
-"101","Wheeler","Bartlett","5","Upper Elkhorn Natural Resources District","NON","Issac Wright",35
-"102","Wheeler","Ericson","5","Upper Elkhorn Natural Resources District","NON","Issac Wright",0
-"103","Wheeler","Bartlett","5","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"104","Wheeler","Ericson","5","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"105","Wheeler","Bartlett","6","Upper Elkhorn Natural Resources District","NON","Ted D. Hughes",48
-"106","Wheeler","Ericson","6","Upper Elkhorn Natural Resources District","NON","Ted D. Hughes",0
-"107","Wheeler","Bartlett","6","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"108","Wheeler","Ericson","6","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"109","Wheeler","Bartlett","7","Upper Elkhorn Natural Resources District","NON","Mark Schrage",29
-"110","Wheeler","Ericson","7","Upper Elkhorn Natural Resources District","NON","Mark Schrage",0
-"111","Wheeler","Bartlett","7","Upper Elkhorn Natural Resources District","NON","Keith Heithoff",26
-"112","Wheeler","Ericson","7","Upper Elkhorn Natural Resources District","NON","Keith Heithoff",0
-"113","Wheeler","Bartlett","7","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"114","Wheeler","Ericson","7","Upper Elkhorn Natural Resources District","NON","Write-ins",0
-"115","Wheeler","Bartlett","1","Cornhusker Public Power District Board","NON","William J. Robinson",36
-"116","Wheeler","Ericson","1","Cornhusker Public Power District Board","NON","William J. Robinson",0
-"117","Wheeler","Bartlett","1","Cornhusker Public Power District Board","NON","Write-ins",0
-"118","Wheeler","Ericson","1","Cornhusker Public Power District Board","NON","Write-ins",0
-"119","Wheeler","Bartlett","3","Elkhorn Rural Public Power District","NON","Joseph G. Thiele",63
-"120","Wheeler","Ericson","3","Elkhorn Rural Public Power District","NON","Joseph G. Thiele",0
-"121","Wheeler","Bartlett","3","Elkhorn Rural Public Power District","NON","Write-ins",0
-"122","Wheeler","Ericson","3","Elkhorn Rural Public Power District","NON","Write-ins",0
-"123","Wheeler","Bartlett","6-year term","Loup Valley Rural Public Power District","NON","Larry O. White",60
-"124","Wheeler","Ericson","6-year term","Loup Valley Rural Public Power District","NON","Larry O. White",65
-"125","Wheeler","Bartlett","6-year term","Loup Valley Rural Public Power District","NON","Andrew Augustyn",47
-"126","Wheeler","Ericson","6-year term","Loup Valley Rural Public Power District","NON","Andrew Augustyn",44
-"127","Wheeler","Bartlett","6-year term","Loup Valley Rural Public Power District","NON","Michael Cruikshank",65
-"128","Wheeler","Ericson","6-year term","Loup Valley Rural Public Power District","NON","Michael Cruikshank",47
-"129","Wheeler","Bartlett","6-year term","Loup Valley Rural Public Power District","NON","Randy Wadas",61
-"130","Wheeler","Ericson","6-year term","Loup Valley Rural Public Power District","NON","Randy Wadas",62
-"131","Wheeler","Bartlett","6-year term","Loup Valley Rural Public Power District","NON","Write-ins",1
-"132","Wheeler","Ericson","6-year term","Loup Valley Rural Public Power District","NON","Write-ins",2
-"133","Wheeler","Bartlett","4-year term","Loup Valley Rural Public Power District","NON","Marvin A. Scheideler",33
-"134","Wheeler","Ericson","4-year term","Loup Valley Rural Public Power District","NON","Marvin A. Scheideler",31
-"135","Wheeler","Bartlett","4-year term","Loup Valley Rural Public Power District","NON","Ricky S. Koch",23
-"136","Wheeler","Ericson","4-year term","Loup Valley Rural Public Power District","NON","Ricky S. Koch",18
-"137","Wheeler","Bartlett","4-year term","Loup Valley Rural Public Power District","NON","Cody E. Freouf",51
-"138","Wheeler","Ericson","4-year term","Loup Valley Rural Public Power District","NON","Cody E. Freouf",62
-"139","Wheeler","Bartlett","4-year term","Loup Valley Rural Public Power District","NON","Write-ins",1
-"140","Wheeler","Ericson","4-year term","Loup Valley Rural Public Power District","NON","Write-ins",1
-"141","Wheeler","Bartlett","","Educational Service Unit 8 Board","NON","Tim Lambert",238
-"142","Wheeler","Ericson","","Educational Service Unit 8 Board","NON","Tim Lambert",87
-"143","Wheeler","Bartlett","","Educational Service Unit 8 Board","NON","Write-ins",0
-"144","Wheeler","Ericson","","Educational Service Unit 8 Board","NON","Write-ins",0
-"145","Wheeler","Bartlett","2","Wheeler Central School Board","NON","Dennis Derner",123
-"146","Wheeler","Ericson","2","Wheeler Central School Board","NON","Dennis Derner",50
-"147","Wheeler","Bartlett","2","Wheeler Central School Board","NON","Jerilee Wright",235
-"148","Wheeler","Ericson","2","Wheeler Central School Board","NON","Jerilee Wright",109
-"149","Wheeler","Bartlett","2","Wheeler Central School Board","NON","Write-ins",17
-"150","Wheeler","Ericson","2","Wheeler Central School Board","NON","Write-ins",13
-"151","Wheeler","Bartlett","3","Wheeler Central School Board","NON","Adam Freouf",246
-"152","Wheeler","Ericson","3","Wheeler Central School Board","NON","Adam Freouf",115
-"153","Wheeler","Bartlett","3","Wheeler Central School Board","NON","Write-ins",4
-"154","Wheeler","Ericson","3","Wheeler Central School Board","NON","Write-ins",4
-"155","Wheeler","Bartlett","4-year term","Elgin Public School Board","NON","Stanley Heithoff",4
-"156","Wheeler","Ericson","4-year term","Elgin Public School Board","NON","Stanley Heithoff",0
-"157","Wheeler","Bartlett","4-year term","Elgin Public School Board","NON","Steve Busteed",8
-"158","Wheeler","Ericson","4-year term","Elgin Public School Board","NON","Steve Busteed",0
-"159","Wheeler","Bartlett","4-year term","Elgin Public School Board","NON","Michael Braband",2
-"160","Wheeler","Ericson","4-year term","Elgin Public School Board","NON","Michael Braband",0
-"161","Wheeler","Bartlett","4-year term","Elgin Public School Board","NON","Douglas Jones",6
-"162","Wheeler","Ericson","4-year term","Elgin Public School Board","NON","Douglas Jones",0
-"163","Wheeler","Bartlett","4-year term","Elgin Public School Board","NON","Write-ins",0
-"164","Wheeler","Ericson","4-year term","Elgin Public School Board","NON","Write-ins",0
-"165","Wheeler","Bartlett","2-year term","Elgin Public School Board","NON","Lisa Welding",8
-"166","Wheeler","Ericson","2-year term","Elgin Public School Board","NON","Lisa Welding",0
-"167","Wheeler","Bartlett","2-year term","Elgin Public School Board","NON","Write-ins",0
-"168","Wheeler","Ericson","2-year term","Elgin Public School Board","NON","Write-ins",0
-"169","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Patti Behnk",2
-"170","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Patti Behnk",0
-"171","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Jarrod Long",0
-"172","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Jarrod Long",0
-"173","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Marty J. Kerkman",2
-"174","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Marty J. Kerkman",0
-"175","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Michael Klabenes",0
-"176","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Michael Klabenes",0
-"177","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Amy Thiele",2
-"178","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Amy Thiele",0
-"179","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Brian King",0
-"180","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Brian King",0
-"181","Wheeler","Bartlett","4-year term","Clearwater School Board","NON","Write-ins",0
-"182","Wheeler","Ericson","4-year term","Clearwater School Board","NON","Write-ins",0
-"183","Wheeler","Bartlett","2-year term","Clearwater School Board","NON","Tom Thiele",2
-"184","Wheeler","Ericson","2-year term","Clearwater School Board","NON","Tom Thiele",0
-"185","Wheeler","Bartlett","2-year term","Clearwater School Board","NON","Write-ins",0
-"186","Wheeler","Ericson","2-year term","Clearwater School Board","NON","Write-ins",0
-"187","Wheeler","Bartlett","","Ewing School Board","NON","Pete Funk",13
-"188","Wheeler","Ericson","","Ewing School Board","NON","Pete Funk",0
-"189","Wheeler","Bartlett","","Ewing School Board","NON","LeRoy M. Napier",7
-"190","Wheeler","Ericson","","Ewing School Board","NON","LeRoy M. Napier",0
-"191","Wheeler","Bartlett","","Ewing School Board","NON","Mark P. Ramold",11
-"192","Wheeler","Ericson","","Ewing School Board","NON","Mark P. Ramold",0
-"193","Wheeler","Bartlett","","Ewing School Board","NON","Ed Nordby",16
-"194","Wheeler","Ericson","","Ewing School Board","NON","Ed Nordby",0
-"195","Wheeler","Bartlett","","Ewing School Board","NON","Write-ins",0
-"196","Wheeler","Ericson","","Ewing School Board","NON","Write-ins",0
-"197","Wheeler","Bartlett","4-year term","Chambers School Board","NON","Lenone F. Koenig ",1
-"198","Wheeler","Ericson","4-year term","Chambers School Board","NON","Lenone F. Koenig ",0
-"199","Wheeler","Bartlett","4-year term","Chambers School Board","NON","Brian McManigal",1
-"200","Wheeler","Ericson","4-year term","Chambers School Board","NON","Brian McManigal",0
-"201","Wheeler","Bartlett","4-year term","Chambers School Board","NON","Write-ins",0
-"202","Wheeler","Ericson","4-year term","Chambers School Board","NON","Write-ins",0
-"203","Wheeler","Bartlett","2-year term","Chambers School Board","NON","Matt Ehlers",1
-"204","Wheeler","Ericson","2-year term","Chambers School Board","NON","Matt Ehlers",0
-"205","Wheeler","Bartlett","2-year term","Chambers School Board","NON","Write-ins",0
-"206","Wheeler","Ericson","2-year term","Chambers School Board","NON","Write-ins",0
-"207","Wheeler","Bartlett","","Bartlett Village Board","NON","Letti Nichols ",58
-"208","Wheeler","Ericson","","Bartlett Village Board","NON","Letti Nichols ",0
-"209","Wheeler","Bartlett","","Bartlett Village Board","NON","Paul Nordhues ",63
-"210","Wheeler","Ericson","","Bartlett Village Board","NON","Paul Nordhues ",0
-"211","Wheeler","Bartlett","","Bartlett Village Board","NON","Write-ins",0
-"212","Wheeler","Ericson","","Bartlett Village Board","NON","Write-ins",0
-"213","Wheeler","Bartlett","","Ericson Village Board","NON","Duane Waddle ",0
-"214","Wheeler","Ericson","","Ericson Village Board","NON","Duane Waddle ",31
-"215","Wheeler","Bartlett","","Ericson Village Board","NON","Jerry B. Horwart ",0
-"216","Wheeler","Ericson","","Ericson Village Board","NON","Jerry B. Horwart ",30
-"217","Wheeler","Bartlett","","Ericson Village Board","NON","William Curry ",0
-"218","Wheeler","Ericson","","Ericson Village Board","NON","William Curry ",49
-"219","Wheeler","Bartlett","","Ericson Village Board","NON","Write-ins",0
-"220","Wheeler","Ericson","","Ericson Village Board","NON","Write-ins",5
+,county,precinct,district,office,party,candidate,votes
+1,Wheeler,Bartlett,,President,REP,Donald J. Trump,271
+2,Wheeler,Ericson,,President,REP,Donald J. Trump,106
+3,Wheeler,Bartlett,,President,DEM,Hillary Clinton,36
+4,Wheeler,Ericson,,President,DEM,Hillary Clinton,26
+5,Wheeler,Bartlett,,President,LIB,Johnson/Weld,13
+6,Wheeler,Ericson,,President,LIB,Johnson/Weld,4
+7,Wheeler,Bartlett,,President,PET,Jill Stein,4
+8,Wheeler,Ericson,,President,PET,Jill Stein,0
+9,Wheeler,Bartlett,,President,NON,Write-ins,4
+10,Wheeler,Ericson,,President,NON,Write-ins,1
+11,Wheeler,Bartlett,3,U.S. House,REP,Adrian Smith,292
+12,Wheeler,Ericson,3,U.S. House,REP,Adrian Smith,114
+13,Wheeler,Bartlett,3,U.S. House,NON,Write-ins,2
+14,Wheeler,Ericson,3,U.S. House,NON,Write-ins,1
+15,Wheeler,Bartlett,,Public Service Commissioner,NON,Rod Johnson,241
+16,Wheeler,Ericson,,Public Service Commissioner,NON,Rod Johnson,105
+17,Wheeler,Bartlett,,Public Service Commissioner,NON,Write-ins,0
+18,Wheeler,Ericson,,Public Service Commissioner,NON,Write-ins,0
+19,Wheeler,Bartlett,,County Commissioner,NON,Jesse Plugge,149
+20,Wheeler,Ericson,,County Commissioner,NON,Jesse Plugge,73
+21,Wheeler,Bartlett,,County Commissioner,NON,Jim Hoerle,168
+22,Wheeler,Ericson,,County Commissioner,NON,Jim Hoerle,60
+23,Wheeler,Bartlett,,County Commissioner,NON,Write-ins,0
+24,Wheeler,Ericson,,County Commissioner,NON,Write-ins,0
+25,Wheeler,Bartlett,41,Legislature,NON,Tom Briese,236
+26,Wheeler,Ericson,41,Legislature,NON,Tom Briese,92
+27,Wheeler,Bartlett,41,Legislature,NON,Write-ins,0
+28,Wheeler,Ericson,41,Legislature,NON,Write-ins,0
+29,Wheeler,Bartlett,6,University of Nebraska Board of Regents,NON,Marsha E. Fangmeyer,73
+30,Wheeler,Ericson,6,University of Nebraska Board of Regents,NON,Marsha E. Fangmeyer,22
+31,Wheeler,Bartlett,6,University of Nebraska Board of Regents,NON,Paul Kenney,139
+32,Wheeler,Ericson,6,University of Nebraska Board of Regents,NON,Paul Kenney,65
+33,Wheeler,Bartlett,6,University of Nebraska Board of Regents,NON,Write-ins,1
+34,Wheeler,Ericson,6,University of Nebraska Board of Regents,NON,Write-ins,0
+35,Wheeler,Bartlett,,Retain Chief Justice of the Supreme Court Michael Heavican,NON,Yes,156
+36,Wheeler,Ericson,,Retain Chief Justice of the Supreme Court Michael Heavican,NON,Yes,59
+37,Wheeler,Bartlett,,Retain Chief Justice of the Supreme Court Michael Heavican,NON,No,65
+38,Wheeler,Ericson,,Retain Chief Justice of the Supreme Court Michael Heavican,NON,No,38
+39,Wheeler,Bartlett,,Retain William B. Cassel,NON,Yes,158
+40,Wheeler,Ericson,,Retain William B. Cassel,NON,Yes,61
+41,Wheeler,Bartlett,,Retain William B. Cassel,NON,No,57
+42,Wheeler,Ericson,,Retain William B. Cassel,NON,No,31
+43,Wheeler,Bartlett,,Retain Francie Riedmann Weis,NON,Yes,137
+44,Wheeler,Ericson,,Retain Francie Riedmann Weis,NON,Yes,52
+45,Wheeler,Bartlett,,Retain Francie Riedmann Weis,NON,No,64
+46,Wheeler,Ericson,,Retain Francie Riedmann Weis,NON,No,38
+47,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich,NON,Yes,144
+48,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich,NON,Yes,53
+49,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich,NON,No,59
+50,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge Daniel R. Fridrich,NON,No,36
+51,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge John R. Hoffert,NON,Yes,151
+52,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge John R. Hoffert,NON,Yes,56
+53,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge John R. Hoffert,NON,No,54
+54,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge John R. Hoffert,NON,No,28
+55,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge James R. Coe,NON,Yes,147
+56,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge James R. Coe,NON,Yes,55
+57,Wheeler,Bartlett,,Retain Nebraska Workers' Compensation Court Judge James R. Coe,NON,No,55
+58,Wheeler,Ericson,,Retain Nebraska Workers' Compensation Court Judge James R. Coe,NON,No,27
+59,Wheeler,Bartlett,,Retain Karin Noakes,NON,Yes,143
+60,Wheeler,Ericson,,Retain Karin Noakes,NON,Yes,54
+61,Wheeler,Bartlett,,Retain Karin Noakes,NON,No,63
+62,Wheeler,Ericson,,Retain Karin Noakes,NON,No,34
+63,Wheeler,Bartlett,,Retain Tami K. Schendt,NON,Yes,143
+64,Wheeler,Ericson,,Retain Tami K. Schendt,NON,Yes,55
+65,Wheeler,Bartlett,,Retain Tami K. Schendt,NON,No,59
+66,Wheeler,Ericson,,Retain Tami K. Schendt,NON,No,31
+67,Wheeler,Bartlett,1,Northeast Community College Board,NON,Shirley J. Petsche,203
+68,Wheeler,Ericson,1,Northeast Community College Board,NON,Shirley J. Petsche,83
+69,Wheeler,Bartlett,1,Northeast Community College Board,NON,Write-ins,1
+70,Wheeler,Ericson,1,Northeast Community College Board,NON,Write-ins,0
+71,Wheeler,Bartlett,At-large,Northeast Community College Board,NON,Ted Hillman,97
+72,Wheeler,Ericson,At-large,Northeast Community College Board,NON,Ted Hillman,40
+73,Wheeler,Bartlett,At-large,Northeast Community College Board,NON,Jeffrey M. Scherer,89
+74,Wheeler,Ericson,At-large,Northeast Community College Board,NON,Jeffrey M. Scherer,39
+75,Wheeler,Bartlett,At-large,Northeast Community College Board,NON,Write-ins,0
+76,Wheeler,Ericson,At-large,Northeast Community College Board,NON,Write-ins,0
+77,Wheeler,Bartlett,2,Lower Loup Natural Resources District,NON,Alan D. Petersen,166
+78,Wheeler,Ericson,2,Lower Loup Natural Resources District,NON,Alan D. Petersen,89
+79,Wheeler,Bartlett,2,Lower Loup Natural Resources District,NON,Write-ins,6
+80,Wheeler,Ericson,2,Lower Loup Natural Resources District,NON,Write-ins,7
+81,Wheeler,Bartlett,6,Lower Loup Natural Resources District,NON,Write-ins,54
+82,Wheeler,Ericson,6,Lower Loup Natural Resources District,NON,Write-ins,29
+83,Wheeler,Bartlett,1,Upper Elkhorn Natural Resources District,NON,Roy Stewart,48
+84,Wheeler,Ericson,1,Upper Elkhorn Natural Resources District,NON,Roy Stewart,0
+85,Wheeler,Bartlett,1,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+86,Wheeler,Ericson,1,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+87,Wheeler,Bartlett,2,Upper Elkhorn Natural Resources District,NON,Curtis Gotschall,51
+88,Wheeler,Ericson,2,Upper Elkhorn Natural Resources District,NON,Curtis Gotschall,0
+89,Wheeler,Bartlett,2,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+90,Wheeler,Ericson,2,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+91,Wheeler,Bartlett,3,Upper Elkhorn Natural Resources District,NON,Gene Kelly,53
+92,Wheeler,Ericson,3,Upper Elkhorn Natural Resources District,NON,Gene Kelly,0
+93,Wheeler,Bartlett,3,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+94,Wheeler,Ericson,3,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+95,Wheeler,Bartlett,4,Upper Elkhorn Natural Resources District,NON,Gary L. Bartak,58
+96,Wheeler,Ericson,4,Upper Elkhorn Natural Resources District,NON,Gary L. Bartak,0
+97,Wheeler,Bartlett,4,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+98,Wheeler,Ericson,4,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+99,Wheeler,Bartlett,5,Upper Elkhorn Natural Resources District,NON,Mark Carpenter,17
+100,Wheeler,Ericson,5,Upper Elkhorn Natural Resources District,NON,Mark Carpenter,0
+101,Wheeler,Bartlett,5,Upper Elkhorn Natural Resources District,NON,Issac Wright,35
+102,Wheeler,Ericson,5,Upper Elkhorn Natural Resources District,NON,Issac Wright,0
+103,Wheeler,Bartlett,5,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+104,Wheeler,Ericson,5,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+105,Wheeler,Bartlett,6,Upper Elkhorn Natural Resources District,NON,Ted D. Hughes,48
+106,Wheeler,Ericson,6,Upper Elkhorn Natural Resources District,NON,Ted D. Hughes,0
+107,Wheeler,Bartlett,6,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+108,Wheeler,Ericson,6,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+109,Wheeler,Bartlett,7,Upper Elkhorn Natural Resources District,NON,Mark Schrage,29
+110,Wheeler,Ericson,7,Upper Elkhorn Natural Resources District,NON,Mark Schrage,0
+111,Wheeler,Bartlett,7,Upper Elkhorn Natural Resources District,NON,Keith Heithoff,26
+112,Wheeler,Ericson,7,Upper Elkhorn Natural Resources District,NON,Keith Heithoff,0
+113,Wheeler,Bartlett,7,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+114,Wheeler,Ericson,7,Upper Elkhorn Natural Resources District,NON,Write-ins,0
+115,Wheeler,Bartlett,1,Cornhusker Public Power District Board,NON,William J. Robinson,36
+116,Wheeler,Ericson,1,Cornhusker Public Power District Board,NON,William J. Robinson,0
+117,Wheeler,Bartlett,1,Cornhusker Public Power District Board,NON,Write-ins,0
+118,Wheeler,Ericson,1,Cornhusker Public Power District Board,NON,Write-ins,0
+119,Wheeler,Bartlett,3,Elkhorn Rural Public Power District,NON,Joseph G. Thiele,63
+120,Wheeler,Ericson,3,Elkhorn Rural Public Power District,NON,Joseph G. Thiele,0
+121,Wheeler,Bartlett,3,Elkhorn Rural Public Power District,NON,Write-ins,0
+122,Wheeler,Ericson,3,Elkhorn Rural Public Power District,NON,Write-ins,0
+123,Wheeler,Bartlett,6-year term,Loup Valley Rural Public Power District,NON,Larry O. White,60
+124,Wheeler,Ericson,6-year term,Loup Valley Rural Public Power District,NON,Larry O. White,65
+125,Wheeler,Bartlett,6-year term,Loup Valley Rural Public Power District,NON,Andrew Augustyn,47
+126,Wheeler,Ericson,6-year term,Loup Valley Rural Public Power District,NON,Andrew Augustyn,44
+127,Wheeler,Bartlett,6-year term,Loup Valley Rural Public Power District,NON,Michael Cruikshank,65
+128,Wheeler,Ericson,6-year term,Loup Valley Rural Public Power District,NON,Michael Cruikshank,47
+129,Wheeler,Bartlett,6-year term,Loup Valley Rural Public Power District,NON,Randy Wadas,61
+130,Wheeler,Ericson,6-year term,Loup Valley Rural Public Power District,NON,Randy Wadas,62
+131,Wheeler,Bartlett,6-year term,Loup Valley Rural Public Power District,NON,Write-ins,1
+132,Wheeler,Ericson,6-year term,Loup Valley Rural Public Power District,NON,Write-ins,2
+133,Wheeler,Bartlett,4-year term,Loup Valley Rural Public Power District,NON,Marvin A. Scheideler,33
+134,Wheeler,Ericson,4-year term,Loup Valley Rural Public Power District,NON,Marvin A. Scheideler,31
+135,Wheeler,Bartlett,4-year term,Loup Valley Rural Public Power District,NON,Ricky S. Koch,23
+136,Wheeler,Ericson,4-year term,Loup Valley Rural Public Power District,NON,Ricky S. Koch,18
+137,Wheeler,Bartlett,4-year term,Loup Valley Rural Public Power District,NON,Cody E. Freouf,51
+138,Wheeler,Ericson,4-year term,Loup Valley Rural Public Power District,NON,Cody E. Freouf,62
+139,Wheeler,Bartlett,4-year term,Loup Valley Rural Public Power District,NON,Write-ins,1
+140,Wheeler,Ericson,4-year term,Loup Valley Rural Public Power District,NON,Write-ins,1
+141,Wheeler,Bartlett,,Educational Service Unit 8 Board,NON,Tim Lambert,238
+142,Wheeler,Ericson,,Educational Service Unit 8 Board,NON,Tim Lambert,87
+143,Wheeler,Bartlett,,Educational Service Unit 8 Board,NON,Write-ins,0
+144,Wheeler,Ericson,,Educational Service Unit 8 Board,NON,Write-ins,0
+145,Wheeler,Bartlett,2,Wheeler Central School Board,NON,Dennis Derner,123
+146,Wheeler,Ericson,2,Wheeler Central School Board,NON,Dennis Derner,50
+147,Wheeler,Bartlett,2,Wheeler Central School Board,NON,Jerilee Wright,235
+148,Wheeler,Ericson,2,Wheeler Central School Board,NON,Jerilee Wright,109
+149,Wheeler,Bartlett,2,Wheeler Central School Board,NON,Write-ins,17
+150,Wheeler,Ericson,2,Wheeler Central School Board,NON,Write-ins,13
+151,Wheeler,Bartlett,3,Wheeler Central School Board,NON,Adam Freouf,246
+152,Wheeler,Ericson,3,Wheeler Central School Board,NON,Adam Freouf,115
+153,Wheeler,Bartlett,3,Wheeler Central School Board,NON,Write-ins,4
+154,Wheeler,Ericson,3,Wheeler Central School Board,NON,Write-ins,4
+155,Wheeler,Bartlett,4-year term,Elgin Public School Board,NON,Stanley Heithoff,4
+156,Wheeler,Ericson,4-year term,Elgin Public School Board,NON,Stanley Heithoff,0
+157,Wheeler,Bartlett,4-year term,Elgin Public School Board,NON,Steve Busteed,8
+158,Wheeler,Ericson,4-year term,Elgin Public School Board,NON,Steve Busteed,0
+159,Wheeler,Bartlett,4-year term,Elgin Public School Board,NON,Michael Braband,2
+160,Wheeler,Ericson,4-year term,Elgin Public School Board,NON,Michael Braband,0
+161,Wheeler,Bartlett,4-year term,Elgin Public School Board,NON,Douglas Jones,6
+162,Wheeler,Ericson,4-year term,Elgin Public School Board,NON,Douglas Jones,0
+163,Wheeler,Bartlett,4-year term,Elgin Public School Board,NON,Write-ins,0
+164,Wheeler,Ericson,4-year term,Elgin Public School Board,NON,Write-ins,0
+165,Wheeler,Bartlett,2-year term,Elgin Public School Board,NON,Lisa Welding,8
+166,Wheeler,Ericson,2-year term,Elgin Public School Board,NON,Lisa Welding,0
+167,Wheeler,Bartlett,2-year term,Elgin Public School Board,NON,Write-ins,0
+168,Wheeler,Ericson,2-year term,Elgin Public School Board,NON,Write-ins,0
+169,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Patti Behnk,2
+170,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Patti Behnk,0
+171,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Jarrod Long,0
+172,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Jarrod Long,0
+173,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Marty J. Kerkman,2
+174,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Marty J. Kerkman,0
+175,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Michael Klabenes,0
+176,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Michael Klabenes,0
+177,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Amy Thiele,2
+178,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Amy Thiele,0
+179,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Brian King,0
+180,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Brian King,0
+181,Wheeler,Bartlett,4-year term,Clearwater School Board,NON,Write-ins,0
+182,Wheeler,Ericson,4-year term,Clearwater School Board,NON,Write-ins,0
+183,Wheeler,Bartlett,2-year term,Clearwater School Board,NON,Tom Thiele,2
+184,Wheeler,Ericson,2-year term,Clearwater School Board,NON,Tom Thiele,0
+185,Wheeler,Bartlett,2-year term,Clearwater School Board,NON,Write-ins,0
+186,Wheeler,Ericson,2-year term,Clearwater School Board,NON,Write-ins,0
+187,Wheeler,Bartlett,,Ewing School Board,NON,Pete Funk,13
+188,Wheeler,Ericson,,Ewing School Board,NON,Pete Funk,0
+189,Wheeler,Bartlett,,Ewing School Board,NON,LeRoy M. Napier,7
+190,Wheeler,Ericson,,Ewing School Board,NON,LeRoy M. Napier,0
+191,Wheeler,Bartlett,,Ewing School Board,NON,Mark P. Ramold,11
+192,Wheeler,Ericson,,Ewing School Board,NON,Mark P. Ramold,0
+193,Wheeler,Bartlett,,Ewing School Board,NON,Ed Nordby,16
+194,Wheeler,Ericson,,Ewing School Board,NON,Ed Nordby,0
+195,Wheeler,Bartlett,,Ewing School Board,NON,Write-ins,0
+196,Wheeler,Ericson,,Ewing School Board,NON,Write-ins,0
+197,Wheeler,Bartlett,4-year term,Chambers School Board,NON,Lenone F. Koenig,1
+198,Wheeler,Ericson,4-year term,Chambers School Board,NON,Lenone F. Koenig,0
+199,Wheeler,Bartlett,4-year term,Chambers School Board,NON,Brian McManigal,1
+200,Wheeler,Ericson,4-year term,Chambers School Board,NON,Brian McManigal,0
+201,Wheeler,Bartlett,4-year term,Chambers School Board,NON,Write-ins,0
+202,Wheeler,Ericson,4-year term,Chambers School Board,NON,Write-ins,0
+203,Wheeler,Bartlett,2-year term,Chambers School Board,NON,Matt Ehlers,1
+204,Wheeler,Ericson,2-year term,Chambers School Board,NON,Matt Ehlers,0
+205,Wheeler,Bartlett,2-year term,Chambers School Board,NON,Write-ins,0
+206,Wheeler,Ericson,2-year term,Chambers School Board,NON,Write-ins,0
+207,Wheeler,Bartlett,,Bartlett Village Board,NON,Letti Nichols,58
+208,Wheeler,Ericson,,Bartlett Village Board,NON,Letti Nichols,0
+209,Wheeler,Bartlett,,Bartlett Village Board,NON,Paul Nordhues,63
+210,Wheeler,Ericson,,Bartlett Village Board,NON,Paul Nordhues,0
+211,Wheeler,Bartlett,,Bartlett Village Board,NON,Write-ins,0
+212,Wheeler,Ericson,,Bartlett Village Board,NON,Write-ins,0
+213,Wheeler,Bartlett,,Ericson Village Board,NON,Duane Waddle,0
+214,Wheeler,Ericson,,Ericson Village Board,NON,Duane Waddle,31
+215,Wheeler,Bartlett,,Ericson Village Board,NON,Jerry B. Horwart,0
+216,Wheeler,Ericson,,Ericson Village Board,NON,Jerry B. Horwart,30
+217,Wheeler,Bartlett,,Ericson Village Board,NON,William Curry,0
+218,Wheeler,Ericson,,Ericson Village Board,NON,William Curry,49
+219,Wheeler,Bartlett,,Ericson Village Board,NON,Write-ins,0
+220,Wheeler,Ericson,,Ericson Village Board,NON,Write-ins,5


### PR DESCRIPTION
This removes leading and trailing whitespace characters.  In doing so, some unnecessary double quotes were also removed.